### PR TITLE
chore: set default code formatter to `deno fmt`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,6 @@
   "deno.enable": true,
   "deno.lint": true,
   "deno.unstable": false,
+  "editor.defaultFormatter": "denoland.vscode-deno",
   "markdown.extension.toc.levels": "2..6"
 }


### PR DESCRIPTION
<!--

Thanks for submitting a pull request!

- If this pr is your frist contribution, read "CONTRIBUTING.md".:
  hhttps://github.com/pulsate-dev/.github?tab=coc-ov-file
- Run `deno fmt` to format your code.
- If your PR is not finished, set it as "draft" PR.
  See more: https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request
-->

## What does this PR do?

Set the default code formatter of VSCode to `deno fmt`.
Useful for the environments that use Prettier by default.