### PR TITLE
fix(bug): wrong format verify token

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -38,6 +38,7 @@
   "imports": {
     "std/assert": "https://deno.land/std@0.206.0/assert/mod.ts",
     "std/encoding/hex": "https://deno.land/std@0.206.0/encoding/hex.ts",
+    "std/encoding/base64": "https://deno.land/std@0.206.0/encoding/base64.ts",
     "jose": "https://deno.land/x/jose@v5.1.0/index.ts",
     "nhttp": "https://deno.land/x/nhttp@1.3.9/mod.ts",
     "scrypt": "https://deno.land/x/scrypt@v4.2.1/mod.ts",

--- a/deno.lock
+++ b/deno.lock
@@ -2239,6 +2239,7 @@
     "https://deno.land/std@0.206.0/assert/unimplemented.ts": "d56fbeecb1f108331a380f72e3e010a1f161baa6956fd0f7cf3e095ae1a4c75a",
     "https://deno.land/std@0.206.0/assert/unreachable.ts": "4600dc0baf7d9c15a7f7d234f00c23bca8f3eba8b140286aaca7aa998cf9a536",
     "https://deno.land/std@0.206.0/encoding/_util.ts": "f368920189c4fe6592ab2e93bd7ded8f3065b84f95cd3e036a4a10a75649dcba",
+    "https://deno.land/std@0.206.0/encoding/base64.ts": "cc03110d6518170aeaa68ec97f89c6d6e2276294b30807e7332591d7ce2e4b72",
     "https://deno.land/std@0.206.0/encoding/hex.ts": "d41e9c3f7dd9d4738c40c2b9e6db5eb32e9dc103360291aff63a5c3fccdb45a6",
     "https://deno.land/std@0.206.0/fmt/colors.ts": "c51c4642678eb690dcf5ffee5918b675bf01a33fba82acf303701ae1a4f8c8d9",
     "https://deno.land/x/hono@v3.8.2/client/client.ts": "ff340f58041203879972dd368b011ed130c66914f789826610869a90603406bf",

--- a/pkg/accounts/service/tokenVerify.test.ts
+++ b/pkg/accounts/service/tokenVerify.test.ts
@@ -14,6 +14,7 @@ Deno.test('generate/verify account verify token', async () => {
   if (Result.isErr(token)) {
     return;
   }
+
   const verify = await service.verify('1' as ID<AccountID>, token[1]);
   if (Result.isErr(verify)) {
     return;

--- a/pkg/accounts/service/tokenVerify.ts
+++ b/pkg/accounts/service/tokenVerify.ts
@@ -1,4 +1,5 @@
 import { Option, Result } from 'mini-fn';
+import {encodeBase64} from "std/encoding/base64";
 import { AccountVerifyTokenRepository } from '../model/repository.ts';
 import { ID } from '../../id/type.ts';
 import { AccountID } from '../model/account.ts';
@@ -34,16 +35,18 @@ export class TokenVerifyService {
       Number(this.clock.Now()) + 7 * 24 * 60 * 60 * 1000,
     );
 
+    const encodedToken = encodeBase64(verifyToken);
+
     const res = await this.repository.create(
       accountID,
-      verifyToken.toString(),
+      encodedToken,
       expireDate,
     );
     if (Result.isErr(res)) {
       return Result.err(res[1]);
     }
 
-    return Result.ok(verifyToken.toString());
+    return Result.ok(encodedToken);
   }
 
   /**

--- a/pkg/accounts/service/tokenVerify.ts
+++ b/pkg/accounts/service/tokenVerify.ts
@@ -1,5 +1,5 @@
 import { Option, Result } from 'mini-fn';
-import {encodeBase64} from "std/encoding/base64";
+import { encodeBase64 } from 'std/encoding/base64';
 import { AccountVerifyTokenRepository } from '../model/repository.ts';
 import { ID } from '../../id/type.ts';
 import { AccountID } from '../model/account.ts';


### PR DESCRIPTION
## What does this PR do?
`26,171,156,60,129,175,29,202,111,157,110,229,40,151,46,128,146,111,101,38,184,211,211,227,198,46,200,252,225,153,188,9` というような形式で(Uint8Arrayそのままの形式で)出力されるのをBase64で出力するように修正しました

## Additional information