### PR TITLE
chore(deps): bump CI deno version

### DIFF
--- a/.github/workflows/deno.yaml
+++ b/.github/workflows/deno.yaml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: denoland/setup-deno@v1
         with:
-          deno-version: "1.37.2"
+          deno-version: "1.39.0"
 
       - name: Run fmt
         run: |


### PR DESCRIPTION
## What does this PR do?
CIで使用しているdenoのバージョンを現在時点での最新版`v1.3９.0`に上げました

## Additional information
