### PR TITLE
ci: add pull-request workflow

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,0 +1,27 @@
+name: Pull request workflow
+
+on:
+  pull_request:
+    types: ["opened"]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  assign:
+    if: ${{ github.event.pull_request.user.login != 'renovate[bot]' || toJSON(github.event.pull_request.assignees) == '[]' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.rest.issues.addAssignees({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              assignees: `${{ github.actor}}`
+            })
+

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -22,6 +22,6 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
-              assignees: `${{ github.actor}}`
+              assignees: `${{ github.actor }}`
             })
 


### PR DESCRIPTION
## What does this PR do?

Add pull-request workflow (GitHub Actions) to the project.

Automatically assigns a PR creator when the Assign field is empty.

