### PR TITLE
chore: Replace missing Node.js settings

### DIFF
--- a/.github/CONTRIBUTING_JA.md
+++ b/.github/CONTRIBUTING_JA.md
@@ -8,8 +8,6 @@ Pulsate Project への貢献に関するガイド.
 - [Pull Requests](#pull-requests)
   - [レビュー](#レビュー)
 - [コミットメッセージ](#コミットメッセージ)
-- [Deno](#deno)
-  - [依存関係の追加](#依存関係の追加)
 - [スタイルガイド](#スタイルガイド)
   - [TypeScript](#typescript)
     - [null と undefined](#null-と-undefined)
@@ -87,41 +85,11 @@ Pulsateコミットメッセージは[Conventional commit](https://www.conventio
 - 後方互換性を破壊するような変更を行う場合は, `scope` を `!` に設定し, `body` に破壊的な変更についての説明を追加しなければなりません.
   - 破壊的変更が必要な場合はまず Issue または Discussion でメンテナに連絡してください. **ほとんどの場合, そのような変更は望まれていません**.
 
-## Deno
-
-### 依存関係の追加
-
-Denoの依存関係を追加するにはimport_mapsを使用してください. **ソースコードに直接 URL は追加しないでください**.
-
-import_maps は `deno.jsonc` の `imports` に直接 URL を挿入することで定義できます.
-
-```json
-"imports": {
-  "std/assert": "https://deno.land/std@0.205.0/assert/mod.ts",
-  "hono": "https://deno.land/x/hono@v3.8.2/mod.ts",
-  "mini-fn": "npm:@mikuroxina/mini-fn"
-}
-```
-
-実際のソースコードに`imports`のキーを入れることで依存関係を使うことができます.
-
-```ts
-import { Hono } from 'hono';
-
-import { accounts } from './pkg/accounts/mod.ts';
-
-const app = new Hono();
-
-app.route('/accounts', accounts);
-
-Deno.serve({ port: 3000 }, app.fetch);
-```
-
 ## スタイルガイド
 
 Pulsate開発のためのスタイルガイド.
 
-- これらの設定は deno fmt,.editorconfigによって統一されています.
+- これらの設定は Prettier, ESLint, .editorconfig によって統一されています.
   - エディタやIDEによっては, 特別なプラグインをインストールする必要があります.
   - 詳細は[こちら](https://editorconfig.org/#download)をクリックしてください.
 

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,7 @@
 {
   "recommendations": [
-    "denoland.vscode-deno",
+    "esbenp.prettier-vscode",
+    "dbaeumer.vscode-eslint",
     "yzhang.markdown-all-in-one",
     "EditorConfig.EditorConfig"
   ]

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,12 @@
 {
-  "deno.enable": true,
-  "deno.lint": true,
-  "deno.unstable": false,
-  "editor.defaultFormatter": "denoland.vscode-deno",
-  "markdown.extension.toc.levels": "2..6"
+  // editor settings
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.formatOnSave": true,
+
+  // Markdown All in One settings
+  "markdown.extension.toc.levels": "2..6",
+
+  // prettier extension settings
+  "prettier.requireConfig": true,
+  "prettier.configPath": ".prettierrc"
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,8 +8,6 @@ A guide on how to participate in this project.
 - [Pull Requests](#pull-requests)
   - [Review](#review)
 - [Commit Message](#commit-message)
-- [Deno](#deno)
-  - [How to add dependencies](#how-to-add-dependencies)
 - [Style Guide](#style-guide)
   - [TypeScript](#typescript)
     - [null and undefined](#null-and-undefined)
@@ -87,41 +85,11 @@ Pulsate commit messages must follow [conventional commit](https://www.convention
 - If you make any backward-compatibility-breaking changes, you must set `scope` to `!` and add a description of the destructive change to `body`.
   - Please contact the maintainer via Issue or Discussion once you make such a change. In most cases, such changes are not desired.
 
-## Deno
-
-### How to add dependencies
-
-Use import_maps to add Deno dependencies. **DO NOT** add URLs directly to the source code.
-
-Import_maps can be used by inserting the URL directly into `imports` of `deno.jsonc`.
-
-```json
-"imports": {
-  "std/assert": "https://deno.land/std@0.205.0/assert/mod.ts",
-  "hono": "https://deno.land/x/hono@v3.8.2/mod.ts",
-  "mini-fn": "npm:@mikuroxina/mini-fn"
-}
-```
-
-You can use dependencies by putting the key of `imports` in the actual source code.
-
-```ts
-import { Hono } from 'hono';
-
-import { accounts } from './pkg/accounts/mod.ts';
-
-const app = new Hono();
-
-app.route('/accounts', accounts);
-
-Deno.serve({ port: 3000 }, app.fetch);
-```
-
 ## Style Guide
 
 A style guide for Pulsate development.
 
-- These settings are bound by deno fmt, .editorconfig.
+- These settings are bound by Prettier, ESLint, .editorconfig.
   - Some editors and IDEs require special plug-ins to be installed.
   - For more details, click [here](https://editorconfig.org/#download).
 

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ fast, and developer and user friendly.
   <!-- TODO: Insert Pulsate Screenshot -->
   <br />
   <br />
-  <a href="https://github.com/pulsate-dev/pulsate/actions/workflows/deno.yaml">
-    <img src="https://github.com/pulsate-dev/pulsate/actions/workflows/deno.yaml/badge.svg">
+  <a href="https://github.com/pulsate-dev/pulsate/actions/workflows/node.yaml">
+    <img src="https://github.com/pulsate-dev/pulsate/actions/workflows/node.yaml/badge.svg">
   </a>
   <a href="https://link.pulsate.dev/discord">
     <img src="https://img.shields.io/discord/1155472831744856164?label=Discord&color=5865F2">


### PR DESCRIPTION
## What does this PR do?

The replacement of Deno with Node.js in the documentation and VSCode extension configuration was not completed.

This pull request completes the replacement.