### PR TITLE
test: replace `RegisterService` to `InMemoryAccountRepository`

### DIFF
--- a/pkg/accounts/service/editAccount.test.ts
+++ b/pkg/accounts/service/editAccount.test.ts
@@ -1,33 +1,29 @@
-import { Result } from '@mikuroxina/mini-fn';
+import { Option, Result } from '@mikuroxina/mini-fn';
 import { describe, it, expect, afterEach } from 'vitest';
 
-import { type Clock, SnowflakeIDGenerator } from '../../id/mod.js';
+import type { ID } from '../../id/type.js';
 import { Argon2idPasswordEncoder } from '../../password/mod.js';
-import {
-  InMemoryAccountRepository,
-  InMemoryAccountVerifyTokenRepository,
-} from '../adaptor/repository/dummy.js';
-import { type AccountName, type AccountRole } from '../model/account.js';
+import { InMemoryAccountRepository } from '../adaptor/repository/dummy.js';
+import { Account, type AccountID } from '../model/account.js';
 import { EditAccountService } from './editAccount.js';
 import { EtagVerifyService } from './etagGenerateVerify.js';
-import { RegisterAccountService } from './register.js';
-import { DummySendNotificationService } from './sendNotification.js';
-import { TokenVerifyService } from './tokenVerify.js';
 
 const repository = new InMemoryAccountRepository();
-const verifyRepository = new InMemoryAccountVerifyTokenRepository();
-class DummyClock implements Clock {
-  Now(): bigint {
-    return BigInt(new Date('2023/9/10 00:00:00 UTC').getTime());
-  }
-}
-const registerService: RegisterAccountService = new RegisterAccountService({
-  repository,
-  idGenerator: new SnowflakeIDGenerator(1, new DummyClock()),
-  passwordEncoder: new Argon2idPasswordEncoder(),
-  sendNotification: new DummySendNotificationService(),
-  verifyTokenService: new TokenVerifyService(verifyRepository),
-});
+repository.create(
+  Account.new({
+    id: '1' as ID<AccountID>,
+    name: '@john@example.com',
+    mail: 'johndoe@example.com',
+    nickname: 'John Doe',
+    passphraseHash: 'hash',
+    bio: '',
+    role: 'normal',
+    frozen: 'normal',
+    silenced: 'normal',
+    status: 'notActivated',
+    createdAt: new Date(),
+  }),
+);
 const etagVerifyService = new EtagVerifyService();
 const editAccountService = new EditAccountService(
   repository,
@@ -35,119 +31,73 @@ const editAccountService = new EditAccountService(
   new Argon2idPasswordEncoder(),
 );
 
-const exampleInput = {
-  name: '@john_doe@example.com' as AccountName,
-  mail: 'johndoe@example.com',
-  nickname: 'John Doe',
-  passphrase: 'password',
-  bio: 'Hello, World!',
-  role: 'normal' as AccountRole,
-};
-
 describe('EditAccountService', () => {
   afterEach(() => repository.reset());
+
   it('should be success to update nickname', async () => {
-    const res = await registerService.handle(
-      exampleInput.name,
-      exampleInput.mail,
-      exampleInput.nickname,
-      exampleInput.passphrase,
-      exampleInput.bio,
-      exampleInput.role,
-    );
-    const account = Result.unwrap(res);
-    const etag = await etagVerifyService.generate(account);
+    const account = await repository.findByName('@john@example.com');
+    if (Option.isNone(account)) return;
+
+    const etag = await etagVerifyService.generate(account[1]);
     const updateRes = await editAccountService.editNickname(
       etag,
-      exampleInput.name,
+      '@john@example.com',
       'new nickname',
     );
     expect(Result.isErr(updateRes)).toBe(false);
     expect(updateRes[1]).toBe(true);
-    expect(account.getNickname).toBe('new nickname');
+    expect(account[1].getNickname).toBe('new nickname');
   });
 
   it('should be fail to update nickname when nickname shorter more than 1', async () => {
-    const res = await registerService.handle(
-      exampleInput.name,
-      exampleInput.mail,
-      exampleInput.nickname,
-      exampleInput.passphrase,
-      exampleInput.bio,
-      exampleInput.role,
-    );
-    const account = Result.unwrap(res);
-    expect(Result.isErr(res)).toBe(false);
+    const account = await repository.findByName('@john@example.com');
+    if (Option.isNone(account)) return;
 
-    const etag = await etagVerifyService.generate(account);
+    const etag = await etagVerifyService.generate(account[1]);
     const updateRes = await editAccountService.editNickname(
       etag,
-      exampleInput.name,
+      '@john@example.com',
       '',
     );
     expect(Result.isErr(updateRes)).toBe(true);
   });
 
   it('should be fail to update nickname when nickname more than 256', async () => {
-    const res = await registerService.handle(
-      exampleInput.name,
-      exampleInput.mail,
-      exampleInput.nickname,
-      exampleInput.passphrase,
-      exampleInput.bio,
-      exampleInput.role,
-    );
-    const account = Result.unwrap(res);
-    expect(Result.isErr(res)).toBe(false);
+    const account = await repository.findByName('@john@example.com');
+    if (Option.isNone(account)) return;
 
-    const etag = await etagVerifyService.generate(account);
+    const etag = await etagVerifyService.generate(account[1]);
     const updateRes = await editAccountService.editNickname(
       etag,
-      exampleInput.name,
+      '@john@example.com',
       'a'.repeat(257),
     );
     expect(Result.isErr(updateRes)).toBe(true);
   });
 
   it('should be success to update nickname when nickname 256', async () => {
-    const res = await registerService.handle(
-      exampleInput.name,
-      exampleInput.mail,
-      exampleInput.nickname,
-      exampleInput.passphrase,
-      exampleInput.bio,
-      exampleInput.role,
-    );
-    const account = Result.unwrap(res);
-    expect(Result.isErr(res)).toBe(false);
+    const account = await repository.findByName('@john@example.com');
+    if (Option.isNone(account)) return;
 
-    const etag = await etagVerifyService.generate(account);
+    const etag = await etagVerifyService.generate(account[1]);
     const updateRes = await editAccountService.editNickname(
       etag,
-      exampleInput.name,
+      '@john@example.com',
       'a'.repeat(256),
     );
     expect(Result.isErr(updateRes)).toBe(false);
     expect(updateRes[1]).toBe(true);
-    expect(account.getNickname).toBe('a'.repeat(256));
+    expect(account[1].getNickname).toBe('a'.repeat(256));
   });
 
   it('should be success to update nickname when nickname 1', async () => {
-    const res = await registerService.handle(
-      exampleInput.name,
-      exampleInput.mail,
-      exampleInput.nickname,
-      exampleInput.passphrase,
-      exampleInput.bio,
-      exampleInput.role,
-    );
-    const account = Result.unwrap(res);
-    expect(Result.isErr(res)).toBe(false);
+    const account = await repository.findByName('@john@example.com');
+    if (Option.isNone(account)) return;
 
-    const etag = await etagVerifyService.generate(account);
+    const etag = await etagVerifyService.generate(account[1]);
     const updateRes = await editAccountService.editNickname(
       etag,
-      exampleInput.name,
+      '@john@example.com',
       'a',
     );
     expect(Result.isErr(updateRes)).toBe(false);
@@ -155,18 +105,13 @@ describe('EditAccountService', () => {
   });
 
   it('should be fail to update nickname when etag not match', async () => {
-    await registerService.handle(
-      exampleInput.name,
-      exampleInput.mail,
-      exampleInput.nickname,
-      exampleInput.passphrase,
-      exampleInput.bio,
-      exampleInput.role,
-    );
+    const account = await repository.findByName('@john@example.com');
+    if (Option.isNone(account)) return;
 
+    const etag = await etagVerifyService.generate(account[1]);
     const res = await editAccountService.editNickname(
-      'invalid_etag',
-      exampleInput.name,
+      etag,
+      '@john@example.com',
       'new nickname',
     );
     expect(Result.isErr(res)).toBe(true);
@@ -182,20 +127,13 @@ describe('EditAccountService', () => {
   });
 
   it('should be success to update passphrase', async () => {
-    const res = await registerService.handle(
-      exampleInput.name,
-      exampleInput.mail,
-      exampleInput.nickname,
-      exampleInput.passphrase,
-      exampleInput.bio,
-      exampleInput.role,
-    );
-    const account = Result.unwrap(res);
-    const etag = await etagVerifyService.generate(account);
+    const account = await repository.findByName('@john@example.com');
+    if (Option.isNone(account)) return;
 
-    const updateRes = await editAccountService.editPassphrase(
+    const etag = await etagVerifyService.generate(account[1]);
+    const updateRes = await editAccountService.editNickname(
       etag,
-      exampleInput.name,
+      '@john@example.com',
       'new password',
     );
     expect(Result.isErr(updateRes)).toBe(false);
@@ -203,66 +141,39 @@ describe('EditAccountService', () => {
   });
 
   it('should be fail to update passphrase when passphrase shorter more than 8', async () => {
-    const res = await registerService.handle(
-      exampleInput.name,
-      exampleInput.mail,
-      exampleInput.nickname,
-      exampleInput.passphrase,
-      exampleInput.bio,
-      exampleInput.role,
-    );
-    const account = Result.unwrap(res);
-    expect(Result.isErr(res)).toBe(false);
+    const account = await repository.findByName('@john@example.com');
+    if (Option.isNone(account)) return;
 
-    const etag = await etagVerifyService.generate(account);
-
-    const updateRes = await editAccountService.editPassphrase(
+    const etag = await etagVerifyService.generate(account[1]);
+    const updateRes = await editAccountService.editNickname(
       etag,
-      exampleInput.name,
+      '@john@example.com',
       'a'.repeat(7),
     );
     expect(Result.isErr(updateRes)).toBe(true);
   });
 
   it('should be fail to update passphrase when passphrase longer more than 512', async () => {
-    const res = await registerService.handle(
-      exampleInput.name,
-      exampleInput.mail,
-      exampleInput.nickname,
-      exampleInput.passphrase,
-      exampleInput.bio,
-      exampleInput.role,
-    );
-    const account = Result.unwrap(res);
-    expect(Result.isErr(res)).toBe(false);
+    const account = await repository.findByName('@john@example.com');
+    if (Option.isNone(account)) return;
 
-    const etag = await etagVerifyService.generate(account);
-
-    const updateRes = await editAccountService.editPassphrase(
+    const etag = await etagVerifyService.generate(account[1]);
+    const updateRes = await editAccountService.editNickname(
       etag,
-      exampleInput.name,
+      '@john@example.com',
       'a'.repeat(513),
     );
     expect(Result.isErr(updateRes)).toBe(true);
   });
 
   it('should be success to update passphrase when passphrase 8', async () => {
-    const res = await registerService.handle(
-      exampleInput.name,
-      exampleInput.mail,
-      exampleInput.nickname,
-      exampleInput.passphrase,
-      exampleInput.bio,
-      exampleInput.role,
-    );
-    const account = Result.unwrap(res);
-    expect(Result.isErr(res)).toBe(false);
+    const account = await repository.findByName('@john@example.com');
+    if (Option.isNone(account)) return;
 
-    const etag = await etagVerifyService.generate(account);
-
-    const updateRes = await editAccountService.editPassphrase(
+    const etag = await etagVerifyService.generate(account[1]);
+    const updateRes = await editAccountService.editNickname(
       etag,
-      exampleInput.name,
+      '@john@example.com',
       'a'.repeat(8),
     );
     expect(Result.isErr(updateRes)).toBe(false);
@@ -270,22 +181,13 @@ describe('EditAccountService', () => {
   });
 
   it('should be success to update passphrase when passphrase 512', async () => {
-    const res = await registerService.handle(
-      exampleInput.name,
-      exampleInput.mail,
-      exampleInput.nickname,
-      exampleInput.passphrase,
-      exampleInput.bio,
-      exampleInput.role,
-    );
-    const account = Result.unwrap(res);
-    expect(Result.isErr(res)).toBe(false);
+    const account = await repository.findByName('@john@example.com');
+    if (Option.isNone(account)) return;
 
-    const etag = await etagVerifyService.generate(account);
-
-    const updateRes = await editAccountService.editPassphrase(
+    const etag = await etagVerifyService.generate(account[1]);
+    const updateRes = await editAccountService.editNickname(
       etag,
-      exampleInput.name,
+      '@john@example.com',
       'a'.repeat(512),
     );
     expect(Result.isErr(updateRes)).toBe(false);
@@ -293,18 +195,9 @@ describe('EditAccountService', () => {
   });
 
   it('should be fail to update passphrase when etag not match', async () => {
-    await registerService.handle(
-      exampleInput.name,
-      exampleInput.mail,
-      exampleInput.nickname,
-      exampleInput.passphrase,
-      exampleInput.bio,
-      exampleInput.role,
-    );
-
     const res = await editAccountService.editPassphrase(
       'invalid_etag',
-      exampleInput.name,
+      '@john@example.com',
       'new password',
     );
     expect(Result.isErr(res)).toBe(true);
@@ -320,20 +213,13 @@ describe('EditAccountService', () => {
   });
 
   it('should be success to update email', async () => {
-    const res = await registerService.handle(
-      exampleInput.name,
-      exampleInput.mail,
-      exampleInput.nickname,
-      exampleInput.passphrase,
-      exampleInput.bio,
-      exampleInput.role,
-    );
-    const account = Result.unwrap(res);
-    const etag = await etagVerifyService.generate(account);
+    const account = await repository.findByName('@john@example.com');
+    if (Option.isNone(account)) return;
 
+    const etag = await etagVerifyService.generate(account[1]);
     const updateRes = await editAccountService.editEmail(
       etag,
-      exampleInput.name,
+      '@john@example.com',
       'pulsate@example.com',
     );
     expect(Result.isErr(updateRes)).toBe(false);
@@ -341,19 +227,12 @@ describe('EditAccountService', () => {
   });
 
   it('should be fail to update email when etag not match', async () => {
-    const res = await registerService.handle(
-      exampleInput.name,
-      exampleInput.mail,
-      exampleInput.nickname,
-      exampleInput.passphrase,
-      exampleInput.bio,
-      exampleInput.role,
-    );
-    Result.unwrap(res);
+    const account = await repository.findByName('@john@example.com');
+    if (Option.isNone(account)) return;
 
     const updateRes = await editAccountService.editEmail(
       'invalid_etag',
-      exampleInput.name,
+      '@john@example.com',
       'pulsate@example.com',
     );
     expect(Result.isErr(updateRes)).toBe(true);
@@ -369,21 +248,13 @@ describe('EditAccountService', () => {
   });
 
   it('should be success to update email when email shortest', async () => {
-    const res = await registerService.handle(
-      exampleInput.name,
-      exampleInput.mail,
-      exampleInput.nickname,
-      exampleInput.passphrase,
-      exampleInput.bio,
-      exampleInput.role,
-    );
-    const account = Result.unwrap(res);
-    expect(Result.isErr(res)).toBe(false);
-    const etag = await etagVerifyService.generate(account);
+    const account = await repository.findByName('@john@example.com');
+    if (Option.isNone(account)) return;
 
+    const etag = await etagVerifyService.generate(account[1]);
     const updateRes = await editAccountService.editEmail(
       etag,
-      exampleInput.name,
+      '@john@example.com',
       'a'.repeat(7),
     );
     expect(Result.isErr(updateRes)).toBe(false);
@@ -391,21 +262,13 @@ describe('EditAccountService', () => {
   });
 
   it('should be success to update email when email length 8', async () => {
-    const res = await registerService.handle(
-      exampleInput.name,
-      exampleInput.mail,
-      exampleInput.nickname,
-      exampleInput.passphrase,
-      exampleInput.bio,
-      exampleInput.role,
-    );
-    const account = Result.unwrap(res);
-    expect(Result.isErr(res)).toBe(false);
-    const etag = await etagVerifyService.generate(account);
+    const account = await repository.findByName('@john@example.com');
+    if (Option.isNone(account)) return;
 
+    const etag = await etagVerifyService.generate(account[1]);
     const updateRes = await editAccountService.editEmail(
       etag,
-      exampleInput.name,
+      '@john@example.com',
       'a'.repeat(8),
     );
     expect(Result.isErr(updateRes)).toBe(false);
@@ -413,42 +276,26 @@ describe('EditAccountService', () => {
   });
 
   it('should be fail to update email when email too long', async () => {
-    const res = await registerService.handle(
-      exampleInput.name,
-      exampleInput.mail,
-      exampleInput.nickname,
-      exampleInput.passphrase,
-      exampleInput.bio,
-      exampleInput.role,
-    );
-    const account = Result.unwrap(res);
-    expect(Result.isErr(res)).toBe(false);
-    const etag = await etagVerifyService.generate(account);
+    const account = await repository.findByName('@john@example.com');
+    if (Option.isNone(account)) return;
 
+    const etag = await etagVerifyService.generate(account[1]);
     const updateRes = await editAccountService.editEmail(
       etag,
-      exampleInput.name,
+      '@john@example.com',
       'a'.repeat(320),
     );
     expect(Result.isErr(updateRes)).toBe(true);
   });
 
   it('should be success to update email when email length 319', async () => {
-    const res = await registerService.handle(
-      exampleInput.name,
-      exampleInput.mail,
-      exampleInput.nickname,
-      exampleInput.passphrase,
-      exampleInput.bio,
-      exampleInput.role,
-    );
-    const account = Result.unwrap(res);
-    expect(Result.isErr(res)).toBe(false);
-    const etag = await etagVerifyService.generate(account);
+    const account = await repository.findByName('@john@example.com');
+    if (Option.isNone(account)) return;
 
+    const etag = await etagVerifyService.generate(account[1]);
     const updateRes = await editAccountService.editEmail(
       etag,
-      exampleInput.name,
+      '@john@example.com',
       'a'.repeat(319),
     );
     expect(Result.isErr(updateRes)).toBe(false);

--- a/pkg/accounts/service/etagGenerateVerify.test.ts
+++ b/pkg/accounts/service/etagGenerateVerify.test.ts
@@ -1,91 +1,55 @@
-import { Result } from '@mikuroxina/mini-fn';
+import { Option } from '@mikuroxina/mini-fn';
 import { afterEach, describe, expect, it } from 'vitest';
 
-import { type Clock, SnowflakeIDGenerator } from '../../id/mod.js';
-import { Argon2idPasswordEncoder } from '../../password/mod.js';
-import {
-  InMemoryAccountRepository,
-  InMemoryAccountVerifyTokenRepository,
-} from '../adaptor/repository/dummy.js';
-import { type AccountName, type AccountRole } from '../model/account.js';
+import type { ID } from '../../id/type.js';
+import { InMemoryAccountRepository } from '../adaptor/repository/dummy.js';
+import { Account, type AccountID } from '../model/account.js';
 import { EtagVerifyService } from './etagGenerateVerify.js';
-import { RegisterAccountService } from './register.js';
-import { DummySendNotificationService } from './sendNotification.js';
-import { TokenVerifyService } from './tokenVerify.js';
-
-class DummyClock implements Clock {
-  Now(): bigint {
-    return BigInt(new Date('2023/9/10 00:00:00 UTC').getTime());
-  }
-}
 
 const repository = new InMemoryAccountRepository();
-const verifyRepository = new InMemoryAccountVerifyTokenRepository();
-const registerService = new RegisterAccountService({
-  repository: repository,
-  idGenerator: new SnowflakeIDGenerator(1, new DummyClock()),
-  passwordEncoder: new Argon2idPasswordEncoder(),
-  sendNotification: new DummySendNotificationService(),
-  verifyTokenService: new TokenVerifyService(verifyRepository),
-});
+repository.create(
+  Account.new({
+    id: '1' as ID<AccountID>,
+    name: '@john@example.com',
+    mail: 'johndoe@example.com',
+    nickname: 'John Doe',
+    passphraseHash: 'hash',
+    bio: '',
+    role: 'normal',
+    frozen: 'normal',
+    silenced: 'normal',
+    status: 'notActivated',
+    createdAt: new Date(),
+  }),
+);
 const etagVerifyService: EtagVerifyService = new EtagVerifyService();
-
-const exampleInput = {
-  name: '@john_doe@example.com' as AccountName,
-  mail: 'johndoe@example.com',
-  nickname: 'John Doe',
-  passphrase: 'password',
-  bio: 'Hello, World!',
-  role: 'normal' as AccountRole,
-};
 
 describe('EtagVerifyService', () => {
   afterEach(() => repository.reset());
 
   it('success to verify etag', async () => {
-    const res = await registerService.handle(
-      exampleInput.name,
-      exampleInput.mail,
-      exampleInput.nickname,
-      exampleInput.passphrase,
-      exampleInput.bio,
-      exampleInput.role,
-    );
-    const account = Result.unwrap(res);
+    const account = await repository.findByName('@john@example.com');
+    if (Option.isNone(account)) return;
 
-    const etag = await etagVerifyService.generate(account);
-    const result = await etagVerifyService.verify(account, etag);
+    const etag = await etagVerifyService.generate(account[1]);
+    const result = await etagVerifyService.verify(account[1], etag);
     expect(result).toBe(true);
   });
 
   it('failed to verify etag', async () => {
-    const res = await registerService.handle(
-      exampleInput.name,
-      exampleInput.mail,
-      exampleInput.nickname,
-      exampleInput.passphrase,
-      exampleInput.bio,
-      exampleInput.role,
-    );
-    const account = Result.unwrap(res);
+    const account = await repository.findByName('@john@example.com');
+    if (Option.isNone(account)) return;
 
-    const etag = `${await etagVerifyService.generate(account)}_invalid`;
-    const result = await etagVerifyService.verify(account, etag);
+    const etag = `${await etagVerifyService.generate(account[1])}_invalid`;
+    const result = await etagVerifyService.verify(account[1], etag);
     expect(result).toBe(false);
   });
 
   it('should return string which is 64 characters long', async () => {
-    const res = await registerService.handle(
-      exampleInput.name,
-      exampleInput.mail,
-      exampleInput.nickname,
-      exampleInput.passphrase,
-      exampleInput.bio,
-      exampleInput.role,
-    );
-    const account = Result.unwrap(res);
+    const account = await repository.findByName('@john@example.com');
+    if (Option.isNone(account)) return;
 
-    const etag = await etagVerifyService.generate(account);
+    const etag = await etagVerifyService.generate(account[1]);
     expect(etag.length).toBe(64);
   });
 });

--- a/pkg/accounts/service/fetchAccount.test.ts
+++ b/pkg/accounts/service/fetchAccount.test.ts
@@ -25,6 +25,8 @@ repository.create(
 const fetchAccountService = new FetchAccountService(repository);
 
 describe('FetchAccountService', () => {
+  afterEach(() => repository.reset());
+
   it('fetch account info', async () => {
     const account = await fetchAccountService.fetchAccount('@john@example.com');
     if (Result.isErr(account)) return;
@@ -50,6 +52,4 @@ describe('FetchAccountService', () => {
 
     expect(Result.isErr(account)).toBe(true);
   });
-
-  afterEach(() => repository.reset());
 });

--- a/pkg/accounts/service/freeze.test.ts
+++ b/pkg/accounts/service/freeze.test.ts
@@ -1,77 +1,50 @@
-import { Result } from '@mikuroxina/mini-fn';
+import { Option } from '@mikuroxina/mini-fn';
+import { afterEach } from 'vitest';
 import { describe, it, expect } from 'vitest';
 
-import { type Clock, SnowflakeIDGenerator } from '../../id/mod.js';
-import { Argon2idPasswordEncoder } from '../../password/mod.js';
-import {
-  InMemoryAccountRepository,
-  InMemoryAccountVerifyTokenRepository,
-} from '../adaptor/repository/dummy.js';
-import { type AccountName, type AccountRole } from '../model/account.js';
+import type { ID } from '../../id/type.js';
+import { InMemoryAccountRepository } from '../adaptor/repository/dummy.js';
+import { Account, type AccountID } from '../model/account.js';
 import { FreezeService } from './freeze.js';
-import { RegisterAccountService } from './register.js';
-import { DummySendNotificationService } from './sendNotification.js';
-import { TokenVerifyService } from './tokenVerify.js';
 
 const repository = new InMemoryAccountRepository();
-const verifyRepository = new InMemoryAccountVerifyTokenRepository();
-class DummyClock implements Clock {
-  Now(): bigint {
-    return BigInt(new Date('2023/9/10 00:00:00 UTC').getTime());
-  }
-}
-const registerService: RegisterAccountService = new RegisterAccountService({
-  repository,
-  idGenerator: new SnowflakeIDGenerator(1, new DummyClock()),
-  passwordEncoder: new Argon2idPasswordEncoder(),
-  sendNotification: new DummySendNotificationService(),
-  verifyTokenService: new TokenVerifyService(verifyRepository),
-});
+repository.create(
+  Account.new({
+    id: '1' as ID<AccountID>,
+    name: '@john@example.com',
+    mail: 'johndoe@example.com',
+    nickname: 'John Doe',
+    passphraseHash: 'hash',
+    bio: '',
+    role: 'normal',
+    frozen: 'normal',
+    silenced: 'normal',
+    status: 'notActivated',
+    createdAt: new Date(),
+  }),
+);
 const freezeService = new FreezeService(repository);
 
-const exampleInput = {
-  name: '@john_doe@example.com' as AccountName,
-  mail: 'johndoe@example.com',
-  nickname: 'John Doe',
-  passphrase: 'password',
-  bio: 'Hello, World!',
-  role: 'normal' as AccountRole,
-};
-
 describe('FreezeService', () => {
+  afterEach(() => repository.reset());
+
   it('set account freeze', async () => {
-    const res = await registerService.handle(
-      exampleInput.name,
-      exampleInput.mail,
-      exampleInput.nickname,
-      exampleInput.passphrase,
-      exampleInput.bio,
-      exampleInput.role,
-    );
-    if (Result.isErr(res)) return;
+    const account = await repository.findByName('@john@example.com');
+    if (Option.isNone(account)) return;
 
-    await freezeService.setFreeze(exampleInput.name);
+    await freezeService.setFreeze('@john@example.com');
 
-    expect(res[1].getFrozen).toBe('frozen');
-    expect(res[1].getFrozen).not.toBe('normal');
-    repository.reset();
+    expect(account[1].getFrozen).toBe('frozen');
+    expect(account[1].getFrozen).not.toBe('normal');
   });
 
   it('unset account freeze', async () => {
-    const res = await registerService.handle(
-      exampleInput.name,
-      exampleInput.mail,
-      exampleInput.nickname,
-      exampleInput.passphrase,
-      exampleInput.bio,
-      exampleInput.role,
-    );
-    if (Result.isErr(res)) return;
+    const account = await repository.findByName('@john@example.com');
+    if (Option.isNone(account)) return;
 
-    await freezeService.undoFreeze(exampleInput.name);
+    await freezeService.undoFreeze('@john@example.com');
 
-    expect(res[1].getFrozen).toBe('normal');
-    expect(res[1].getFrozen).not.toBe('frozen');
-    repository.reset();
+    expect(account[1].getFrozen).toBe('normal');
+    expect(account[1].getFrozen).not.toBe('frozen');
   });
 });


### PR DESCRIPTION
## What does this PR do?

Mock accounts used in almost all test cases are now created in-memory.