### PR TITLE
refactor: Improve method names

### DIFF
--- a/pkg/accounts/adaptor/repository/dummy.ts
+++ b/pkg/accounts/adaptor/repository/dummy.ts
@@ -26,7 +26,7 @@ export class InMemoryAccountRepository implements AccountRepository {
   }
 
   findByName(name: string): Promise<Option.Option<Account>> {
-    const account = Array.from(this.data).find((a) => a.getName === name);
+    const account = Array.from(this.data).find((a) => a.getName() === name);
     if (!account) {
       return Promise.resolve(Option.none());
     }
@@ -34,7 +34,7 @@ export class InMemoryAccountRepository implements AccountRepository {
   }
 
   findByMail(mail: string): Promise<Option.Option<Account>> {
-    const account = Array.from(this.data).find((a) => a.getMail === mail);
+    const account = Array.from(this.data).find((a) => a.getMail() === mail);
     if (!account) {
       return Promise.resolve(Option.none());
     }

--- a/pkg/accounts/adaptor/repository/prisma.ts
+++ b/pkg/accounts/adaptor/repository/prisma.ts
@@ -82,43 +82,43 @@ export class PrismaAccountRepository implements AccountRepository {
         moderator: 1,
         admin: 2,
       } satisfies Record<AccountRole, number>
-    )[account.getRole];
+    )[account.getRole()];
 
     const status = (
       {
         active: 0,
         notActivated: 1,
       } satisfies Record<AccountStatus, number>
-    )[account.getStatus];
+    )[account.getStatus()];
 
     const frozen = (
       {
         normal: 0,
         frozen: 1,
       } satisfies Record<AccountFrozen, number>
-    )[account.getFrozen];
+    )[account.getFrozen()];
 
     const silenced = (
       {
         normal: 0,
         silenced: 1,
       } satisfies Record<AccountSilenced, number>
-    )[account.getSilenced];
+    )[account.getSilenced()];
 
     return {
-      id: account.getID,
-      name: account.getName,
-      nickname: account.getNickname,
-      mail: account.getMail,
-      passphrase_hash: account.getPassphraseHash ?? '',
-      bio: account.getBio,
+      id: account.getID(),
+      name: account.getName(),
+      nickname: account.getNickname(),
+      mail: account.getMail(),
+      passphrase_hash: account.getPassphraseHash() ?? '',
+      bio: account.getBio(),
       role: role,
       frozen: frozen,
       silenced: silenced,
       status: status,
-      created_at: account.getCreatedAt,
-      updated_at: !account.getUpdatedAt ? null : account.getUpdatedAt,
-      deleted_at: !account.getDeletedAt ? null : account.getDeletedAt,
+      created_at: account.getCreatedAt(),
+      updated_at: account.getUpdatedAt() ?? null,
+      deleted_at: account.getDeletedAt() ?? null,
     };
   }
 

--- a/pkg/accounts/model/account.test.ts
+++ b/pkg/accounts/model/account.test.ts
@@ -23,17 +23,17 @@ describe('Account', () => {
   it('generate new instance', () => {
     const account = Account.new(exampleInput);
 
-    expect(account.getID).toBe(exampleInput.id);
-    expect(account.getName).toBe(exampleInput.name);
-    expect(account.getMail).toBe(exampleInput.mail);
-    expect(account.getNickname).toBe(exampleInput.nickname);
-    expect(account.getPassphraseHash).toBe(exampleInput.passphraseHash);
-    expect(account.getBio).toBe(exampleInput.bio);
-    expect(account.getRole).toBe(exampleInput.role);
-    expect(account.getStatus).toBe('notActivated');
-    expect(account.getCreatedAt).toBe(exampleInput.createdAt);
-    expect(account.getUpdatedAt).toBe(undefined);
-    expect(account.getDeletedAt).toBe(undefined);
+    expect(account.getID()).toBe(exampleInput.id);
+    expect(account.getName()).toBe(exampleInput.name);
+    expect(account.getMail()).toBe(exampleInput.mail);
+    expect(account.getNickname()).toBe(exampleInput.nickname);
+    expect(account.getPassphraseHash()).toBe(exampleInput.passphraseHash);
+    expect(account.getBio()).toBe(exampleInput.bio);
+    expect(account.getRole()).toBe(exampleInput.role);
+    expect(account.getStatus()).toBe('notActivated');
+    expect(account.getCreatedAt()).toBe(exampleInput.createdAt);
+    expect(account.getUpdatedAt()).toBe(undefined);
+    expect(account.getDeletedAt()).toBe(undefined);
   });
 
   it('account nickname must be less than 256', () => {

--- a/pkg/accounts/model/account.ts
+++ b/pkg/accounts/model/account.ts
@@ -49,30 +49,30 @@ export class Account {
 
   // 不変
   private readonly id: ID<AccountID>;
-  get getID(): ID<AccountID> {
+  getID(): ID<AccountID> {
     return this.id;
   }
 
   private readonly name: AccountName;
-  get getName(): AccountName {
+  getName(): AccountName {
     return this.name;
   }
 
   private createdAt: Date;
-  get getCreatedAt(): Date {
+  getCreatedAt(): Date {
     return this.createdAt;
   }
 
   // 可変
   private mail: string;
-  get getMail(): string {
+  getMail(): string {
     return this.mail;
   }
   public setMail(mail: string) {
     if (this.isDeleted()) {
       throw new AccountAlreadyDeletedError('account already deleted');
     }
-    if (this.getFrozen === 'frozen') {
+    if (this.getFrozen() === 'frozen') {
       throw new AccountAlreadyFrozenError('account already frozen');
     }
 
@@ -80,14 +80,14 @@ export class Account {
   }
 
   private nickname: string;
-  get getNickname(): string {
+  getNickname(): string {
     return this.nickname;
   }
   public setNickName(name: string) {
     if (this.isDeleted()) {
       throw new AccountAlreadyDeletedError('account already deleted');
     }
-    if (this.getFrozen === 'frozen') {
+    if (this.getFrozen() === 'frozen') {
       throw new AccountAlreadyFrozenError('account already frozen');
     }
 
@@ -98,14 +98,14 @@ export class Account {
   }
 
   private passphraseHash: string | undefined;
-  get getPassphraseHash(): string | undefined {
+  getPassphraseHash(): string | undefined {
     return this.passphraseHash;
   }
   public setPassphraseHash(hash: string) {
     if (this.isDeleted()) {
       throw new AccountAlreadyDeletedError('account already deleted');
     }
-    if (this.getFrozen === 'frozen') {
+    if (this.getFrozen() === 'frozen') {
       throw new AccountAlreadyFrozenError('account already frozen');
     }
 
@@ -113,14 +113,14 @@ export class Account {
   }
 
   private bio: string;
-  get getBio(): string {
+  getBio(): string {
     return this.bio;
   }
   public setBio(bio: string) {
     if (this.isDeleted()) {
       throw new AccountAlreadyDeletedError('account already deleted');
     }
-    if (this.getFrozen === 'frozen') {
+    if (this.getFrozen() === 'frozen') {
       throw new AccountAlreadyFrozenError('account already frozen');
     }
 
@@ -131,14 +131,14 @@ export class Account {
   }
 
   private role: AccountRole;
-  get getRole(): AccountRole {
+  getRole(): AccountRole {
     return this.role;
   }
   public toAdmin() {
     if (this.isDeleted()) {
       throw new AccountAlreadyDeletedError('account already deleted');
     }
-    if (this.getFrozen === 'frozen') {
+    if (this.getFrozen() === 'frozen') {
       throw new AccountAlreadyFrozenError('account already frozen');
     }
 
@@ -148,7 +148,7 @@ export class Account {
     if (this.isDeleted()) {
       throw new AccountAlreadyDeletedError('account already deleted');
     }
-    if (this.getFrozen === 'frozen') {
+    if (this.getFrozen() === 'frozen') {
       throw new AccountAlreadyFrozenError('account already frozen');
     }
 
@@ -158,7 +158,7 @@ export class Account {
     if (this.isDeleted()) {
       throw new AccountAlreadyDeletedError('account already deleted');
     }
-    if (this.getFrozen === 'frozen') {
+    if (this.getFrozen() === 'frozen') {
       throw new AccountAlreadyFrozenError('account already frozen');
     }
 
@@ -166,7 +166,7 @@ export class Account {
   }
 
   private frozen: AccountFrozen;
-  get getFrozen(): AccountFrozen {
+  getFrozen(): AccountFrozen {
     return this.frozen;
   }
   public setFreeze() {
@@ -185,14 +185,14 @@ export class Account {
   }
 
   private silenced: AccountSilenced;
-  get getSilenced(): AccountSilenced {
+  getSilenced(): AccountSilenced {
     return this.silenced;
   }
   public setSilence() {
     if (this.isDeleted()) {
       throw new AccountAlreadyDeletedError('account already deleted');
     }
-    if (this.getFrozen === 'frozen') {
+    if (this.getFrozen() === 'frozen') {
       throw new AccountAlreadyFrozenError('account already frozen');
     }
 
@@ -202,7 +202,7 @@ export class Account {
     if (this.isDeleted()) {
       throw new AccountAlreadyDeletedError('account already deleted');
     }
-    if (this.getFrozen === 'frozen') {
+    if (this.getFrozen() === 'frozen') {
       throw new AccountAlreadyFrozenError('account already frozen');
     }
 
@@ -210,21 +210,21 @@ export class Account {
   }
 
   private status: AccountStatus;
-  get getStatus(): AccountStatus {
+  getStatus(): AccountStatus {
     return this.status;
   }
   public activate() {
     if (this.isDeleted()) {
       throw new AccountAlreadyDeletedError('account already deleted');
     }
-    if (this.getFrozen === 'frozen') {
+    if (this.getFrozen() === 'frozen') {
       throw new AccountAlreadyFrozenError('account already frozen');
     }
     this.status = 'active';
   }
 
   private updatedAt: Date | undefined;
-  get getUpdatedAt(): Date | undefined {
+  getUpdatedAt(): Date | undefined {
     return this.updatedAt;
   }
   public setUpdatedAt(at: Date) {
@@ -235,7 +235,7 @@ export class Account {
   }
 
   private deletedAt: Date | undefined;
-  get getDeletedAt(): Date | undefined {
+  getDeletedAt(): Date | undefined {
     return this.deletedAt;
   }
   public setDeletedAt(at: Date) {

--- a/pkg/accounts/service/accountVerifyToken.test.ts
+++ b/pkg/accounts/service/accountVerifyToken.test.ts
@@ -27,7 +27,7 @@ describe('TokenVerifyService', () => {
   });
 
   class DateClock implements Clock {
-    Now(): bigint {
+    now(): bigint {
       return 0n;
     }
   }

--- a/pkg/accounts/service/accountVerifyToken.ts
+++ b/pkg/accounts/service/accountVerifyToken.ts
@@ -6,7 +6,7 @@ import { type AccountID } from '../model/account.js';
 import { type AccountVerifyTokenRepository } from '../model/repository.js';
 
 class DateClock implements Clock {
-  Now(): bigint {
+  now(): bigint {
     return BigInt(Date.now());
   }
 }
@@ -32,7 +32,7 @@ export class TokenVerifyService {
 
     // expireDate: After 7 days
     const expireDate = new Date(
-      Number(this.clock.Now()) + 7 * 24 * 60 * 60 * 1000,
+      Number(this.clock.now()) + 7 * 24 * 60 * 60 * 1000,
     );
 
     const encodedToken = Buffer.from(verifyToken).toString('base64');

--- a/pkg/accounts/service/authenticate.test.ts
+++ b/pkg/accounts/service/authenticate.test.ts
@@ -12,7 +12,7 @@ describe('AuthenticationService', () => {
   it('Generate valid token pair', async () => {
     const encoder = new Argon2idPasswordEncoder();
     const passphraseHash =
-      await encoder.EncodePassword('じゃすた・いぐざんぽぅ');
+      await encoder.encodePassword('じゃすた・いぐざんぽぅ');
 
     const accountRepository = new InMemoryAccountRepository();
     await accountRepository.create(

--- a/pkg/accounts/service/authenticate.ts
+++ b/pkg/accounts/service/authenticate.ts
@@ -35,7 +35,7 @@ export class AuthenticationService {
       return Result.err(new Error('Account not found'));
     }
 
-    const isMatch = await this.passwordEncoder.IsMatchPassword(
+    const isMatch = await this.passwordEncoder.isMatchPassword(
       passphrase,
       Option.unwrap(account).getPassphraseHash ?? '',
     );

--- a/pkg/accounts/service/authenticate.ts
+++ b/pkg/accounts/service/authenticate.ts
@@ -37,14 +37,14 @@ export class AuthenticationService {
 
     const isMatch = await this.passwordEncoder.isMatchPassword(
       passphrase,
-      Option.unwrap(account).getPassphraseHash ?? '',
+      Option.unwrap(account).getPassphraseHash() ?? '',
     );
     if (!isMatch) {
       return Result.err(new Error('Password is incorrect'));
     }
 
     const authorizationToken = await this.tokenGenerator.generate(
-      Option.unwrap(account).getName,
+      Option.unwrap(account).getName(),
       convertTo(new Date()),
       convertTo(addSecondsToDate(new Date(), 900)),
     );
@@ -54,7 +54,7 @@ export class AuthenticationService {
     }
 
     const refreshToken = await this.tokenGenerator.generate(
-      Option.unwrap(account).getName,
+      Option.unwrap(account).getName(),
       convertTo(new Date()),
       convertTo(addSecondsToDate(new Date(), 2_592_000)),
     );

--- a/pkg/accounts/service/editAccount.test.ts
+++ b/pkg/accounts/service/editAccount.test.ts
@@ -46,7 +46,7 @@ describe('EditAccountService', () => {
     );
     expect(Result.isErr(updateRes)).toBe(false);
     expect(updateRes[1]).toBe(true);
-    expect(account[1].getNickname).toBe('new nickname');
+    expect(account[1].getNickname()).toBe('new nickname');
   });
 
   it('should be fail to update nickname when nickname shorter more than 1', async () => {
@@ -87,7 +87,7 @@ describe('EditAccountService', () => {
     );
     expect(Result.isErr(updateRes)).toBe(false);
     expect(updateRes[1]).toBe(true);
-    expect(account[1].getNickname).toBe('a'.repeat(256));
+    expect(account[1].getNickname()).toBe('a'.repeat(256));
   });
 
   it('should be success to update nickname when nickname 1', async () => {

--- a/pkg/accounts/service/editAccount.ts
+++ b/pkg/accounts/service/editAccount.ts
@@ -83,7 +83,7 @@ export class EditAccountService {
 
     try {
       account.setPassphraseHash(
-        await this.passwordEncoder.EncodePassword(newPassphrase),
+        await this.passwordEncoder.encodePassword(newPassphrase),
       );
       return Result.ok(true);
     } catch (e) {

--- a/pkg/accounts/service/fetchAccount.test.ts
+++ b/pkg/accounts/service/fetchAccount.test.ts
@@ -31,17 +31,17 @@ describe('FetchAccountService', () => {
     const account = await fetchAccountService.fetchAccount('@john@example.com');
     if (Result.isErr(account)) return;
 
-    expect(account[1].getID).toBe('1');
-    expect(account[1].getName).toBe('@john@example.com');
-    expect(account[1].getMail).toBe('johndoe@example.com');
-    expect(account[1].getNickname).toBe('John Doe');
-    expect(account[1].getPassphraseHash).toBe('hash');
-    expect(account[1].getBio).toBe('');
-    expect(account[1].getRole).toBe('normal');
-    expect(account[1].getFrozen).toBe('normal');
-    expect(account[1].getSilenced).toBe('normal');
-    expect(account[1].getStatus).toBe('notActivated');
-    expect(account[1].getCreatedAt).toBeInstanceOf(Date);
+    expect(account[1].getID()).toBe('1');
+    expect(account[1].getName()).toBe('@john@example.com');
+    expect(account[1].getMail()).toBe('johndoe@example.com');
+    expect(account[1].getNickname()).toBe('John Doe');
+    expect(account[1].getPassphraseHash()).toBe('hash');
+    expect(account[1].getBio()).toBe('');
+    expect(account[1].getRole()).toBe('normal');
+    expect(account[1].getFrozen()).toBe('normal');
+    expect(account[1].getSilenced()).toBe('normal');
+    expect(account[1].getStatus()).toBe('notActivated');
+    expect(account[1].getCreatedAt()).toBeInstanceOf(Date);
   });
 
   it("fetch account info doesn't exist", async () => {

--- a/pkg/accounts/service/follow.ts
+++ b/pkg/accounts/service/follow.ts
@@ -27,8 +27,8 @@ export class FollowService {
     }
 
     const follow = AccountFollow.new({
-      fromID: fromAccount[1].getID,
-      targetID: targetAccount[1].getID,
+      fromID: fromAccount[1].getID(),
+      targetID: targetAccount[1].getID(),
       createdAt: new Date(),
     });
 

--- a/pkg/accounts/service/freeze.test.ts
+++ b/pkg/accounts/service/freeze.test.ts
@@ -34,8 +34,8 @@ describe('FreezeService', () => {
 
     await freezeService.setFreeze('@john@example.com');
 
-    expect(account[1].getFrozen).toBe('frozen');
-    expect(account[1].getFrozen).not.toBe('normal');
+    expect(account[1].getFrozen()).toBe('frozen');
+    expect(account[1].getFrozen()).not.toBe('normal');
   });
 
   it('unset account freeze', async () => {
@@ -44,7 +44,7 @@ describe('FreezeService', () => {
 
     await freezeService.undoFreeze('@john@example.com');
 
-    expect(account[1].getFrozen).toBe('normal');
-    expect(account[1].getFrozen).not.toBe('frozen');
+    expect(account[1].getFrozen()).toBe('normal');
+    expect(account[1].getFrozen()).not.toBe('frozen');
   });
 });

--- a/pkg/accounts/service/register.test.ts
+++ b/pkg/accounts/service/register.test.ts
@@ -50,12 +50,12 @@ describe('RegisterAccountService', () => {
     );
     if (Result.isErr(res)) return;
 
-    expect(res[1].getName).toBe(exampleInput.name);
-    expect(res[1].getMail).toBe(exampleInput.mail);
-    expect(res[1].getNickname).toBe(exampleInput.nickname);
-    expect(res[1].getBio).toBe(exampleInput.bio);
-    expect(res[1].getRole).toBe(exampleInput.role);
-    expect(res[1].getStatus).toBe('notActivated');
+    expect(res[1].getName()).toBe(exampleInput.name);
+    expect(res[1].getMail()).toBe(exampleInput.mail);
+    expect(res[1].getNickname()).toBe(exampleInput.nickname);
+    expect(res[1].getBio()).toBe(exampleInput.bio);
+    expect(res[1].getRole()).toBe(exampleInput.role);
+    expect(res[1].getStatus()).toBe('notActivated');
     repository.reset();
   });
 });

--- a/pkg/accounts/service/register.test.ts
+++ b/pkg/accounts/service/register.test.ts
@@ -16,7 +16,7 @@ const repository = new InMemoryAccountRepository();
 const verifyRepository = new InMemoryAccountVerifyTokenRepository();
 
 class DummyClock implements Clock {
-  Now(): bigint {
+  now(): bigint {
     return BigInt(new Date('2023/9/10 00:00:00 UTC').getTime());
   }
 }

--- a/pkg/accounts/service/register.ts
+++ b/pkg/accounts/service/register.ts
@@ -57,7 +57,7 @@ export class RegisterAccountService {
     }
 
     const passphraseHash =
-      await this.passwordEncoder.EncodePassword(passphrase);
+      await this.passwordEncoder.encodePassword(passphrase);
 
     const generatedID = this.snowflakeIDGenerator.generate<AccountID>();
     if (Result.isErr(generatedID)) {
@@ -87,7 +87,7 @@ export class RegisterAccountService {
     }
 
     // ToDo: Notification Body
-    this.sendNotificationService.Send(mail, `token: ${token[1]}`);
+    this.sendNotificationService.send(mail, `token: ${token[1]}`);
     return Result.ok(account);
   }
 

--- a/pkg/accounts/service/register.ts
+++ b/pkg/accounts/service/register.ts
@@ -81,7 +81,7 @@ export class RegisterAccountService {
       return Result.err(res[1]);
     }
 
-    const token = await this.tokenVerifyService.generate(account.getID);
+    const token = await this.tokenVerifyService.generate(account.getID());
     if (Result.isErr(token)) {
       return Result.err(token[1]);
     }

--- a/pkg/accounts/service/resendToken.ts
+++ b/pkg/accounts/service/resendToken.ts
@@ -35,7 +35,7 @@ export class ResendVerifyTokenService {
       return Option.some(token[1]);
     }
 
-    this.sendNotificationService.Send(account[1].getMail, token[1]);
+    this.sendNotificationService.send(account[1].getMail, token[1]);
 
     return Option.none();
   }

--- a/pkg/accounts/service/resendToken.ts
+++ b/pkg/accounts/service/resendToken.ts
@@ -26,16 +26,16 @@ export class ResendVerifyTokenService {
       return Option.some(new Error('AccountNotFoundError'));
     }
 
-    if (account[1].getStatus !== 'notActivated') {
+    if (account[1].getStatus() !== 'notActivated') {
       return Option.some(new Error('AccountAlreadyVerifiedError'));
     }
 
-    const token = await this.tokenVerifyService.generate(account[1].getID);
+    const token = await this.tokenVerifyService.generate(account[1].getID());
     if (Result.isErr(token)) {
       return Option.some(token[1]);
     }
 
-    this.sendNotificationService.send(account[1].getMail, token[1]);
+    this.sendNotificationService.send(account[1].getMail(), token[1]);
 
     return Option.none();
   }

--- a/pkg/accounts/service/sendNotification.ts
+++ b/pkg/accounts/service/sendNotification.ts
@@ -1,11 +1,11 @@
 import { Result } from '@mikuroxina/mini-fn';
 
 export interface SendNotificationService {
-  Send(to: string, body: string): Promise<Result.Result<Error, void>>;
+  send(to: string, body: string): Promise<Result.Result<Error, void>>;
 }
 
 export class DummySendNotificationService implements SendNotificationService {
-  Send(): Promise<Result.Result<Error, void>> {
+  send(): Promise<Result.Result<Error, void>> {
     return Promise.resolve(Result.ok(undefined));
   }
 }

--- a/pkg/accounts/service/silence.test.ts
+++ b/pkg/accounts/service/silence.test.ts
@@ -33,8 +33,8 @@ describe('SilenceService', () => {
 
     await silenceService.setSilence('@john@example.com');
 
-    expect(account[1].getSilenced).toBe('silenced');
-    expect(account[1].getSilenced).not.toBe('normal');
+    expect(account[1].getSilenced()).toBe('silenced');
+    expect(account[1].getSilenced()).not.toBe('normal');
   });
 
   it('unset account silence', async () => {
@@ -43,7 +43,7 @@ describe('SilenceService', () => {
 
     await silenceService.undoSilence('@john@example.com');
 
-    expect(account[1].getSilenced).toBe('normal');
-    expect(account[1].getSilenced).not.toBe('silenced');
+    expect(account[1].getSilenced()).toBe('normal');
+    expect(account[1].getSilenced()).not.toBe('silenced');
   });
 });

--- a/pkg/accounts/service/unfollow.ts
+++ b/pkg/accounts/service/unfollow.ts
@@ -26,8 +26,8 @@ export class UnfollowService {
     }
 
     const res = await this.followRepository.unfollow(
-      fromAccount[1].getID,
-      targetAccount[1].getID,
+      fromAccount[1].getID(),
+      targetAccount[1].getID(),
     );
     if (Result.isErr(res)) {
       return Option.some(res[1]);

--- a/pkg/id/mod.test.ts
+++ b/pkg/id/mod.test.ts
@@ -4,7 +4,7 @@ import { describe, it, expect } from 'vitest';
 import { type Clock, SnowflakeIDGenerator } from './mod.js';
 
 class DummyClock implements Clock {
-  Now(): bigint {
+  now(): bigint {
     return BigInt(new Date('2023/9/10 00:00:00 UTC').getTime());
   }
 }

--- a/pkg/id/mod.ts
+++ b/pkg/id/mod.ts
@@ -4,7 +4,7 @@ import { OFFSET_FROM_UNIX_EPOCH } from '../time/mod.js';
 import type { ID } from './type.js';
 
 export interface Clock {
-  Now(): bigint;
+  now(): bigint;
 }
 
 export class SnowflakeIDGenerator {
@@ -34,7 +34,7 @@ export class SnowflakeIDGenerator {
    * @returns SnowflakeID (string)
    */
   public generate<T>(): Result.Result<Error, ID<T>> {
-    const now = this.clock.Now();
+    const now = this.clock.now();
     const timeFromEpoch = now - OFFSET_FROM_UNIX_EPOCH;
     if (timeFromEpoch < 0) {
       return Result.err(new Error('invalid date'));

--- a/pkg/password/mod.test.ts
+++ b/pkg/password/mod.test.ts
@@ -7,13 +7,13 @@ const raw = 'じゃすた・いぐざんぽぅ';
 
 describe('ScryptPasswordEncoder', () => {
   it('verify password with bcrypt', async () => {
-    const encoded = await encoder.EncodePassword(raw);
-    const actual = await encoder.IsMatchPassword(raw, encoded);
+    const encoded = await encoder.encodePassword(raw);
+    const actual = await encoder.isMatchPassword(raw, encoded);
     expect(actual).toBe(true);
   });
 
   it('when verify failed, it returns false', async () => {
-    const res = await encoder.IsMatchPassword(raw, '');
+    const res = await encoder.isMatchPassword(raw, '');
     expect(res).toBe(false);
   });
 });

--- a/pkg/password/mod.ts
+++ b/pkg/password/mod.ts
@@ -4,18 +4,18 @@ import { argon2id, hash, verify } from 'argon2';
 export type EncodedPassword = string;
 
 export interface PasswordEncoder {
-  EncodePassword(raw: string): Promise<EncodedPassword>;
-  IsMatchPassword(raw: string, encoded: EncodedPassword): Promise<boolean>;
+  encodePassword(raw: string): Promise<EncodedPassword>;
+  isMatchPassword(raw: string, encoded: EncodedPassword): Promise<boolean>;
 }
 
 export class Argon2idPasswordEncoder implements PasswordEncoder {
-  async EncodePassword(raw: string) {
+  async encodePassword(raw: string) {
     return await hash(raw, {
       type: argon2id,
     });
   }
 
-  async IsMatchPassword(
+  async isMatchPassword(
     raw: string,
     encoded: EncodedPassword,
   ): Promise<boolean> {


### PR DESCRIPTION
## What does this PR do?

Sometimes methods in the interfaces/classes are not compliant to the coding style. So this refactors method names like as:

- Make method names camelCase
- Make get-accessors into getters

## Additional information

It seems that the account model definition is lacking domain-specific responsibilities. So it may be needed to improve with appending more functional methods.
