### PR TITLE
feat: impl create note API endpoint

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -3,6 +3,7 @@ import { apiReference } from '@scalar/hono-api-reference';
 import { Hono } from 'hono';
 
 import { accounts } from './pkg/accounts/mod.js';
+import { noteHandlers } from './pkg/notes/mod.js';
 
 const app = new Hono();
 
@@ -10,10 +11,11 @@ const app = new Hono();
 All routes must be "/"
 (The "/" account cannot be written in the library specification.
  */
+app.route('/', noteHandlers);
 app.route('/', accounts);
 
 app.get('/doc.json', async (c) => {
-  const modulePath: string[] = ['accounts'];
+  const modulePath: string[] = ['accounts', 'notes'];
   const basePath = 'http://localhost:3000/';
   const openAPIBase = {
     openapi: '3.0.0',

--- a/pkg/notes/adaptor/controller/note.ts
+++ b/pkg/notes/adaptor/controller/note.ts
@@ -1,0 +1,43 @@
+import { type z } from '@hono/zod-openapi';
+import { Option, Result } from '@mikuroxina/mini-fn';
+
+import type { AccountID } from '../../../accounts/model/account.js';
+import type { ID } from '../../../id/type.js';
+import type { NoteVisibility } from '../../model/note.js';
+import type { CreateNoteService } from '../../service/create.js';
+import { type CreateNoteResponseSchema } from '../validator/schema.js';
+
+export class NoteController {
+  constructor(private readonly createNoteService: CreateNoteService) {}
+
+  async createNote(
+    authorID: string,
+    content: string,
+    visibility: string,
+    contentsWarningComment: string,
+    sendTo?: string,
+  ): Promise<Result.Result<Error, z.infer<typeof CreateNoteResponseSchema>>> {
+    const res = await this.createNoteService.handle(
+      content,
+      contentsWarningComment,
+      !sendTo ? Option.none() : Option.some(sendTo as ID<AccountID>),
+      authorID as ID<AccountID>,
+      visibility as NoteVisibility,
+    );
+    if (Result.isErr(res)) {
+      return res;
+    }
+
+    return Result.ok({
+      id: res[1].getID(),
+      content: res[1].getContent(),
+      visibility: res[1].getVisibility(),
+      contents_warning_comment: res[1].getCwComment(),
+      send_to: Option.isSome(res[1].getSendTo())
+        ? Option.unwrap(res[1].getSendTo())
+        : undefined,
+      author_id: res[1].getAuthorID(),
+      created_at: res[1].getCreatedAt().toUTCString(),
+    });
+  }
+}

--- a/pkg/notes/adaptor/validator/schema.ts
+++ b/pkg/notes/adaptor/validator/schema.ts
@@ -60,7 +60,7 @@ export const CreateNoteResponseSchema = z.object({
     description: 'Author account ID',
   }),
   created_at: z.string().openapi({
-    // example: '2021-01-01T00:00:00Z',
-    // description: 'Note created date',
+    example: '2021-01-01T00:00:00Z',
+    description: 'Note created date',
   }),
 });

--- a/pkg/notes/adaptor/validator/schema.ts
+++ b/pkg/notes/adaptor/validator/schema.ts
@@ -1,0 +1,66 @@
+import { z } from '@hono/zod-openapi';
+
+export const CommonErrorSchema = z.object({
+  // ToDo: define error code list (oneOf)
+  error: z.string().openapi({
+    example: 'TEST_ERROR_CODE',
+    description: 'Error code',
+    default: '',
+  }),
+});
+
+export const CreateNoteRequestSchema = z.object({
+  content: z.string().max(3000).openapi({
+    example: 'hello world!',
+    description:
+      'Note content (max 3000 characters/if attachment file exists, allow 0 character)',
+    default: '',
+  }),
+  visibility: z.string().openapi({
+    example: 'PUBLIC',
+    description: 'Note visibility (PUBLIC/HOME/FOLLOWERS/DIRECT)',
+    default: 'PUBLIC',
+  }),
+  // ToDo: Define attachment schema
+  contents_warning_comment: z.string().max(256).openapi({
+    example: 'This note contains sensitive content',
+    description: 'Contents warning comment (max 256 characters)',
+    default: '',
+  }),
+  send_to: z.string().optional().openapi({
+    example: '38477395',
+    description: 'Send to account ID (if visibility is DIRECT)',
+    default: '',
+  }),
+});
+
+export const CreateNoteResponseSchema = z.object({
+  id: z.string().openapi({
+    example: '38477395',
+    description: 'Note ID',
+  }),
+  content: z.string().openapi({
+    example: 'hello world!',
+    description: 'Note content',
+  }),
+  visibility: z.string().openapi({
+    example: 'PUBLIC',
+    description: 'Note visibility',
+  }),
+  contents_warning_comment: z.string().openapi({
+    example: 'This note contains sensitive content',
+    description: 'Contents warning comment',
+  }),
+  send_to: z.string().optional().openapi({
+    example: '38477395',
+    description: 'Send to account ID',
+  }),
+  author_id: z.string().openapi({
+    example: '38477395',
+    description: 'Author account ID',
+  }),
+  created_at: z.string().openapi({
+    // example: '2021-01-01T00:00:00Z',
+    // description: 'Note created date',
+  }),
+});

--- a/pkg/notes/mod.ts
+++ b/pkg/notes/mod.ts
@@ -1,0 +1,41 @@
+import { OpenAPIHono } from '@hono/zod-openapi';
+import { Result } from '@mikuroxina/mini-fn';
+
+import { SnowflakeIDGenerator } from '../id/mod.js';
+import { NoteController } from './adaptor/controller/note.js';
+import { InMemoryNoteRepository } from './adaptor/repository/dummy.js';
+import { CreateNoteRoute } from './router.js';
+import { CreateNoteService } from './service/create.js';
+
+const notes = new OpenAPIHono();
+const noteRepository = new InMemoryNoteRepository();
+const idGenerator = new SnowflakeIDGenerator(0, {
+  now: () => BigInt(Date.now()),
+});
+const createNoteService = new CreateNoteService(noteRepository, idGenerator);
+const controller = new NoteController(createNoteService);
+
+notes.doc('/notes/doc.json', {
+  openapi: '3.0.0',
+  info: {
+    title: 'Notes API',
+    version: '0.1.0',
+  },
+});
+
+notes.openapi(CreateNoteRoute, async (c) => {
+  const { content, visibility, contents_warning_comment, send_to } =
+    c.req.valid('json');
+  const res = await controller.createNote(
+    '',
+    content,
+    visibility,
+    contents_warning_comment,
+    send_to,
+  );
+  if (Result.isErr(res)) {
+    return c.json({ error: res[1].message }, 400);
+  }
+
+  return c.json(res[1]);
+});

--- a/pkg/notes/mod.ts
+++ b/pkg/notes/mod.ts
@@ -7,7 +7,7 @@ import { InMemoryNoteRepository } from './adaptor/repository/dummy.js';
 import { CreateNoteRoute } from './router.js';
 import { CreateNoteService } from './service/create.js';
 
-const notes = new OpenAPIHono();
+export const noteHandlers = new OpenAPIHono();
 const noteRepository = new InMemoryNoteRepository();
 const idGenerator = new SnowflakeIDGenerator(0, {
   now: () => BigInt(Date.now()),
@@ -15,7 +15,7 @@ const idGenerator = new SnowflakeIDGenerator(0, {
 const createNoteService = new CreateNoteService(noteRepository, idGenerator);
 const controller = new NoteController(createNoteService);
 
-notes.doc('/notes/doc.json', {
+noteHandlers.doc('/notes/doc.json', {
   openapi: '3.0.0',
   info: {
     title: 'Notes API',
@@ -23,7 +23,7 @@ notes.doc('/notes/doc.json', {
   },
 });
 
-notes.openapi(CreateNoteRoute, async (c) => {
+noteHandlers.openapi(CreateNoteRoute, async (c) => {
   const { content, visibility, contents_warning_comment, send_to } =
     c.req.valid('json');
   const res = await controller.createNote(

--- a/pkg/notes/router.ts
+++ b/pkg/notes/router.ts
@@ -1,0 +1,49 @@
+import { createRoute } from '@hono/zod-openapi';
+
+import { CommonErrorResponseSchema } from '../accounts/adaptor/validator/schema.js';
+import {
+  CreateNoteRequestSchema,
+  CreateNoteResponseSchema,
+} from './adaptor/validator/schema.js';
+
+export const CreateNoteRoute = createRoute({
+  method: 'post',
+  tags: ['notes'],
+  path: '/notes',
+  request: {
+    body: {
+      content: {
+        'application/json': {
+          schema: CreateNoteRequestSchema,
+        },
+      },
+    },
+  },
+  responses: {
+    200: {
+      description: 'OK',
+      content: {
+        'application/json': {
+          schema: CreateNoteResponseSchema,
+        },
+      },
+    },
+    400: {
+      description: 'Bad Request',
+      content: {
+        'application/json': {
+          schema: CommonErrorResponseSchema,
+        },
+      },
+    },
+    403: {
+      description: 'You are silenced',
+      content: {
+        'application/json': {
+          schema: CommonErrorResponseSchema,
+        },
+      },
+    },
+    // ToDo: Define 404 (Attachment not found/Send to Account not found)
+  },
+});

--- a/pkg/notes/service/create.test.ts
+++ b/pkg/notes/service/create.test.ts
@@ -26,6 +26,29 @@ describe('CreateNoteService', () => {
     );
 
     expect(Result.isOk(res)).toBe(true);
-    console.log(res[1]);
+  });
+
+  it('note content must be less than 3000 chars', async () => {
+    const res = await createNoteService.handle(
+      'a'.repeat(3001),
+      '',
+      Option.none(),
+      '1' as ID<AccountID>,
+      'PUBLIC',
+    );
+
+    expect(Result.isErr(res)).toBe(true);
+  });
+
+  it('note visibility DIRECT must have a destination', async () => {
+    const res = await createNoteService.handle(
+      'Hello world',
+      '',
+      Option.none(),
+      '1' as ID<AccountID>,
+      'DIRECT',
+    );
+
+    expect(Result.isErr(res)).toBe(true);
   });
 });

--- a/pkg/notes/service/create.test.ts
+++ b/pkg/notes/service/create.test.ts
@@ -10,7 +10,9 @@ import { CreateNoteService } from './create.js';
 const noteRepository = new InMemoryNoteRepository();
 const createNoteService = new CreateNoteService(
   noteRepository,
-  new SnowflakeIDGenerator(0, { now: () => BigInt(Date.now()) }),
+  new SnowflakeIDGenerator(0, {
+    now: () => BigInt(Date.UTC(2023, 9, 10, 0, 0)),
+  }),
 );
 
 describe('CreateNoteService', () => {

--- a/pkg/notes/service/create.test.ts
+++ b/pkg/notes/service/create.test.ts
@@ -1,0 +1,29 @@
+import { Option, Result } from '@mikuroxina/mini-fn';
+import { describe, expect, it } from 'vitest';
+
+import type { AccountID } from '../../accounts/model/account.js';
+import { SnowflakeIDGenerator } from '../../id/mod.js';
+import type { ID } from '../../id/type.js';
+import { InMemoryNoteRepository } from '../adaptor/repository/dummy.js';
+import { CreateNoteService } from './create.js';
+
+const noteRepository = new InMemoryNoteRepository();
+const createNoteService = new CreateNoteService(
+  noteRepository,
+  new SnowflakeIDGenerator(0, { now: () => BigInt(Date.now()) }),
+);
+
+describe('CreateNoteService', () => {
+  it('should create a note', async () => {
+    const res = await createNoteService.handle(
+      'Hello world',
+      '',
+      Option.none(),
+      '1' as ID<AccountID>,
+      'PUBLIC',
+    );
+
+    expect(Result.isOk(res)).toBe(true);
+    console.log(res[1]);
+  });
+});

--- a/pkg/notes/service/create.ts
+++ b/pkg/notes/service/create.ts
@@ -18,21 +18,25 @@ export class CreateNoteService {
     if (Result.isErr(id)) {
       return id;
     }
-    const note = Note.new({
-      id: id[1],
-      content: content,
-      contentsWarningComment: contentsWarningComment,
-      createdAt: new Date(),
-      sendTo: sendTo,
-      visibility: visibility,
-      authorID: authorID,
-    });
-    const res = await this.noteRepository.create(note);
-    if (Result.isErr(res)) {
-      return res;
-    }
+    try {
+      const note = Note.new({
+        id: id[1],
+        content: content,
+        contentsWarningComment: contentsWarningComment,
+        createdAt: new Date(),
+        sendTo: sendTo,
+        visibility: visibility,
+        authorID: authorID,
+      });
+      const res = await this.noteRepository.create(note);
+      if (Result.isErr(res)) {
+        return res;
+      }
 
-    return Result.ok(note);
+      return Result.ok(note);
+    } catch (e) {
+      return Result.err(e as unknown as Error);
+    }
   }
 
   constructor(

--- a/pkg/notes/service/create.ts
+++ b/pkg/notes/service/create.ts
@@ -1,0 +1,42 @@
+import { type Option, Result } from '@mikuroxina/mini-fn';
+
+import type { AccountID } from '../../accounts/model/account.js';
+import type { SnowflakeIDGenerator } from '../../id/mod.js';
+import type { ID } from '../../id/type.js';
+import { Note, type NoteID, type NoteVisibility } from '../model/note.js';
+import type { NoteRepository } from '../model/repository.js';
+
+export class CreateNoteService {
+  async handle(
+    content: string,
+    contentsWarningComment: string,
+    sendTo: Option.Option<ID<AccountID>>,
+    authorID: ID<AccountID>,
+    visibility: NoteVisibility,
+  ): Promise<Result.Result<Error, Note>> {
+    const id = this.idGenerator.generate<NoteID>();
+    if (Result.isErr(id)) {
+      return id;
+    }
+    const note = Note.new({
+      id: id[1],
+      content: content,
+      contentsWarningComment: contentsWarningComment,
+      createdAt: new Date(),
+      sendTo: sendTo,
+      visibility: visibility,
+      authorID: authorID,
+    });
+    const res = await this.noteRepository.create(note);
+    if (Result.isErr(res)) {
+      return res;
+    }
+
+    return Result.ok(note);
+  }
+
+  constructor(
+    private readonly noteRepository: NoteRepository,
+    private readonly idGenerator: SnowflakeIDGenerator,
+  ) {}
+}


### PR DESCRIPTION
## What does this PR do?
- `CreateNoteService`の実装とテスト
- `POST /notes`のスキーマ定義/コントローラー実装/エンドポイント実装

## Additional information
Schemaでz.dateを使おうとするとエラーになる謎の不具合に遭遇しました.  
調査はしますが現状はstringに書き直しています.
