### PR TITLE
chore: fix License name

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2023 Approvers
+   Copyright 2023 pulsate-dev
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
## What does this PR do?

The license name in the `LICENSE` was still `Approvers`, so it has been changed to `pulsate-dev`.