### PR TITLE
chore: fix `clean` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,14 +16,14 @@
   },
   "scripts": {
     "build": "tsc -p .",
+    "clean": "rm -r ./build",
     "start": "node ./build/main.js",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "format": "prettier --write \"./**/*.{js,ts,md}\"",
     "format:check": "prettier --check \"./**/*.{js,ts,md}\"",
     "lint": "eslint . ",
-    "postinstall": "lefthook install",
-    "clean": "rm -rf ./build/*"
+    "postinstall": "lefthook install"
   },
   "dependencies": {
     "@hono/node-server": "^1.7.0",


### PR DESCRIPTION
## What does this PR do?

`pnpm run clean` does not work as expected, and the `rm` command does not work correctly on Windows OS, which is different from macOS and Linux. 

The `-force` option exists in `rm` on Windows OS, but it is different from `-f` in `rm` on Unix, so the `-f` option has been removed from `clean` scripts to work correctly on Windows OS.