### PR TITLE
chore: fix Codeowner error

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,15 +1,7 @@
-# Tech Leader: @laminne
+CODE_OF_CONDUCT.md @pulsate-dev/core-team
 
-pkg/ @laminne
+.github/CODE_OF_CONDUCT_JA.md @pulsate-dev/core-team
 
-resources/ @laminne
+SECURITY_JA.md @pulsate-dev/core-team
 
-main.ts @laminne
-
-docs/api.yaml @laminne
-
-# Core Team: @m1sk9, @MikuroXina, @Colk-tech
-
-.github/CODE_OF_CONDUCT_JA.md @m1sk9 @MikuroXina @Colk-tech
-
-CODE_OF_CONDUCT.md @m1sk9 @MikuroXina @Colk-tech
+.github/SECURITY_JA.md @pulsate-dev/core-team


### PR DESCRIPTION
## What does this PR do?

The error is due to a member who has already left the team and is listed in the `CODEOWNER` file.

I removed the IDs of the departed members, switched to the method of specifying the Org Team directly, and removed @laminne from the code owner of all source code files.