### PR TITLE
test: restrict coverage measure to the `pkg/` dir only

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,8 @@ export default defineConfig({
   test: {
     exclude: [...configDefaults.exclude, 'build/**'],
     coverage: {
+      include: ['pkg/**'],
+      exclude: [...configDefaults.exclude, 'build/**'],
       reporter: ['text', 'json', 'html'],
     },
   },


### PR DESCRIPTION
## What does this PR do?

Restrict Coverage measurement to `pkg/` and exclude unnecessary files such as `main.ts`, `build.js`, etc.

See also: https://linear.app/pulsate/issue/DEV-174/