### PR TITLE
docs: allow filename casing `lowercase`

### DIFF
--- a/.github/CONTRIBUTING_JA.md
+++ b/.github/CONTRIBUTING_JA.md
@@ -179,6 +179,7 @@ Pulsate開発のためのスタイルガイド.
 - 名前空間名は `PascalCase`.
 
 - ファイル名は `camelCase` で作成する必要があります.
+  - 1語になる場合は `lowercase` を使用してください.
 
 #### null と undefined
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -177,6 +177,7 @@ Also, in situations where `camelCase` should be used, it is counted as a single 
 - The namespace name is `PascalCase`.
 
 - The file name should be in `camelCase`.
+  - Use `lowercase` for a single word.
 
 #### null and undefined
 


### PR DESCRIPTION
## What does this PR do?

Fixed `CONTRIBUTING.md`, #237 , because of limited permission to use `lowercase` in file names.