### PR TITLE
ci: bump `pnpm/action-setup` v2 to v3

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup pnpm v8
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v3
         with:
           version: 8
 


### PR DESCRIPTION
## What does this PR do?

Upgraded `pnpm/action-setup`.

It now works with Node.js v16 to v20.