### PR TITLE
docs: Remove remaining Deno content from Contributing Guide

### DIFF
--- a/.github/CONTRIBUTING_JA.md
+++ b/.github/CONTRIBUTING_JA.md
@@ -61,7 +61,7 @@ Pulsateにプルリクエストを提出するには, **なぜこの変更が必
   - 進行中のPRを投稿したい場合は, ["Draft" として投稿してください](https://docs.github.com/ja/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request).
 - プルリクエストのタイトルは[Conventional Commits](#コミットメッセージ)に準拠してください.
 
-完了次第 `deno fmt` を実行してコードを整形してください.
+完了次第 `pnpm format` を実行してコードを整形してください. (VSCode を使用している場合は自動的に整形されます.)
 
 Pulsate メンテナーのレビューと承認が得られれば, マージできます.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,7 @@ Before submitting a pull request, please check the following points:
   - If you want to submit a PR in progress, [please submit it as "Draft"](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request).
 - Pull request title conforms to [Conventional Commits](#commit-message)
 
-If you are sure, run "deno fmt" to format the code.
+After finishing, please run `pnpm format` to format the code. (If you are using VSCode, it will be formatted automatically.)
 
 Once it has been reviewed and approved by the Pulsate maintainer, it can be merged.
 


### PR DESCRIPTION
## What does this PR do?

Deno content forgotten during Node.js migration has been removed from the Contributing Guide