### PR TITLE
feat: add `FetchAccountFollowService`

### DIFF
--- a/pkg/accounts/service/fetchAccountFollow.test.ts
+++ b/pkg/accounts/service/fetchAccountFollow.test.ts
@@ -1,0 +1,137 @@
+import { Result } from '@mikuroxina/mini-fn';
+import { describe, expect, it } from 'vitest';
+
+import type { ID } from '../../id/type.js';
+import {
+  InMemoryAccountFollowRepository,
+  InMemoryAccountRepository,
+} from '../adaptor/repository/dummy.js';
+import { Account, type AccountID } from '../model/account.js';
+import { AccountFollow } from '../model/follow.js';
+import { FetchAccountFollowService } from './fetchAccountFollow.js';
+
+const accountRepository = new InMemoryAccountRepository();
+
+await accountRepository.create(
+  Account.reconstruct({
+    id: '1' as ID<AccountID>,
+    name: '@johndoe@example.com',
+    bio: '',
+    mail: '',
+    nickname: '',
+    passphraseHash: undefined,
+    frozen: 'normal',
+    role: 'normal',
+    silenced: 'normal',
+    status: 'active',
+    createdAt: new Date(),
+    updatedAt: undefined,
+    deletedAt: undefined,
+  }),
+);
+
+await accountRepository.create(
+  Account.reconstruct({
+    id: '2' as ID<AccountID>,
+    name: '@testuser@example.com',
+    bio: '',
+    mail: '',
+    nickname: '',
+    passphraseHash: undefined,
+    frozen: 'normal',
+    role: 'normal',
+    silenced: 'normal',
+    status: 'active',
+    createdAt: new Date(),
+    updatedAt: undefined,
+    deletedAt: undefined,
+  }),
+);
+
+const createdAt = new Date();
+const repository = new InMemoryAccountFollowRepository();
+
+await repository.follow(
+  AccountFollow.new({
+    fromID: '1' as ID<AccountID>,
+    targetID: '2' as ID<AccountID>,
+    createdAt,
+  }),
+);
+
+await repository.follow(
+  AccountFollow.new({
+    fromID: '2' as ID<AccountID>,
+    targetID: '1' as ID<AccountID>,
+    createdAt,
+  }),
+);
+
+const service = new FetchAccountFollowService(repository, accountRepository);
+
+describe('FetchAccountFollowService', () => {
+  const USER = {
+    id: '1' as ID<AccountID>,
+    name: '@johndoe@example.com' as const,
+  };
+
+  it('fetch followings by id', async () => {
+    const resFollows = await service.fetchFollowingsByID(USER.id);
+    if (Result.isErr(resFollows)) {
+      return;
+    }
+
+    expect(resFollows[1]).toStrictEqual([
+      AccountFollow.new({
+        fromID: '1' as ID<AccountID>,
+        targetID: '2' as ID<AccountID>,
+        createdAt,
+      }),
+    ]);
+  });
+
+  it('fetch followings by name', async () => {
+    const resFollows = await service.fetchFollowingsByName(USER.name);
+    if (Result.isErr(resFollows)) {
+      return;
+    }
+
+    expect(resFollows[1]).toStrictEqual([
+      AccountFollow.new({
+        fromID: '1' as ID<AccountID>,
+        targetID: '2' as ID<AccountID>,
+        createdAt,
+      }),
+    ]);
+  });
+
+  it('fetch followers by id', async () => {
+    const resFollows = await service.fetchFollowersByID(USER.id);
+    if (Result.isErr(resFollows)) {
+      return;
+    }
+
+    expect(resFollows[1]).toStrictEqual([
+      AccountFollow.new({
+        fromID: '2' as ID<AccountID>,
+        targetID: '1' as ID<AccountID>,
+        createdAt,
+      }),
+    ]);
+  });
+
+  it('fetch followers by name', async () => {
+    const resFollows = await service.fetchFollowersByName(USER.name);
+    if (Result.isErr(resFollows)) {
+      return;
+    }
+
+    expect(resFollows[1]).toStrictEqual([
+      AccountFollow.new({
+        fromID: '2' as ID<AccountID>,
+        targetID: '1' as ID<AccountID>,
+        createdAt,
+      }),
+    ]);
+  });
+});

--- a/pkg/accounts/service/fetchAccountFollow.ts
+++ b/pkg/accounts/service/fetchAccountFollow.ts
@@ -1,0 +1,41 @@
+import { Option } from '@mikuroxina/mini-fn';
+
+import type { AccountID, AccountName } from '../../accounts/model/account.js';
+import type { ID } from '../../id/type.js';
+import type {
+  AccountFollowRepository,
+  AccountRepository,
+} from '../model/repository.js';
+
+export class FetchAccountFollowService {
+  constructor(
+    private readonly accountFollowRepository: AccountFollowRepository,
+    private readonly accountRepository: AccountRepository,
+  ) {}
+
+  async fetchFollowingsByID(id: ID<AccountID>) /* inferred */ {
+    return this.accountFollowRepository.fetchAllFollowing(id);
+  }
+
+  async fetchFollowingsByName(name: AccountName) /* inferred */ {
+    const id = await this.accountRepository
+      .findByName(name)
+      .then((o) => Option.unwrap(o))
+      .then((a) => a.getID());
+
+    return this.fetchFollowingsByID(id);
+  }
+
+  async fetchFollowersByID(id: ID<AccountID>) /* inferred */ {
+    return this.accountFollowRepository.fetchAllFollowers(id);
+  }
+
+  async fetchFollowersByName(name: AccountName) /* inferred */ {
+    const id = await this.accountRepository
+      .findByName(name)
+      .then((o) => Option.unwrap(o))
+      .then((a) => a.getID());
+
+    return this.fetchFollowersByID(id);
+  }
+}


### PR DESCRIPTION
## What does this PR do?

`FetchAccountFollowService` を追加します. `ID<AccountID>` のみでなく `AccountName` でも取得できるよう拡張しています.

## Additional information

- `/* inferred */` の部分, きちんと型宣言した方が良いですか？
- `AccountName` を使えるようにする拡張, 要る？