### PR TITLE
ci: add comment pr step

### DIFF
--- a/.github/workflows/check-pr-title.yaml
+++ b/.github/workflows/check-pr-title.yaml
@@ -12,6 +12,33 @@ jobs:
     name: Check PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - name: Check PR title
+        id: check_pr_title
+        uses: amannn/action-semantic-pull-request@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Comment PR
+        uses: thollander/actions-comment-pull-request@v2
+        if: failure() && steps.check_pr_title.outcome == 'failure'
+        with:
+          message: |
+            @${{ github.actor }}
+            To merge a pull request, the title must be according to [Conventional Commits](https://conventionalcommits.org/).
+            Click the "Edit" button at the top right of the page to change the title, please.
+
+            <details>
+            <summary>Available types:</summary>
+
+            - feat: A new feature
+            - fix: A bug fix
+            - docs: Documentation only changes
+            - style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
+            - refactor: A code change that neither fixes a bug nor adds a feature
+            - perf: A code change that improves performance
+            - test: Adding missing tests or correcting existing tests
+            - build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
+            - ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
+            - chore: Other changes that don't modify src or test files
+            - revert: Reverts a previous commit
+            </details>


### PR DESCRIPTION
## What does this PR do?

Add a comment to prompt correction when the CI that checks if the title complies with Conventional Commits fails.