### PR TITLE
feat(AccountRepository): add edit method

### DIFF
--- a/pkg/accounts/adaptor/repository/dummy.ts
+++ b/pkg/accounts/adaptor/repository/dummy.ts
@@ -52,6 +52,17 @@ export class InMemoryAccountRepository implements AccountRepository {
 
     return Promise.resolve(Option.some(account));
   }
+
+  async edit(account: Account): Promise<Result.Result<Error, void>> {
+    this.data.forEach((a) => {
+      if (a.getID() === account.getID()) {
+        this.data.delete(a);
+      }
+    });
+    this.data.add(account);
+
+    return Result.ok(undefined);
+  }
 }
 
 export class InMemoryAccountVerifyTokenRepository

--- a/pkg/accounts/adaptor/repository/prisma.ts
+++ b/pkg/accounts/adaptor/repository/prisma.ts
@@ -88,6 +88,19 @@ export class PrismaAccountRepository implements AccountRepository {
     return Option.some(this.fromPrismaArgs(res));
   }
 
+  async edit(account: Account): Promise<Result.Result<Error, void>> {
+    try {
+      await this.prisma.account.update({
+        where: { id: account.getID() },
+        data: this.toPrismaArgs(account),
+      });
+    } catch (e) {
+      return Result.err(e as Error);
+    }
+
+    return Result.ok(undefined);
+  }
+
   private toPrismaArgs(account: Account): AccountPrismaArgs {
     const role = (
       {

--- a/pkg/accounts/model/repository.ts
+++ b/pkg/accounts/model/repository.ts
@@ -11,6 +11,7 @@ export interface AccountRepository {
   findByName(name: string): Promise<Option.Option<Account>>;
   findByID(id: ID<AccountID>): Promise<Option.Option<Account>>;
   findByMail(mail: string): Promise<Option.Option<Account>>;
+  edit(account: Account): Promise<Result.Result<Error, void>>;
 }
 
 export interface InactiveAccountRepository {


### PR DESCRIPTION
## What does this PR do?

- AccountRepositoryの定義にeditメソッドを追加
- dummy, prismaそれぞれでeditメソッドを実装