### PR TITLE
ci: fix pnpm version issue

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,10 +15,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup pnpm v9
+      - name: Setup pnpm
         uses: pnpm/action-setup@v3
-        with:
-          version: 9
 
       - name: Setup Node.js 20
         uses: actions/setup-node@v4


### PR DESCRIPTION
## What does this PR do?

`pnpm/action-setup@v3` は `version` での指定を外すと package.json の `packageManager` を見てバージョンを設定するようです.

Pulsate では CI 上で pnpm が最新版に固定されてしまい lockfile でエラーが発生していたのでこの指定を外し `packageManager` の値を見るようにします.