### PR TITLE
feat: use hono rpc mode in intermodule interfaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@prisma/client": "5.12.1",
     "@scalar/hono-api-reference": "^0.5.0",
     "argon2": "^0.40.0",
-    "hono": "^4.2.9",
+    "hono": "^4.0.0",
     "jose": "^5.2.1",
     "prisma": "^5.9.1",
     "typescript": "^5.3.3"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@prisma/client": "5.12.1",
     "@scalar/hono-api-reference": "^0.5.0",
     "argon2": "^0.40.0",
-    "hono": "^4.0.0",
+    "hono": "^4.2.9",
     "jose": "^5.2.1",
     "prisma": "^5.9.1",
     "typescript": "^5.3.3"

--- a/pkg/accounts/mod.ts
+++ b/pkg/accounts/mod.ts
@@ -106,23 +106,18 @@ accounts.doc('/accounts/doc.json', {
   },
 });
 
-export type AccountModuleHandlerType =
-  | typeof GetAccountHandler
-  | typeof CreateAccountHandler;
+export type AccountModuleHandlerType = typeof GetAccountHandler;
 
-export const CreateAccountHandler = accounts.openapi(
-  CreateAccountRoute,
-  async (c) => {
-    const { name, email, passphrase } = c.req.valid('json');
+accounts.openapi(CreateAccountRoute, async (c) => {
+  const { name, email, passphrase } = c.req.valid('json');
 
-    const res = await controller.createAccount(name, email, passphrase);
-    if (Result.isErr(res)) {
-      return c.json({ error: res[1].message }, { status: 400 });
-    }
+  const res = await controller.createAccount(name, email, passphrase);
+  if (Result.isErr(res)) {
+    return c.json({ error: res[1].message }, { status: 400 });
+  }
 
-    return c.json(res[1]);
-  },
-);
+  return c.json(res[1]);
+});
 
 accounts.openapi(UpdateAccountRoute, async (c) => {
   const name = c.req.param('name');

--- a/pkg/accounts/mod.ts
+++ b/pkg/accounts/mod.ts
@@ -179,29 +179,26 @@ accounts.openapi(VerifyEmailRoute, async (c) => {
   return new Response(null, { status: 204 });
 });
 
-export const GetAccountHandler = accounts.openapi(
-  GetAccountRoute,
-  async (c) => {
-    const name = c.req.param('name');
+const GetAccountHandler = accounts.openapi(GetAccountRoute, async (c) => {
+  const name = c.req.param('name');
 
-    const res = await controller.getAccount(name);
-    if (Result.isErr(res)) {
-      return c.json({ error: res[1].message }, { status: 404 });
-    }
+  const res = await controller.getAccount(name);
+  if (Result.isErr(res)) {
+    return c.json({ error: res[1].message }, { status: 404 });
+  }
 
-    return c.json({
-      id: res[1].id,
-      name: res[1].name,
-      nickname: res[1].nickname,
-      bio: res[1].bio,
-      avatar: '',
-      header: '',
-      followed_count: res[1].followed_count,
-      following_count: res[1].following_count,
-      note_count: res[1].note_count,
-    });
-  },
-);
+  return c.json({
+    id: res[1].id,
+    name: res[1].name,
+    nickname: res[1].nickname,
+    bio: res[1].bio,
+    avatar: '',
+    header: '',
+    followed_count: res[1].followed_count,
+    following_count: res[1].following_count,
+    note_count: res[1].note_count,
+  });
+});
 
 accounts.openapi(LoginRoute, async (c) => {
   const { name, passphrase } = c.req.valid('json');

--- a/pkg/accounts/mod.ts
+++ b/pkg/accounts/mod.ts
@@ -106,16 +106,19 @@ accounts.doc('/accounts/doc.json', {
   },
 });
 
-accounts.openapi(CreateAccountRoute, async (c) => {
-  const { name, email, passphrase } = c.req.valid('json');
+export const CreateAccountHandler = accounts.openapi(
+  CreateAccountRoute,
+  async (c) => {
+    const { name, email, passphrase } = c.req.valid('json');
 
-  const res = await controller.createAccount(name, email, passphrase);
-  if (Result.isErr(res)) {
-    return c.json({ error: res[1].message }, { status: 400 });
-  }
+    const res = await controller.createAccount(name, email, passphrase);
+    if (Result.isErr(res)) {
+      return c.json({ error: res[1].message }, { status: 400 });
+    }
 
-  return c.json(res[1]);
-});
+    return c.json(res[1]);
+  },
+);
 
 accounts.openapi(UpdateAccountRoute, async (c) => {
   const name = c.req.param('name');
@@ -177,26 +180,29 @@ accounts.openapi(VerifyEmailRoute, async (c) => {
   return new Response(null, { status: 204 });
 });
 
-accounts.openapi(GetAccountRoute, async (c) => {
-  const name = c.req.param('name');
+export const GetAccountHandler = accounts.openapi(
+  GetAccountRoute,
+  async (c) => {
+    const name = c.req.param('name');
 
-  const res = await controller.getAccount(name);
-  if (Result.isErr(res)) {
-    return c.json({ error: res[1].message }, { status: 404 });
-  }
+    const res = await controller.getAccount(name);
+    if (Result.isErr(res)) {
+      return c.json({ error: res[1].message }, { status: 404 });
+    }
 
-  return c.json({
-    id: res[1].id,
-    name: res[1].name,
-    nickname: res[1].nickname,
-    bio: res[1].bio,
-    avatar: '',
-    header: '',
-    followed_count: res[1].followed_count,
-    following_count: res[1].following_count,
-    note_count: res[1].note_count,
-  });
-});
+    return c.json({
+      id: res[1].id,
+      name: res[1].name,
+      nickname: res[1].nickname,
+      bio: res[1].bio,
+      avatar: '',
+      header: '',
+      followed_count: res[1].followed_count,
+      following_count: res[1].following_count,
+      note_count: res[1].note_count,
+    });
+  },
+);
 
 accounts.openapi(LoginRoute, async (c) => {
   const { name, passphrase } = c.req.valid('json');

--- a/pkg/accounts/mod.ts
+++ b/pkg/accounts/mod.ts
@@ -106,6 +106,10 @@ accounts.doc('/accounts/doc.json', {
   },
 });
 
+export type AccountModuleHandlerType =
+  | typeof GetAccountHandler
+  | typeof CreateAccountHandler;
+
 export const CreateAccountHandler = accounts.openapi(
   CreateAccountRoute,
   async (c) => {

--- a/pkg/intermodule/account.ts
+++ b/pkg/intermodule/account.ts
@@ -27,7 +27,7 @@ export class AccountModule {
     name: AccountName,
   ): Promise<Result.Result<Error, Account>> {
     const res = await this.client.accounts[':name'].$get({
-      param: { name: name },
+      param: { name },
     });
 
     if (!res.ok) {

--- a/pkg/intermodule/account.ts
+++ b/pkg/intermodule/account.ts
@@ -1,6 +1,11 @@
 import { Result } from '@mikuroxina/mini-fn';
+import { hc } from 'hono/client';
 
 import type { AccountController } from '../accounts/adaptor/controller/account.js';
+import {
+  type CreateAccountHandler,
+  type GetAccountHandler,
+} from '../accounts/mod.js';
 import {
   Account,
   type AccountFrozen,
@@ -12,35 +17,53 @@ import {
 } from '../accounts/model/account.js';
 import type { ID } from '../id/type.js';
 
+type accountModuleHandlerType =
+  | typeof GetAccountHandler
+  | typeof CreateAccountHandler;
+
 export class AccountModule {
+  // NOTE: This is a temporary solution to use hono client
+  // ToDo: base url should be configurable
+  private readonly client = hc<accountModuleHandlerType>(
+    'http://localhost:3000',
+  );
+
   constructor(private readonly controller: AccountController) {}
 
   async fetchAccount(
     name: AccountName,
   ): Promise<Result.Result<Error, Account>> {
-    const res = await this.controller.getAccount(name);
+    const res = await this.client.accounts[':name'].$get({
+      param: { name: name },
+    });
 
-    if (Result.isErr(res)) {
-      return res;
+    if (!res.ok) {
+      return Result.err(new Error('Failed to fetch account'));
     }
-    const unwrapped = Result.unwrap(res);
+
+    const body = await res.json();
+    if ('error' in body) {
+      return Result.err(new Error(body.error));
+    }
+
     const account = Account.new({
-      id: unwrapped.id as ID<AccountID>,
-      mail: unwrapped.email as string,
-      name: unwrapped.name as AccountName,
-      nickname: unwrapped.nickname,
-      bio: unwrapped.bio,
-      role: unwrapped.role as AccountRole,
-      frozen: unwrapped.frozen as AccountFrozen,
-      silenced: unwrapped.silenced as AccountSilenced,
-      status: unwrapped.status as AccountStatus,
-      createdAt: unwrapped.created_at as Date,
+      id: body.id as ID<AccountID>,
+      mail: body.email as string,
+      name: body.name as AccountName,
+      nickname: body.nickname,
+      bio: body.bio,
+      role: body.role as AccountRole,
+      frozen: body.frozen as AccountFrozen,
+      silenced: body.silenced as AccountSilenced,
+      status: body.status as AccountStatus,
+      createdAt: body.created_at as Date,
       passphraseHash: undefined,
     });
 
     return Result.ok(account);
   }
 
+  // ToDo: use hono rpc in this function
   async fetchAccountByID(
     id: ID<AccountID>,
   ): Promise<Result.Result<Error, Account>> {

--- a/pkg/intermodule/account.ts
+++ b/pkg/intermodule/account.ts
@@ -2,10 +2,7 @@ import { Result } from '@mikuroxina/mini-fn';
 import { hc } from 'hono/client';
 
 import type { AccountController } from '../accounts/adaptor/controller/account.js';
-import {
-  type CreateAccountHandler,
-  type GetAccountHandler,
-} from '../accounts/mod.js';
+import { type AccountModuleHandlerType } from '../accounts/mod.js';
 import {
   Account,
   type AccountFrozen,
@@ -17,14 +14,10 @@ import {
 } from '../accounts/model/account.js';
 import type { ID } from '../id/type.js';
 
-type accountModuleHandlerType =
-  | typeof GetAccountHandler
-  | typeof CreateAccountHandler;
-
 export class AccountModule {
   // NOTE: This is a temporary solution to use hono client
   // ToDo: base url should be configurable
-  private readonly client = hc<accountModuleHandlerType>(
+  private readonly client = hc<AccountModuleHandlerType>(
     'http://localhost:3000',
   );
 


### PR DESCRIPTION
## What does this PR do?
- Hono RPCモードをIntermoduleの`AccountModule`クラスで利用するように

## Additional information
ToDo: コンストラクタ内でHono Clientを初期化する方法を探す  
ToDo: `AccountModule.fetchAccountByID`の実装を考える
