### PR TITLE
fix(notes/repository/BookmarkRepository): BookmarkRepositoryの型定義およびダミー実装の修正

### DIFF
--- a/pkg/notes/adaptor/repository/dummy.ts
+++ b/pkg/notes/adaptor/repository/dummy.ts
@@ -60,22 +60,19 @@ export class InMemoryNoteRepository implements NoteRepository {
 }
 
 export class InMemoryBookmarkRepository implements BookmarkRepository {
-  private readonly bookmarks: Map<`${ID<NoteID>}_${ID<AccountID>}`, Bookmark>;
+  private readonly bookmarks: Map<[ID<NoteID>, ID<AccountID>], Bookmark>;
 
-  private generateBookmarkID(id: {
-    noteID: ID<NoteID>;
-    accountID: ID<AccountID>;
-  }): `${ID<NoteID>}_${ID<AccountID>}` {
-    return `${id.noteID}_${id.accountID}`;
+  private equalID(
+    a: [ID<NoteID>, ID<AccountID>],
+    b: [ID<NoteID>, ID<AccountID>],
+  ): boolean {
+    return a[0] === b[0] && a[1] === b[1];
   }
 
   constructor(bookmarks: Bookmark[] = []) {
     this.bookmarks = new Map(
       bookmarks.map((bookmark) => [
-        this.generateBookmarkID({
-          noteID: bookmark.getNoteID(),
-          accountID: bookmark.getAccountID(),
-        }),
+        [bookmark.getNoteID(), bookmark.getAccountID()],
         bookmark,
       ]),
     );
@@ -86,7 +83,7 @@ export class InMemoryBookmarkRepository implements BookmarkRepository {
     accountID: ID<AccountID>;
   }): Promise<Result.Result<Error, void>> {
     const bookmark = Bookmark.new(id);
-    this.bookmarks.set(this.generateBookmarkID(id), bookmark);
+    this.bookmarks.set([id.noteID, id.accountID], bookmark);
     return Result.ok(undefined);
   }
 
@@ -94,12 +91,15 @@ export class InMemoryBookmarkRepository implements BookmarkRepository {
     noteID: ID<NoteID>;
     accountID: ID<AccountID>;
   }): Promise<Result.Result<Error, void>> {
-    const target = await this.findByID(id);
-    if (Option.isNone(target)) {
+    const key = Array.from(this.bookmarks.keys()).find((k) =>
+      this.equalID(k, [id.noteID, id.accountID]),
+    );
+
+    if (!key) {
       return Result.err(new Error('bookmark not found'));
     }
 
-    this.bookmarks.delete(this.generateBookmarkID(id));
+    this.bookmarks.delete(key);
     return Result.ok(undefined);
   }
 
@@ -107,10 +107,24 @@ export class InMemoryBookmarkRepository implements BookmarkRepository {
     noteID: ID<NoteID>;
     accountID: ID<AccountID>;
   }): Promise<Option.Option<Bookmark>> {
-    const res = this.bookmarks.get(this.generateBookmarkID(id));
-    if (!res) {
+    const bookmark = Array.from(this.bookmarks.entries()).find((v) =>
+      this.equalID(v[0], [id.noteID, id.accountID]),
+    );
+    if (!bookmark) {
       return Promise.resolve(Option.none());
     }
-    return Promise.resolve(Option.some(res));
+    return Promise.resolve(Option.some(bookmark[1]));
+  }
+
+  async findByAccountID(id: ID<AccountID>): Promise<Option.Option<Bookmark[]>> {
+    const bookmarks = Array.from(this.bookmarks.entries())
+      .filter((v) => v[0][1] === id)
+      .map((v) => v[1]);
+
+    if (bookmarks.length === 0) {
+      return Promise.resolve(Option.none());
+    }
+
+    return Promise.resolve(Option.some(bookmarks));
   }
 }

--- a/pkg/notes/model/repository.ts
+++ b/pkg/notes/model/repository.ts
@@ -16,7 +16,16 @@ export interface NoteRepository {
 }
 
 export interface BookmarkRepository {
-  create(note: Note): Promise<Result.Result<Error, void>>;
-  findByID(id: ID<NoteID>): Promise<Option.Option<Bookmark>>;
-  deleteByID(id: ID<NoteID>): Promise<Result.Result<Error, void>>;
+  create(id: {
+    noteID: ID<NoteID>;
+    accountID: ID<AccountID>;
+  }): Promise<Result.Result<Error, void>>;
+  findByID(id: {
+    noteID: ID<NoteID>;
+    accountID: ID<AccountID>;
+  }): Promise<Option.Option<Bookmark>>;
+  deleteByID(id: {
+    noteID: ID<NoteID>;
+    accountID: ID<AccountID>;
+  }): Promise<Result.Result<Error, void>>;
 }


### PR DESCRIPTION
## What does this PR do?

BookmarkRepositoryにおけるcreate, findByID, deleteByIDが

- Bookmarkされた投稿のID(noteID)
- BookmarkしたアカウントのID(accountID)

を受け取り，処理するように修正しました．