### PR TITLE
fix: add servers to openapi spec documentation

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -15,6 +15,12 @@ export const app = new Hono().get('/doc', async (c) => {
       title: 'Pulsate API Document',
       version: '0.1.0',
     },
+    servers: [
+      {
+        url: 'http://localhost:3000/',
+        description: 'Local server',
+      },
+    ],
     components: {
       schemas: {},
       parameters: {},


### PR DESCRIPTION
## What does this PR do?
- 自動生成されるOpenAPI Docsにserversの項目を追加(コード生成機でのエラーを解消できるように)
## Additional information
