### PR TITLE
refactor: Replace DI in accounts pkg with Ether

### DIFF
--- a/pkg/accounts/adaptor/repository/dummy.ts
+++ b/pkg/accounts/adaptor/repository/dummy.ts
@@ -1,14 +1,18 @@
-import { Option, Result } from '@mikuroxina/mini-fn';
+import { Ether, Option, Result } from '@mikuroxina/mini-fn';
 
 import { type ID } from '../../../id/type.js';
 import { type Account, type AccountID } from '../../model/account.js';
 import { type AccountFollow } from '../../model/follow.js';
 import type { InactiveAccount } from '../../model/inactiveAccount.js';
-import type {
-  AccountFollowRepository,
-  AccountRepository,
-  AccountVerifyTokenRepository,
-  InactiveAccountRepository,
+import {
+  accountRepoSymbol,
+  followRepoSymbol,
+  inactiveAccountRepoSymbol,
+  verifyTokenRepoSymbol,
+  type AccountFollowRepository,
+  type AccountRepository,
+  type AccountVerifyTokenRepository,
+  type InactiveAccountRepository,
 } from '../../model/repository.js';
 
 export class InMemoryAccountRepository implements AccountRepository {
@@ -65,6 +69,11 @@ export class InMemoryAccountRepository implements AccountRepository {
     return Result.ok(undefined);
   }
 }
+export const newAccountRepo = (accounts: Account[] = []) =>
+  Ether.newEther(
+    accountRepoSymbol,
+    () => new InMemoryAccountRepository(accounts),
+  );
 
 export class InMemoryAccountVerifyTokenRepository
   implements AccountVerifyTokenRepository
@@ -95,6 +104,10 @@ export class InMemoryAccountVerifyTokenRepository
     return Promise.resolve(Option.some(data));
   }
 }
+export const verifyTokenRepo = Ether.newEther(
+  verifyTokenRepoSymbol,
+  () => new InMemoryAccountVerifyTokenRepository(),
+);
 
 export class InMemoryAccountFollowRepository
   implements AccountFollowRepository
@@ -167,6 +180,11 @@ export class InMemoryAccountFollowRepository
     );
   }
 }
+export const newFollowRepo = (data?: AccountFollow[]) =>
+  Ether.newEther(
+    followRepoSymbol,
+    () => new InMemoryAccountFollowRepository(data),
+  );
 
 export class InMemoryInactiveAccountRepository
   implements InactiveAccountRepository
@@ -203,3 +221,7 @@ export class InMemoryInactiveAccountRepository
     return Promise.resolve(Option.some(account));
   }
 }
+export const inactiveAccountRepo = Ether.newEther(
+  inactiveAccountRepoSymbol,
+  () => new InMemoryInactiveAccountRepository(),
+);

--- a/pkg/accounts/adaptor/repository/prisma.ts
+++ b/pkg/accounts/adaptor/repository/prisma.ts
@@ -1,4 +1,4 @@
-import { Option, Result } from '@mikuroxina/mini-fn';
+import { Ether, Option, Result } from '@mikuroxina/mini-fn';
 import { type PrismaClient } from '@prisma/client';
 
 import type { ID } from '../../../id/type.js';
@@ -12,10 +12,13 @@ import {
   type AccountStatus,
 } from '../../model/account.js';
 import { AccountFollow } from '../../model/follow.js';
-import type {
-  AccountFollowRepository,
-  AccountRepository,
-  AccountVerifyTokenRepository,
+import {
+  accountRepoSymbol,
+  followRepoSymbol,
+  verifyTokenRepoSymbol,
+  type AccountFollowRepository,
+  type AccountRepository,
+  type AccountVerifyTokenRepository,
 } from '../../model/repository.js';
 
 interface AccountPrismaArgs {
@@ -200,6 +203,8 @@ export class PrismaAccountRepository implements AccountRepository {
     });
   }
 }
+export const accountRepo = (client: PrismaClient) =>
+  Ether.newEther(accountRepoSymbol, () => new PrismaAccountRepository(client));
 
 export class PrismaAccountVerifyTokenRepository
   implements AccountVerifyTokenRepository
@@ -243,6 +248,11 @@ export class PrismaAccountVerifyTokenRepository
     });
   }
 }
+export const verifyTokenRepo = (client: PrismaClient) =>
+  Ether.newEther(
+    verifyTokenRepoSymbol,
+    () => new PrismaAccountVerifyTokenRepository(client),
+  );
 
 interface AccountFollowPrismaArgs {
   fromId: string;
@@ -352,3 +362,8 @@ export class PrismaAccountFollowRepository implements AccountFollowRepository {
     });
   }
 }
+export const followRepo = (client: PrismaClient) =>
+  Ether.newEther(
+    followRepoSymbol,
+    () => new PrismaAccountFollowRepository(client),
+  );

--- a/pkg/accounts/model/repository.ts
+++ b/pkg/accounts/model/repository.ts
@@ -1,4 +1,4 @@
-import type { Option, Result } from '@mikuroxina/mini-fn';
+import { Ether, type Option, type Result } from '@mikuroxina/mini-fn';
 
 import { type ID } from '../../id/type.js';
 import type { Account } from './account.js';
@@ -13,12 +13,15 @@ export interface AccountRepository {
   findByMail(mail: string): Promise<Option.Option<Account>>;
   edit(account: Account): Promise<Result.Result<Error, void>>;
 }
+export const accountRepoSymbol = Ether.newEtherSymbol<AccountRepository>();
 
 export interface InactiveAccountRepository {
   create(account: InactiveAccount): Promise<Result.Result<Error, void>>;
   findByName(name: string): Promise<Option.Option<InactiveAccount>>;
   findByMail(mail: string): Promise<Option.Option<InactiveAccount>>;
 }
+export const inactiveAccountRepoSymbol =
+  Ether.newEtherSymbol<InactiveAccountRepository>();
 
 export interface AccountVerifyTokenRepository {
   create(
@@ -31,6 +34,8 @@ export interface AccountVerifyTokenRepository {
     id: ID<AccountID>,
   ): Promise<Option.Option<{ token: string; expire: Date }>>;
 }
+export const verifyTokenRepoSymbol =
+  Ether.newEtherSymbol<AccountVerifyTokenRepository>();
 
 export interface AccountFollowRepository {
   follow(follow: AccountFollow): Promise<Result.Result<Error, void>>;
@@ -53,3 +58,4 @@ export interface AccountFollowRepository {
     limit: number,
   ): Promise<Result.Result<Error, AccountFollow[]>>;
 }
+export const followRepoSymbol = Ether.newEtherSymbol<AccountFollowRepository>();

--- a/pkg/accounts/service/authenticate.ts
+++ b/pkg/accounts/service/authenticate.ts
@@ -1,10 +1,19 @@
-import { Option, Result } from '@mikuroxina/mini-fn';
+import { Ether, Option, Result } from '@mikuroxina/mini-fn';
 
-import type { PasswordEncoder } from '../../password/mod.js';
+import {
+  passwordEncoderSymbol,
+  type PasswordEncoder,
+} from '../../password/mod.js';
 import { addSecondsToDate, convertTo } from '../../time/mod.js';
 import type { AccountName } from '../model/account.js';
-import type { AccountRepository } from '../model/repository.js';
-import type { AuthenticationTokenService } from './authenticationTokenService.js';
+import {
+  accountRepoSymbol,
+  type AccountRepository,
+} from '../model/repository.js';
+import {
+  authenticateTokenSymbol,
+  type AuthenticationTokenService,
+} from './authenticationTokenService.js';
 
 export interface TokenPair {
   authorizationToken: string;
@@ -69,3 +78,14 @@ export class AuthenticateService {
     });
   }
 }
+
+export const authenticateSymbol = Ether.newEtherSymbol<AuthenticateService>();
+export const authenticate = Ether.newEther(
+  authenticateSymbol,
+  (deps) => new AuthenticateService(deps),
+  {
+    accountRepository: accountRepoSymbol,
+    authenticationTokenService: authenticateTokenSymbol,
+    passwordEncoder: passwordEncoderSymbol,
+  },
+);

--- a/pkg/accounts/service/authenticationTokenService.ts
+++ b/pkg/accounts/service/authenticationTokenService.ts
@@ -1,4 +1,4 @@
-import { Option } from '@mikuroxina/mini-fn';
+import { Ether, Option, type Promise } from '@mikuroxina/mini-fn';
 import * as jose from 'jose';
 
 import type { PulsateTime } from '../../time/mod.js';
@@ -47,3 +47,10 @@ export class AuthenticationTokenService {
     }
   }
 }
+
+export const authenticateTokenSymbol =
+  Ether.newEtherSymbol<AuthenticationTokenService>();
+export const authenticateToken = Ether.newEtherT<Promise.PromiseHkt>()(
+  authenticateTokenSymbol,
+  AuthenticationTokenService.new,
+);

--- a/pkg/accounts/service/editAccount.ts
+++ b/pkg/accounts/service/editAccount.ts
@@ -1,9 +1,15 @@
-import { Option, Result } from '@mikuroxina/mini-fn';
+import { Ether, Option, Result } from '@mikuroxina/mini-fn';
 
-import { type PasswordEncoder } from '../../password/mod.js';
+import {
+  passwordEncoderSymbol,
+  type PasswordEncoder,
+} from '../../password/mod.js';
 import type { AccountName } from '../model/account.js';
-import { type AccountRepository } from '../model/repository.js';
-import type { EtagService } from './etagService.js';
+import {
+  accountRepoSymbol,
+  type AccountRepository,
+} from '../model/repository.js';
+import { etagSymbol, type EtagService } from './etagService.js';
 
 export class EditAccountService {
   private readonly nicknameShortest = 1;
@@ -170,3 +176,15 @@ export class EditAccountService {
     }
   }
 }
+
+export const editSymbol = Ether.newEtherSymbol<EditAccountService>();
+export const edit = Ether.newEther(
+  editSymbol,
+  ({ accountRepository, etagService, passwordEncoder }) =>
+    new EditAccountService(accountRepository, etagService, passwordEncoder),
+  {
+    accountRepository: accountRepoSymbol,
+    etagService: etagSymbol,
+    passwordEncoder: passwordEncoderSymbol,
+  },
+);

--- a/pkg/accounts/service/etagService.ts
+++ b/pkg/accounts/service/etagService.ts
@@ -1,3 +1,5 @@
+import { Ether } from '@mikuroxina/mini-fn';
+
 import type { Account } from '../model/account.js';
 
 export class EtagService {
@@ -27,3 +29,6 @@ export class EtagService {
     return Buffer.from(digest).toString('hex');
   }
 }
+
+export const etagSymbol = Ether.newEtherSymbol<EtagService>();
+export const etag = Ether.newEther(etagSymbol, () => new EtagService());

--- a/pkg/accounts/service/fetchAccount.ts
+++ b/pkg/accounts/service/fetchAccount.ts
@@ -1,8 +1,11 @@
-import { Option, Result } from '@mikuroxina/mini-fn';
+import { Ether, Option, Result } from '@mikuroxina/mini-fn';
 
 import type { ID } from '../../id/type.js';
 import { type Account, type AccountID } from '../model/account.js';
-import type { AccountRepository } from '../model/repository.js';
+import {
+  accountRepoSymbol,
+  type AccountRepository,
+} from '../model/repository.js';
 
 export class FetchAccountService {
   private accountRepository: AccountRepository;
@@ -32,3 +35,10 @@ export class FetchAccountService {
     return Option.okOr(new Error('AccountNotFoundError'))(res);
   }
 }
+
+export const fetchSymbol = Ether.newEtherSymbol<FetchAccountService>();
+export const fetch = Ether.newEther(
+  fetchSymbol,
+  ({ accountRepository }) => new FetchAccountService(accountRepository),
+  { accountRepository: accountRepoSymbol },
+);

--- a/pkg/accounts/service/fetchAccountFollow.ts
+++ b/pkg/accounts/service/fetchAccountFollow.ts
@@ -1,11 +1,13 @@
-import { Option, Cat, Result } from '@mikuroxina/mini-fn';
+import { Option, Cat, Result, Ether } from '@mikuroxina/mini-fn';
 
 import type { AccountID, AccountName } from '../../accounts/model/account.js';
 import type { ID } from '../../id/type.js';
 import type { AccountFollow } from '../model/follow.js';
-import type {
-  AccountFollowRepository,
-  AccountRepository,
+import {
+  accountRepoSymbol,
+  followRepoSymbol,
+  type AccountFollowRepository,
+  type AccountRepository,
 } from '../model/repository.js';
 
 export class FetchAccountFollowService {
@@ -54,3 +56,12 @@ export class FetchAccountFollowService {
     return this.fetchFollowersByID(resId[1]);
   }
 }
+
+export const fetchFollowSymbol =
+  Ether.newEtherSymbol<FetchAccountFollowService>();
+export const fetchFollow = Ether.newEther(
+  fetchFollowSymbol,
+  ({ accountRepository, followRepository }) =>
+    new FetchAccountFollowService(followRepository, accountRepository),
+  { followRepository: followRepoSymbol, accountRepository: accountRepoSymbol },
+);

--- a/pkg/accounts/service/follow.ts
+++ b/pkg/accounts/service/follow.ts
@@ -1,10 +1,12 @@
-import { Option, Result } from '@mikuroxina/mini-fn';
+import { Ether, Option, Result } from '@mikuroxina/mini-fn';
 
 import type { AccountName } from '../model/account.js';
 import { AccountFollow } from '../model/follow.js';
-import type {
-  AccountFollowRepository,
-  AccountRepository,
+import {
+  accountRepoSymbol,
+  followRepoSymbol,
+  type AccountFollowRepository,
+  type AccountRepository,
 } from '../model/repository.js';
 
 export class FollowService {
@@ -40,3 +42,11 @@ export class FollowService {
     return Result.ok(follow);
   }
 }
+
+export const followSymbol = Ether.newEtherSymbol<FollowService>();
+export const follow = Ether.newEther(
+  followSymbol,
+  ({ followRepository, accountRepository }) =>
+    new FollowService(followRepository, accountRepository),
+  { followRepository: followRepoSymbol, accountRepository: accountRepoSymbol },
+);

--- a/pkg/accounts/service/freeze.ts
+++ b/pkg/accounts/service/freeze.ts
@@ -1,7 +1,10 @@
-import { Option, Result } from '@mikuroxina/mini-fn';
+import { Ether, Option, Result } from '@mikuroxina/mini-fn';
 
 import type { AccountName } from '../model/account.js';
-import { type AccountRepository } from '../model/repository.js';
+import {
+  accountRepoSymbol,
+  type AccountRepository,
+} from '../model/repository.js';
 
 export class FreezeService {
   private readonly accountRepository: AccountRepository;
@@ -42,3 +45,10 @@ export class FreezeService {
     }
   }
 }
+
+export const freezeSymbol = Ether.newEtherSymbol<FreezeService>();
+export const freeze = Ether.newEther(
+  freezeSymbol,
+  ({ accountRepository }) => new FreezeService(accountRepository),
+  { accountRepository: accountRepoSymbol },
+);

--- a/pkg/accounts/service/register.ts
+++ b/pkg/accounts/service/register.ts
@@ -1,16 +1,31 @@
-import { Option, Result } from '@mikuroxina/mini-fn';
+import { Ether, Option, Result } from '@mikuroxina/mini-fn';
 
-import type { SnowflakeIDGenerator } from '../../id/mod.js';
-import { type PasswordEncoder } from '../../password/mod.js';
+import {
+  snowflakeIDGeneratorSymbol,
+  type SnowflakeIDGenerator,
+} from '../../id/mod.js';
+import {
+  passwordEncoderSymbol,
+  type PasswordEncoder,
+} from '../../password/mod.js';
 import {
   Account,
   type AccountID,
   type AccountName,
   type AccountRole,
 } from '../model/account.js';
-import { type AccountRepository } from '../model/repository.js';
-import { type SendNotificationService } from './sendNotification.js';
-import type { VerifyAccountTokenService } from './verifyToken.js';
+import {
+  accountRepoSymbol,
+  type AccountRepository,
+} from '../model/repository.js';
+import {
+  sendNotificationSymbol,
+  type SendNotificationService,
+} from './sendNotification.js';
+import {
+  verifyAccountTokenSymbol,
+  type VerifyAccountTokenService,
+} from './verifyToken.js';
 
 export class AccountAlreadyExistsError extends Error {
   override readonly name = 'AccountAlreadyExistsError' as const;
@@ -106,3 +121,16 @@ export class RegisterAccountService {
     return Option.isSome(byName) || Option.isSome(byMail);
   }
 }
+
+export const registerSymbol = Ether.newEtherSymbol<RegisterAccountService>();
+export const register = Ether.newEther(
+  registerSymbol,
+  (deps) => new RegisterAccountService(deps),
+  {
+    repository: accountRepoSymbol,
+    idGenerator: snowflakeIDGeneratorSymbol,
+    passwordEncoder: passwordEncoderSymbol,
+    sendNotification: sendNotificationSymbol,
+    verifyAccountTokenService: verifyAccountTokenSymbol,
+  },
+);

--- a/pkg/accounts/service/resendToken.ts
+++ b/pkg/accounts/service/resendToken.ts
@@ -1,9 +1,18 @@
-import { Option, Result } from '@mikuroxina/mini-fn';
+import { Ether, Option, Result } from '@mikuroxina/mini-fn';
 
 import type { AccountName } from '../model/account.js';
-import { type AccountRepository } from '../model/repository.js';
-import { type SendNotificationService } from './sendNotification.js';
-import type { VerifyAccountTokenService } from './verifyToken.js';
+import {
+  accountRepoSymbol,
+  type AccountRepository,
+} from '../model/repository.js';
+import {
+  sendNotificationSymbol,
+  type SendNotificationService,
+} from './sendNotification.js';
+import {
+  verifyAccountTokenSymbol,
+  type VerifyAccountTokenService,
+} from './verifyToken.js';
 
 export class ResendVerifyTokenService {
   private readonly accountRepository: AccountRepository;
@@ -42,3 +51,20 @@ export class ResendVerifyTokenService {
     return Option.none();
   }
 }
+
+export const resendTokenSymbol =
+  Ether.newEtherSymbol<ResendVerifyTokenService>();
+export const resendToken = Ether.newEther(
+  resendTokenSymbol,
+  ({ accountRepository, verifyAccountTokenService, sendNotificationService }) =>
+    new ResendVerifyTokenService(
+      accountRepository,
+      verifyAccountTokenService,
+      sendNotificationService,
+    ),
+  {
+    accountRepository: accountRepoSymbol,
+    verifyAccountTokenService: verifyAccountTokenSymbol,
+    sendNotificationService: sendNotificationSymbol,
+  },
+);

--- a/pkg/accounts/service/sendNotification.ts
+++ b/pkg/accounts/service/sendNotification.ts
@@ -1,11 +1,17 @@
-import { Result } from '@mikuroxina/mini-fn';
+import { Ether, Result } from '@mikuroxina/mini-fn';
 
 export interface SendNotificationService {
   send(to: string, body: string): Promise<Result.Result<Error, void>>;
 }
+export const sendNotificationSymbol =
+  Ether.newEtherSymbol<SendNotificationService>();
 
 export class DummySendNotificationService implements SendNotificationService {
   send(): Promise<Result.Result<Error, void>> {
     return Promise.resolve(Result.ok(undefined));
   }
 }
+export const dummy = Ether.newEther(
+  sendNotificationSymbol,
+  () => new DummySendNotificationService(),
+);

--- a/pkg/accounts/service/silence.ts
+++ b/pkg/accounts/service/silence.ts
@@ -1,7 +1,10 @@
-import { Option, Result } from '@mikuroxina/mini-fn';
+import { Ether, Option, Result } from '@mikuroxina/mini-fn';
 
 import { type AccountName } from '../model/account.js';
-import { type AccountRepository } from '../model/repository.js';
+import {
+  accountRepoSymbol,
+  type AccountRepository,
+} from '../model/repository.js';
 
 export class SilenceService {
   private readonly accountRepository: AccountRepository;
@@ -42,3 +45,10 @@ export class SilenceService {
     }
   }
 }
+
+export const silenceSymbol = Ether.newEtherSymbol<SilenceService>();
+export const silence = Ether.newEther(
+  silenceSymbol,
+  ({ accountRepository }) => new SilenceService(accountRepository),
+  { accountRepository: accountRepoSymbol },
+);

--- a/pkg/accounts/service/unfollow.ts
+++ b/pkg/accounts/service/unfollow.ts
@@ -1,9 +1,11 @@
-import { Option, Result } from '@mikuroxina/mini-fn';
+import { Ether, Option, Result } from '@mikuroxina/mini-fn';
 
 import type { AccountName } from '../model/account.js';
-import type {
-  AccountFollowRepository,
-  AccountRepository,
+import {
+  accountRepoSymbol,
+  followRepoSymbol,
+  type AccountFollowRepository,
+  type AccountRepository,
 } from '../model/repository.js';
 
 export class UnfollowService {
@@ -36,3 +38,14 @@ export class UnfollowService {
     return Option.none();
   }
 }
+
+export const unfollowSymbol = Ether.newEtherSymbol<UnfollowService>();
+export const unfollow = Ether.newEther(
+  unfollowSymbol,
+  ({ accountFollowRepository, accountRepository }) =>
+    new UnfollowService(accountFollowRepository, accountRepository),
+  {
+    accountFollowRepository: followRepoSymbol,
+    accountRepository: accountRepoSymbol,
+  },
+);

--- a/pkg/accounts/service/verifyToken.ts
+++ b/pkg/accounts/service/verifyToken.ts
@@ -1,8 +1,10 @@
-import { Option, Result } from '@mikuroxina/mini-fn';
+import { Ether, Option, Result } from '@mikuroxina/mini-fn';
 
-import { type Clock } from '../../id/mod.js';
+import { clockSymbol, type Clock } from '../../id/mod.js';
 import { type AccountName } from '../model/account.js';
 import {
+  accountRepoSymbol,
+  verifyTokenRepoSymbol,
   type AccountRepository,
   type AccountVerifyTokenRepository,
 } from '../model/repository.js';
@@ -80,3 +82,20 @@ export class VerifyAccountTokenService {
     return Result.ok(undefined);
   }
 }
+
+export const verifyAccountTokenSymbol =
+  Ether.newEtherSymbol<VerifyAccountTokenService>();
+export const verifyAccountToken = Ether.newEther(
+  verifyAccountTokenSymbol,
+  ({ verifyTokenRepository, accountRepository, clock }) =>
+    new VerifyAccountTokenService(
+      verifyTokenRepository,
+      accountRepository,
+      clock,
+    ),
+  {
+    verifyTokenRepository: verifyTokenRepoSymbol,
+    accountRepository: accountRepoSymbol,
+    clock: clockSymbol,
+  },
+);

--- a/pkg/password/mod.ts
+++ b/pkg/password/mod.ts
@@ -1,3 +1,4 @@
+import { Ether } from '@mikuroxina/mini-fn';
 import { hash, verify, argon2id } from 'argon2';
 
 export type EncodedPassword = string;
@@ -6,6 +7,7 @@ export interface PasswordEncoder {
   encodePassword(raw: string): Promise<EncodedPassword>;
   isMatchPassword(raw: string, encoded: EncodedPassword): Promise<boolean>;
 }
+export const passwordEncoderSymbol = Ether.newEtherSymbol<PasswordEncoder>();
 
 export class Argon2idPasswordEncoder implements PasswordEncoder {
   async encodePassword(raw: string) {
@@ -25,3 +27,7 @@ export class Argon2idPasswordEncoder implements PasswordEncoder {
     }
   }
 }
+export const argon2idPasswordEncoder = Ether.newEther(
+  passwordEncoderSymbol,
+  () => new Argon2idPasswordEncoder(),
+);


### PR DESCRIPTION
## What does this PR do?

My library mini-fn has a module `Ether`, the dependency injection helper. It uses `Symbol`s to determine what are resolved or not.

At first, I'd replaced manual DI in `accounts` package with Ether as experiment. It would be nicer than calling their constructor of services directly.
