### PR TITLE
fix(notes/bookmark): return target note model

### DIFF
--- a/pkg/notes/adaptor/controller/bookmark.ts
+++ b/pkg/notes/adaptor/controller/bookmark.ts
@@ -3,7 +3,7 @@ import { type Option, Result } from '@mikuroxina/mini-fn';
 import type { AccountID } from '../../../accounts/model/account.js';
 import type { ID } from '../../../id/type.js';
 import type { Bookmark } from '../../model/bookmark.js';
-import type { NoteID } from '../../model/note.js';
+import type { Note, NoteID } from '../../model/note.js';
 import type { CreateBookmarkService } from '../../service/createBookmark.js';
 import type { DeleteBookmarkService } from '../../service/deleteBookmark.js';
 import type { FetchBookmarkService } from '../../service/fetchBookmark.js';
@@ -18,12 +18,13 @@ export class BookmarkController {
   async createBookmark(
     noteID: string,
     accountID: string,
-  ): Promise<Result.Result<Error, void>> {
+  ): Promise<Result.Result<Error, Note>> {
     const res = await this.createBookmarkService.handle(
       noteID as ID<NoteID>,
       accountID as ID<AccountID>,
     );
-    return Result.map(() => undefined)(res);
+
+    return res;
   }
 
   async getBookmarkByID(

--- a/pkg/notes/service/createBookmark.ts
+++ b/pkg/notes/service/createBookmark.ts
@@ -32,8 +32,11 @@ export class CreateBookmarkService {
       return Result.err(new Error('bookmark has already created'));
     }
 
-    await this.bookmarkRepository.create({ noteID, accountID });
+    const creation = await this.bookmarkRepository.create({
+      noteID,
+      accountID,
+    });
 
-    return Result.ok(Option.unwrap(note));
+    return Result.map(() => Option.unwrap(note))(creation);
   }
 }


### PR DESCRIPTION
## What does this PR do?
- `BookmarkController.createBookmark`メソッドがNoteモデルを返すように変更
- `CreateBookmarkService`がコンストラクタにNoteRepositoryを要求するよう変更
- `CreateBookmarkService.handle`メソッドにブックマーク対象ノートが見つからなかったときの処理を追加
  - 追加した処理に対応するテストコードの追加