### PR TITLE
chore: remove out-of-date renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,11 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>pulsate-dev/renovate-conf"],
-  "reviewers": ["team:pulsate"],
-  "rollback": {
-    "additionalReviewers": ["m1sk9", "MikuroXina", "Colk-tech"]
-  },
-  "vulnerabilityAlerts": {
-    "additionalReviewers": ["m1sk9", "MikuroXina", "Colk-tech"]
-  }
+  "extends": ["github>pulsate-dev/renovate-conf"]
 }

--- a/.github/workflows/auto-assign-pr.yaml
+++ b/.github/workflows/auto-assign-pr.yaml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   assign:
     name: Assign PR to the author
-    if: ${{ github.event.pull_request.user.login != 'renovate[bot]' || toJSON(github.event.pull_request.assignees) == '[]' }}
+    if: ${{ github.event.pull_request.user.login != 'renovate[bot]' && toJSON(github.event.pull_request.assignees) == '[]' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Cherry-picked from https://github.com/pulsate-dev/pulsate.dev/commit/3fbbeb65f2c9079bb93514b8b79ba9547270d49d, https://github.com/pulsate-dev/pulsate.dev/commit/afb7b6a97c3c78a5c446bcb53fe1186558dcd854

## What does this PR do?

Removed outdated renovate settings and fixed an auto-assign workflow that prevented renovate from being assigned.