### PR TITLE
feat: add note/bookmark Prisma Repository implement

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -18,7 +18,7 @@ export const app = new Hono().get('/doc', async (c) => {
     },
     servers: [
       {
-        url: 'http://localhost:3000/',
+        url: 'http://localhost:3000',
         description: 'Local server',
       },
     ],

--- a/pkg/notes/adaptor/repository/prisma.ts
+++ b/pkg/notes/adaptor/repository/prisma.ts
@@ -10,7 +10,7 @@ import type {
   NoteRepository,
 } from '../../model/repository.js';
 
-interface deserializeNoteArgs {
+interface DeserializeNoteArgs {
   id: string;
   visibility: number;
   text: string;
@@ -50,8 +50,8 @@ export class PrismaNoteRepository implements NoteRepository {
     };
   }
 
-  private deserialize(data: deserializeNoteArgs): Note {
-    const visibility = () => {
+  private deserialize(data: DeserializeNoteArgs): Note {
+    const visibility = (): NoteVisibility => {
       switch (data.visibility) {
         case 0:
           return 'PUBLIC';
@@ -62,7 +62,7 @@ export class PrismaNoteRepository implements NoteRepository {
         case 3:
           return 'DIRECT';
         default:
-          return 'PUBLIC';
+          throw new Error('Invalid Visibility');
       }
     };
     return Note.reconstruct({
@@ -129,7 +129,7 @@ export class PrismaNoteRepository implements NoteRepository {
         },
       });
       return Option.some(
-        res.map((v) => this.deserialize(v as deserializeNoteArgs)),
+        res.map((v) => this.deserialize(v as DeserializeNoteArgs)),
       );
     } catch {
       return Option.none();
@@ -145,7 +145,7 @@ export class PrismaNoteRepository implements NoteRepository {
           deletedAt: undefined,
         },
       });
-      return Option.some(this.deserialize(res as deserializeNoteArgs));
+      return Option.some(this.deserialize(res as DeserializeNoteArgs));
     } catch {
       return Option.none();
     }

--- a/pkg/notes/adaptor/repository/prisma.ts
+++ b/pkg/notes/adaptor/repository/prisma.ts
@@ -45,7 +45,9 @@ export class PrismaNoteRepository implements NoteRepository {
   }
 
   private deserialize(data: DeserializeNoteArgs): Note {
-    if (!data) throw new Error('Invalid Note data');
+    if (!data) {
+      throw new Error('Invalid Note data');
+    }
     const visibility = (): NoteVisibility => {
       switch (data.visibility) {
         case 0:

--- a/pkg/notes/adaptor/repository/prisma.ts
+++ b/pkg/notes/adaptor/repository/prisma.ts
@@ -1,0 +1,242 @@
+import { Option, Result } from '@mikuroxina/mini-fn';
+import type { PrismaClient } from '@prisma/client';
+
+import type { AccountID } from '../../../accounts/model/account.js';
+import type { ID } from '../../../id/type.js';
+import { Bookmark } from '../../model/bookmark.js';
+import { Note, type NoteID, type NoteVisibility } from '../../model/note.js';
+import type {
+  BookmarkRepository,
+  NoteRepository,
+} from '../../model/repository.js';
+
+interface deserializeNoteArgs {
+  id: string;
+  visibility: number;
+  text: string;
+  authorId: string;
+  renoteId: string | null;
+  createdAt: Date;
+  deletedAt: Date | null;
+  updatedAt: Date | null;
+}
+
+export class PrismaNoteRepository implements NoteRepository {
+  constructor(private readonly client: PrismaClient) {}
+
+  private serialize(note: Note) {
+    const visibility = () => {
+      switch (note.getVisibility()) {
+        case 'PUBLIC':
+          return 0;
+        case 'HOME':
+          return 1;
+        case 'FOLLOWERS':
+          return 2;
+        case 'DIRECT':
+          return 3;
+      }
+    };
+
+    return {
+      id: note.getID() as string,
+      text: note.getContent(),
+      visibility: visibility(),
+      authorId: note.getAuthorID() as string,
+      createdAt: note.getCreatedAt(),
+      deletedAt: Option.isNone(note.getDeletedAt())
+        ? undefined
+        : Option.unwrap(note.getDeletedAt()),
+    };
+  }
+
+  private deserialize(data: deserializeNoteArgs): Note {
+    const visibility = () => {
+      switch (data.visibility) {
+        case 0:
+          return 'PUBLIC';
+        case 1:
+          return 'HOME';
+        case 2:
+          return 'FOLLOWERS';
+        case 3:
+          return 'DIRECT';
+        default:
+          return 'PUBLIC';
+      }
+    };
+    return Note.reconstruct({
+      id: data.id as ID<NoteID>,
+      content: data.text,
+      authorID: data.authorId as ID<AccountID>,
+      createdAt: data.createdAt,
+      deletedAt: !data.deletedAt ? Option.none() : Option.some(data.deletedAt),
+      contentsWarningComment: '',
+      originalNoteID: !data.renoteId
+        ? Option.some(data.renoteId as ID<NoteID>)
+        : Option.none(),
+      // ToDo: add SendTo field to schema
+      sendTo: Option.none(),
+      updatedAt: data.updatedAt ? Option.some(data.updatedAt) : Option.none(),
+      visibility: visibility() as NoteVisibility,
+    });
+  }
+
+  async create(note: Note): Promise<Result.Result<Error, void>> {
+    const serialized = this.serialize(note);
+    try {
+      await this.client.note.create({
+        data: serialized,
+      });
+    } catch (e) {
+      return Result.err(e as Error);
+    }
+    return Result.ok(undefined);
+  }
+
+  async deleteByID(id: ID<NoteID>): Promise<Result.Result<Error, void>> {
+    try {
+      // NOTE: logical delete
+      await this.client.note.update({
+        where: {
+          id,
+        },
+        data: {
+          // ToDo: use Note.deletedAt
+          deletedAt: new Date(),
+        },
+      });
+    } catch (e) {
+      return Result.err(e as Error);
+    }
+    return Result.ok(undefined);
+  }
+
+  async findByAuthorID(
+    authorId: ID<AccountID>,
+    limit: number,
+  ): Promise<Option.Option<Note[]>> {
+    try {
+      const res = await this.client.note.findMany({
+        where: {
+          authorId,
+          // NOTE: Exclude from the search those whose deletedAt does not appear undefined.
+          deletedAt: undefined,
+        },
+        take: limit,
+        orderBy: {
+          createdAt: 'desc',
+        },
+      });
+      return Option.some(
+        res.map((v) => this.deserialize(v as deserializeNoteArgs)),
+      );
+    } catch {
+      return Option.none();
+    }
+  }
+
+  async findByID(id: ID<NoteID>): Promise<Option.Option<Note>> {
+    try {
+      const res = await this.client.note.findUniqueOrThrow({
+        where: {
+          id,
+          // NOTE: Exclude from the search those whose deletedAt does not appear undefined.
+          deletedAt: undefined,
+        },
+      });
+      return Option.some(this.deserialize(res as deserializeNoteArgs));
+    } catch {
+      return Option.none();
+    }
+  }
+}
+
+export class PrismaBookmarkRepository implements BookmarkRepository {
+  constructor(private readonly client: PrismaClient) {}
+
+  async create(id: {
+    noteID: ID<NoteID>;
+    accountID: ID<AccountID>;
+  }): Promise<Result.Result<Error, void>> {
+    try {
+      await this.client.bookmark.create({
+        data: {
+          noteId: id.noteID,
+          accountId: id.accountID,
+        },
+      });
+      return Result.ok(undefined);
+    } catch (e) {
+      return Result.err(e as Error);
+    }
+  }
+
+  async deleteByID(id: {
+    noteID: ID<NoteID>;
+    accountID: ID<AccountID>;
+  }): Promise<Result.Result<Error, void>> {
+    try {
+      await this.client.bookmark.update({
+        where: {
+          noteId_accountId: {
+            accountId: id.accountID,
+            noteId: id.noteID,
+          },
+        },
+        data: {
+          deletedAt: new Date(),
+        },
+      });
+      return Result.ok(undefined);
+    } catch (e) {
+      return Result.err(e as Error);
+    }
+  }
+
+  async findByAccountID(id: ID<AccountID>): Promise<Option.Option<Bookmark[]>> {
+    try {
+      const res = await this.client.bookmark.findMany({
+        where: {
+          accountId: id,
+          deletedAt: undefined,
+        },
+      });
+      return Option.some(
+        res.map((v) =>
+          Bookmark.new({
+            noteID: v.noteId as ID<NoteID>,
+            accountID: v.accountId as ID<AccountID>,
+          }),
+        ),
+      );
+    } catch {
+      return Option.none();
+    }
+  }
+
+  async findByID(id: {
+    noteID: ID<NoteID>;
+    accountID: ID<AccountID>;
+  }): Promise<Option.Option<Bookmark>> {
+    try {
+      const res = await this.client.bookmark.findUniqueOrThrow({
+        where: {
+          noteId_accountId: {
+            accountId: id.accountID,
+            noteId: id.noteID,
+          },
+          deletedAt: undefined,
+        },
+      });
+      return Option.some(
+        Bookmark.new({
+          noteID: res.noteId as ID<NoteID>,
+          accountID: res.accountId as ID<AccountID>,
+        }),
+      );
+    } catch {
+      return Option.none();
+    }
+  }
+}

--- a/pkg/notes/adaptor/repository/prisma.ts
+++ b/pkg/notes/adaptor/repository/prisma.ts
@@ -18,7 +18,7 @@ type DeserializeNoteArgs = Prisma.PromiseReturnType<
 export class PrismaNoteRepository implements NoteRepository {
   constructor(private readonly client: PrismaClient) {}
 
-  private serialize(note: Note) {
+  private serialize(note: Note): Prisma.NoteCreateInput {
     const visibility = () => {
       switch (note.getVisibility()) {
         case 'PUBLIC':
@@ -33,10 +33,14 @@ export class PrismaNoteRepository implements NoteRepository {
     };
 
     return {
-      id: note.getID() as string,
+      id: note.getID(),
       text: note.getContent(),
       visibility: visibility(),
-      authorId: note.getAuthorID() as string,
+      author: {
+        connect: {
+          id: note.getAuthorID(),
+        },
+      },
       createdAt: note.getCreatedAt(),
       deletedAt: Option.isNone(note.getDeletedAt())
         ? undefined

--- a/pkg/notes/mod.ts
+++ b/pkg/notes/mod.ts
@@ -2,6 +2,7 @@ import { OpenAPIHono } from '@hono/zod-openapi';
 import { Result } from '@mikuroxina/mini-fn';
 
 import type { AccountID } from '../accounts/model/account.js';
+import { prismaClient } from '../adaptors/prisma.js';
 import { SnowflakeIDGenerator } from '../id/mod.js';
 import type { ID } from '../id/type.js';
 import { AccountModule } from '../intermodule/account.js';
@@ -11,6 +12,10 @@ import {
   InMemoryBookmarkRepository,
   InMemoryNoteRepository,
 } from './adaptor/repository/dummy.js';
+import {
+  PrismaBookmarkRepository,
+  PrismaNoteRepository,
+} from './adaptor/repository/prisma.js';
 import {
   CreateBookmarkRoute,
   CreateNoteRoute,
@@ -25,9 +30,14 @@ import { FetchService } from './service/fetch.js';
 import { FetchBookmarkService } from './service/fetchBookmark.js';
 import { RenoteService } from './service/renote.js';
 
+const isProduction = process.env.NODE_ENV === 'production';
 export const noteHandlers = new OpenAPIHono();
-const noteRepository = new InMemoryNoteRepository();
-const bookmarkRepository = new InMemoryBookmarkRepository();
+const noteRepository = isProduction
+  ? new PrismaNoteRepository(prismaClient)
+  : new InMemoryNoteRepository();
+const bookmarkRepository = isProduction
+  ? new PrismaBookmarkRepository(prismaClient)
+  : new InMemoryBookmarkRepository();
 const idGenerator = new SnowflakeIDGenerator(0, {
   now: () => BigInt(Date.now()),
 });


### PR DESCRIPTION
## What does this PR do?
- `PrismaNoteRepository`の実装
- `PrismaBookmarkRepository`の実装
- Note系APIで動作モードを認識してPrisma or InMemoryを使うかの変更を可能に

## Additional information
- ToDo: PrismaSchemaにいくつかの定義抜け(Note)があるのを解決する
- ToDo: 論理削除されているレコードを自動で除外するPrismaのミドルウェアの実装
