### PR TITLE
fix: replace ID<AccountID> to AccountID(`ID<Account>`)

### DIFF
--- a/pkg/accounts/adaptor/controller/account.ts
+++ b/pkg/accounts/adaptor/controller/account.ts
@@ -1,7 +1,6 @@
 import { type z } from '@hono/zod-openapi';
 import { Option, Result } from '@mikuroxina/mini-fn';
 
-import type { ID } from '../../../id/type.js';
 import { type AccountID, type AccountName } from '../../model/account.js';
 import type { AuthenticateService } from '../../service/authenticate.js';
 import type { EditService } from '../../service/edit.js';
@@ -191,7 +190,7 @@ export class AccountController {
   async getAccount(
     id: string,
   ): Promise<Result.Result<Error, z.infer<typeof GetAccountResponseSchema>>> {
-    const res = await this.fetchService.fetchAccountByID(id as ID<AccountID>);
+    const res = await this.fetchService.fetchAccountByID(id as AccountID);
     if (Result.isErr(res)) {
       return res;
     }
@@ -296,7 +295,7 @@ export class AccountController {
     id: string,
   ): Promise<Result.Result<Error, z.infer<typeof GetAccountFollowingSchema>>> {
     const res = await this.fetchFollowService.fetchFollowingsByID(
-      id as ID<AccountID>,
+      id as AccountID,
     );
     if (Result.isErr(res)) {
       return res;
@@ -336,7 +335,7 @@ export class AccountController {
     id: string,
   ): Promise<Result.Result<Error, z.infer<typeof GetAccountFollowerSchema>>> {
     const res = await this.fetchFollowService.fetchFollowersByID(
-      id as ID<AccountID>,
+      id as AccountID,
     );
     if (Result.isErr(res)) {
       return Result.err(res[1]);

--- a/pkg/accounts/adaptor/repository/dummy.ts
+++ b/pkg/accounts/adaptor/repository/dummy.ts
@@ -1,18 +1,17 @@
 import { Ether, Option, Result } from '@mikuroxina/mini-fn';
 
-import { type ID } from '../../../id/type.js';
 import { type Account, type AccountID } from '../../model/account.js';
 import { type AccountFollow } from '../../model/follow.js';
 import type { InactiveAccount } from '../../model/inactiveAccount.js';
 import {
-  accountRepoSymbol,
-  followRepoSymbol,
-  inactiveAccountRepoSymbol,
-  verifyTokenRepoSymbol,
   type AccountFollowRepository,
   type AccountRepository,
+  accountRepoSymbol,
   type AccountVerifyTokenRepository,
+  followRepoSymbol,
   type InactiveAccountRepository,
+  inactiveAccountRepoSymbol,
+  verifyTokenRepoSymbol,
 } from '../../model/repository.js';
 
 export class InMemoryAccountRepository implements AccountRepository {
@@ -31,7 +30,7 @@ export class InMemoryAccountRepository implements AccountRepository {
     this.data.clear();
   }
 
-  findByID(id: ID<AccountID>): Promise<Option.Option<Account>> {
+  findByID(id: AccountID): Promise<Option.Option<Account>> {
     const account = Array.from(this.data).find((a) => a.getID() === id);
     if (!account) {
       return Promise.resolve(Option.none());
@@ -85,7 +84,7 @@ export class InMemoryAccountVerifyTokenRepository
   }
 
   create(
-    accountID: ID<AccountID>,
+    accountID: AccountID,
     token: string,
     expire: Date,
   ): Promise<Result.Result<Error, void>> {
@@ -94,7 +93,7 @@ export class InMemoryAccountVerifyTokenRepository
   }
 
   findByID(
-    id: ID<string>,
+    id: AccountID,
   ): Promise<Option.Option<{ token: string; expire: Date }>> {
     const data = this.data.get(id);
     if (!data) {
@@ -119,14 +118,14 @@ export class InMemoryAccountFollowRepository
   }
 
   async fetchAllFollowers(
-    accountID: ID<AccountID>,
+    accountID: AccountID,
   ): Promise<Result.Result<Error, AccountFollow[]>> {
     const res = [...this.data].filter((f) => f.getTargetID() === accountID);
     return Result.ok(res);
   }
 
   async fetchAllFollowing(
-    accountID: ID<AccountID>,
+    accountID: AccountID,
   ): Promise<Result.Result<Error, AccountFollow[]>> {
     const res = [...this.data].filter((f) => f.getFromID() === accountID);
     return Result.ok(res);
@@ -138,8 +137,8 @@ export class InMemoryAccountFollowRepository
   }
 
   async unfollow(
-    accountID: ID<AccountID>,
-    targetID: ID<AccountID>,
+    accountID: AccountID,
+    targetID: AccountID,
   ): Promise<Result.Result<Error, void>> {
     const follow = [...this.data].find(
       (f) => f.getFromID() === accountID && f.getTargetID() === targetID,
@@ -153,7 +152,7 @@ export class InMemoryAccountFollowRepository
   }
 
   async fetchOrderedFollowers(
-    accountID: ID<AccountID>,
+    accountID: AccountID,
     limit: number,
   ): Promise<Result.Result<Error, AccountFollow[]>> {
     return Result.ok(
@@ -167,7 +166,7 @@ export class InMemoryAccountFollowRepository
   }
 
   async fetchOrderedFollowing(
-    accountID: ID<AccountID>,
+    accountID: AccountID,
     limit: number,
   ): Promise<Result.Result<Error, AccountFollow[]>> {
     return Result.ok(

--- a/pkg/accounts/adaptor/repository/prisma.ts
+++ b/pkg/accounts/adaptor/repository/prisma.ts
@@ -2,7 +2,6 @@ import { Ether, Option, Result } from '@mikuroxina/mini-fn';
 import { type Prisma, type PrismaClient } from '@prisma/client';
 
 import type { prismaClient } from '../../../adaptors/prisma.js';
-import type { ID } from '../../../id/type.js';
 import {
   Account,
   type AccountFrozen,
@@ -43,7 +42,7 @@ export class PrismaAccountRepository implements AccountRepository {
     return Result.ok(undefined);
   }
 
-  async findByID(id: ID<AccountID>): Promise<Option.Option<Account>> {
+  async findByID(id: AccountID): Promise<Option.Option<Account>> {
     const res = await this.prisma.account.findUnique({
       where: {
         id: id,
@@ -178,7 +177,7 @@ export class PrismaAccountRepository implements AccountRepository {
       )[args.silenced] ?? 'normal';
 
     return Account.reconstruct({
-      id: args.id as ID<AccountID>,
+      id: args.id as AccountID,
       name: args.name as AccountName,
       nickname: args.nickname,
       mail: args.mail,
@@ -204,7 +203,7 @@ export class PrismaAccountVerifyTokenRepository
   constructor(private readonly prisma: PrismaClient) {}
 
   async create(
-    accountID: ID<AccountID>,
+    accountID: AccountID,
     token: string,
     expire: Date,
   ): Promise<Result.Result<Error, void>> {
@@ -223,7 +222,7 @@ export class PrismaAccountVerifyTokenRepository
   }
 
   async findByID(
-    id: ID<AccountID>,
+    id: AccountID,
   ): Promise<Option.Option<{ token: string; expire: Date }>> {
     const res = await this.prisma.accountVerifyToken.findUnique({
       where: {
@@ -271,8 +270,8 @@ export class PrismaAccountFollowRepository implements AccountFollowRepository {
   }
 
   async unfollow(
-    fromID: ID<AccountID>,
-    targetID: ID<AccountID>,
+    fromID: AccountID,
+    targetID: AccountID,
   ): Promise<Result.Result<Error, void>> {
     try {
       await this.prisma.following.update({
@@ -293,7 +292,7 @@ export class PrismaAccountFollowRepository implements AccountFollowRepository {
   }
 
   async fetchAllFollowers(
-    accountID: ID<AccountID>,
+    accountID: AccountID,
   ): Promise<Result.Result<Error, AccountFollow[]>> {
     const res = await this.prisma.following.findMany({
       where: {
@@ -303,7 +302,7 @@ export class PrismaAccountFollowRepository implements AccountFollowRepository {
     return Result.ok(res.map((f) => this.fromPrismaArgs(f)));
   }
   async fetchAllFollowing(
-    accountID: ID<AccountID>,
+    accountID: AccountID,
   ): Promise<Result.Result<Error, AccountFollow[]>> {
     const res = await this.prisma.following.findMany({
       where: {
@@ -314,7 +313,7 @@ export class PrismaAccountFollowRepository implements AccountFollowRepository {
   }
 
   async fetchOrderedFollowers(
-    accountID: ID<AccountID>,
+    accountID: AccountID,
     limit: number,
   ): Promise<Result.Result<Error, AccountFollow[]>> {
     const res = await this.prisma.following.findMany({
@@ -330,7 +329,7 @@ export class PrismaAccountFollowRepository implements AccountFollowRepository {
   }
 
   async fetchOrderedFollowing(
-    accountID: ID<AccountID>,
+    accountID: AccountID,
     limit: number,
   ): Promise<Result.Result<Error, AccountFollow[]>> {
     const res = await this.prisma.following.findMany({
@@ -347,8 +346,8 @@ export class PrismaAccountFollowRepository implements AccountFollowRepository {
 
   private fromPrismaArgs(args: AccountFollowPrismaArgs): AccountFollow {
     return AccountFollow.reconstruct({
-      fromID: args.fromId as ID<AccountID>,
-      targetID: args.toId as ID<AccountID>,
+      fromID: args.fromId as AccountID,
+      targetID: args.toId as AccountID,
       createdAt: args.createdAt,
       deletedAt: args.deletedAt === null ? undefined : args.deletedAt,
     });

--- a/pkg/accounts/model/account.test.ts
+++ b/pkg/accounts/model/account.test.ts
@@ -1,15 +1,14 @@
 import { describe, expect, it } from 'vitest';
 
-import { type ID } from '../../id/type.js';
 import {
-  AccountNameSchema,
   Account,
   type AccountID,
+  AccountNameSchema,
   type CreateAccountArgs,
 } from './account.js';
 
 const exampleInput: CreateAccountArgs = {
-  id: '1' as ID<AccountID>,
+  id: '1' as AccountID,
   bio: 'this is john doe’s account!',
   createdAt: new Date('2023-09-10T00:00:00.000Z'),
   mail: 'test@mail.example.com',

--- a/pkg/accounts/model/account.ts
+++ b/pkg/accounts/model/account.ts
@@ -9,7 +9,7 @@ import {
   AccountNickNameLengthError,
 } from './account.errors.js';
 
-export type AccountID = string;
+export type AccountID = ID<Account>;
 export type AccountName = `@${string}@${string}`;
 export type AccountRole = 'admin' | 'normal' | 'moderator';
 export type AccountStatus = 'active' | 'notActivated';
@@ -59,7 +59,7 @@ export const AccountNameSchema = z
   .transform((s) => s as AccountName);
 
 export interface CreateAccountArgs {
-  id: ID<AccountID>;
+  id: AccountID;
   name: AccountName;
   mail: string;
   nickname: string;
@@ -92,8 +92,8 @@ export class Account {
   }
 
   // 不変
-  private readonly id: ID<AccountID>;
-  getID(): ID<AccountID> {
+  private readonly id: AccountID;
+  getID(): AccountID {
     return this.id;
   }
 

--- a/pkg/accounts/model/follow.test.ts
+++ b/pkg/accounts/model/follow.test.ts
@@ -1,15 +1,14 @@
 import { Option } from '@mikuroxina/mini-fn';
 import { describe, expect, it } from 'vitest';
 
-import type { ID } from '../../id/type.js';
 import type { AccountID } from './account.js';
 import { AccountFollow, type CreateAccountFollowArgs } from './follow.js';
 
 describe('AccountFollow', () => {
   it('generate new instance', () => {
     const exampleInput: CreateAccountFollowArgs = {
-      fromID: '1' as ID<AccountID>,
-      targetID: '2' as ID<AccountID>,
+      fromID: '1' as AccountID,
+      targetID: '2' as AccountID,
       createdAt: new Date('2023-09-10T00:00:00.000Z'),
       deletedAt: new Date('2023-09-10T10:00:00.000Z'),
     };

--- a/pkg/accounts/model/follow.ts
+++ b/pkg/accounts/model/follow.ts
@@ -1,11 +1,10 @@
 import { Option } from '@mikuroxina/mini-fn';
 
-import type { ID } from '../../id/type.js';
 import type { AccountID } from './account.js';
 
 export interface CreateAccountFollowArgs {
-  fromID: ID<AccountID>;
-  targetID: ID<AccountID>;
+  fromID: AccountID;
+  targetID: AccountID;
   createdAt: Date;
   deletedAt?: Date;
 }
@@ -41,15 +40,15 @@ export class AccountFollow {
     return new AccountFollow(args);
   }
 
-  private readonly fromID: ID<AccountID>;
+  private readonly fromID: AccountID;
 
-  public getFromID(): ID<AccountID> {
+  public getFromID(): AccountID {
     return this.fromID;
   }
 
-  private readonly targetID: ID<AccountID>;
+  private readonly targetID: AccountID;
 
-  public getTargetID(): ID<AccountID> {
+  public getTargetID(): AccountID {
     return this.targetID;
   }
 

--- a/pkg/accounts/model/inactiveAccount.test.ts
+++ b/pkg/accounts/model/inactiveAccount.test.ts
@@ -1,20 +1,19 @@
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
-import { type ID } from '../../id/type.js';
 import { type AccountID, type CreateAccountArgs } from './account.js';
 import {
-  InactiveAccount,
   type CreateInactiveAccountArgs,
+  InactiveAccount,
 } from './inactiveAccount.js';
 
 const exampleInput: CreateInactiveAccountArgs = {
-  id: '1' as ID<AccountID>,
+  id: '1' as AccountID,
   name: '@johndoe@social.example.com',
   mail: 'test@mail.example.com',
 };
 
 const exampleActivateArgs: CreateAccountArgs = {
-  id: '1' as ID<AccountID>,
+  id: '1' as AccountID,
   bio: "this is john doe's account!",
   createdAt: new Date('2023-09-10T00:00:00.000Z'),
   mail: 'test@mail.example.com',

--- a/pkg/accounts/model/inactiveAccount.ts
+++ b/pkg/accounts/model/inactiveAccount.ts
@@ -1,4 +1,3 @@
-import type { ID } from '../../id/type.js';
 import {
   Account,
   type AccountID,
@@ -7,7 +6,7 @@ import {
 } from './account.js';
 
 export interface CreateInactiveAccountArgs {
-  id: ID<AccountID>;
+  id: AccountID;
   name: AccountName;
   mail: string;
 }
@@ -39,7 +38,7 @@ export class InactiveAccount {
     return this.activated;
   }
 
-  private readonly id: ID<AccountID>;
+  private readonly id: AccountID;
   getID(): string {
     return this.id;
   }

--- a/pkg/accounts/model/repository.ts
+++ b/pkg/accounts/model/repository.ts
@@ -1,6 +1,5 @@
 import { Ether, type Option, type Result } from '@mikuroxina/mini-fn';
 
-import { type ID } from '../../id/type.js';
 import type { Account } from './account.js';
 import { type AccountID } from './account.js';
 import type { AccountFollow } from './follow.js';
@@ -9,7 +8,7 @@ import type { InactiveAccount } from './inactiveAccount.js';
 export interface AccountRepository {
   create(account: Account): Promise<Result.Result<Error, void>>;
   findByName(name: string): Promise<Option.Option<Account>>;
-  findByID(id: ID<AccountID>): Promise<Option.Option<Account>>;
+  findByID(id: AccountID): Promise<Option.Option<Account>>;
   findByMail(mail: string): Promise<Option.Option<Account>>;
   edit(account: Account): Promise<Result.Result<Error, void>>;
 }
@@ -25,13 +24,13 @@ export const inactiveAccountRepoSymbol =
 
 export interface AccountVerifyTokenRepository {
   create(
-    accountID: ID<AccountID>,
+    accountID: AccountID,
     token: string,
     expire: Date,
   ): Promise<Result.Result<Error, void>>;
   // TODO(laminne): Consider create a type for token/expire
   findByID(
-    id: ID<AccountID>,
+    id: AccountID,
   ): Promise<Option.Option<{ token: string; expire: Date }>>;
 }
 export const verifyTokenRepoSymbol =
@@ -40,21 +39,21 @@ export const verifyTokenRepoSymbol =
 export interface AccountFollowRepository {
   follow(follow: AccountFollow): Promise<Result.Result<Error, void>>;
   unfollow(
-    fromID: ID<AccountID>,
-    targetID: ID<AccountID>,
+    fromID: AccountID,
+    targetID: AccountID,
   ): Promise<Result.Result<Error, void>>;
   fetchAllFollowers(
-    accountID: ID<AccountID>,
+    accountID: AccountID,
   ): Promise<Result.Result<Error, AccountFollow[]>>;
   fetchAllFollowing(
-    accountID: ID<AccountID>,
+    accountID: AccountID,
   ): Promise<Result.Result<Error, AccountFollow[]>>;
   fetchOrderedFollowers(
-    accountID: ID<AccountID>,
+    accountID: AccountID,
     limit: number,
   ): Promise<Result.Result<Error, AccountFollow[]>>;
   fetchOrderedFollowing(
-    accountID: ID<AccountID>,
+    accountID: AccountID,
     limit: number,
   ): Promise<Result.Result<Error, AccountFollow[]>>;
 }

--- a/pkg/accounts/service/authenticate.test.ts
+++ b/pkg/accounts/service/authenticate.test.ts
@@ -1,10 +1,9 @@
 import { Result } from '@mikuroxina/mini-fn';
 import { describe, expect, it } from 'vitest';
 
-import type { ID } from '../../id/type.js';
 import { Argon2idPasswordEncoder } from '../../password/mod.js';
 import { InMemoryAccountRepository } from '../adaptor/repository/dummy.js';
-import { Account } from '../model/account.js';
+import { Account, type AccountID } from '../model/account.js';
 import { AuthenticateService } from './authenticate.js';
 import { AuthenticationTokenService } from './authenticationTokenService.js';
 
@@ -17,7 +16,7 @@ describe('AuthenticateService', () => {
     const accountRepository = new InMemoryAccountRepository();
     await accountRepository.create(
       Account.reconstruct({
-        id: '1' as ID<'Account'>,
+        id: '1' as AccountID,
         name: '@test@example.com',
         mail: 'test@example.com',
         bio: '',

--- a/pkg/accounts/service/edit.test.ts
+++ b/pkg/accounts/service/edit.test.ts
@@ -1,7 +1,6 @@
 import { Option, Result } from '@mikuroxina/mini-fn';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import type { ID } from '../../id/type.js';
 import { Argon2idPasswordEncoder } from '../../password/mod.js';
 import { InMemoryAccountRepository } from '../adaptor/repository/dummy.js';
 import { Account, type AccountID } from '../model/account.js';
@@ -20,7 +19,7 @@ describe('EditService', () => {
   beforeEach(async () => {
     await repository.create(
       Account.new({
-        id: '1' as ID<AccountID>,
+        id: '1' as AccountID,
         name: '@john@example.com',
         mail: 'johndoe@example.com',
         nickname: 'John Doe',

--- a/pkg/accounts/service/etagService.test.ts
+++ b/pkg/accounts/service/etagService.test.ts
@@ -1,7 +1,6 @@
 import { Option } from '@mikuroxina/mini-fn';
 import { afterEach, describe, expect, it } from 'vitest';
 
-import type { ID } from '../../id/type.js';
 import { InMemoryAccountRepository } from '../adaptor/repository/dummy.js';
 import { Account, type AccountID } from '../model/account.js';
 import { EtagService } from './etagService.js';
@@ -9,7 +8,7 @@ import { EtagService } from './etagService.js';
 const repository = new InMemoryAccountRepository();
 await repository.create(
   Account.new({
-    id: '1' as ID<AccountID>,
+    id: '1' as AccountID,
     name: '@john@example.com',
     mail: 'johndoe@example.com',
     nickname: 'John Doe',

--- a/pkg/accounts/service/fetch.test.ts
+++ b/pkg/accounts/service/fetch.test.ts
@@ -1,7 +1,6 @@
 import { Result } from '@mikuroxina/mini-fn';
 import { afterEach, describe, expect, it } from 'vitest';
 
-import type { ID } from '../../id/type.js';
 import { InMemoryAccountRepository } from '../adaptor/repository/dummy.js';
 import { Account, type AccountID } from '../model/account.js';
 import { FetchService } from './fetch.js';
@@ -9,7 +8,7 @@ import { FetchService } from './fetch.js';
 const repository = new InMemoryAccountRepository();
 await repository.create(
   Account.new({
-    id: '1' as ID<AccountID>,
+    id: '1' as AccountID,
     name: '@john@example.com',
     mail: 'johndoe@example.com',
     nickname: 'John Doe',
@@ -52,14 +51,14 @@ describe('FetchService', () => {
   });
 
   it('fetch account by ID', async () => {
-    const account = await fetchService.fetchAccountByID('1' as ID<AccountID>);
+    const account = await fetchService.fetchAccountByID('1' as AccountID);
     if (Result.isErr(account)) {
       return;
     }
 
     expect(account[1]).toStrictEqual(
       Account.new({
-        id: '1' as ID<AccountID>,
+        id: '1' as AccountID,
         name: '@john@example.com',
         mail: 'johndoe@example.com',
         nickname: 'John Doe',
@@ -76,7 +75,7 @@ describe('FetchService', () => {
 
   it("fetch account by ID doesn't exist", async () => {
     // `2` is not registered.
-    const account = await fetchService.fetchAccountByID('2' as ID<AccountID>);
+    const account = await fetchService.fetchAccountByID('2' as AccountID);
 
     expect(Result.isErr(account)).toBe(true);
   });

--- a/pkg/accounts/service/fetch.ts
+++ b/pkg/accounts/service/fetch.ts
@@ -1,10 +1,9 @@
 import { Ether, Option, Result } from '@mikuroxina/mini-fn';
 
-import type { ID } from '../../id/type.js';
 import { type Account, type AccountID } from '../model/account.js';
 import {
-  accountRepoSymbol,
   type AccountRepository,
+  accountRepoSymbol,
 } from '../model/repository.js';
 
 export class FetchService {
@@ -29,7 +28,7 @@ export class FetchService {
   }
 
   async fetchAccountByID(
-    id: ID<AccountID>,
+    id: AccountID,
   ): Promise<Result.Result<Error, Account>> {
     const res = await this.accountRepository.findByID(id);
     return Option.okOr(new Error('AccountNotFoundError'))(res);

--- a/pkg/accounts/service/fetchFollow.test.ts
+++ b/pkg/accounts/service/fetchFollow.test.ts
@@ -1,7 +1,6 @@
 import { Result } from '@mikuroxina/mini-fn';
 import { describe, expect, it } from 'vitest';
 
-import type { ID } from '../../id/type.js';
 import {
   InMemoryAccountFollowRepository,
   InMemoryAccountRepository,
@@ -14,7 +13,7 @@ const accountRepository = new InMemoryAccountRepository();
 
 await accountRepository.create(
   Account.reconstruct({
-    id: '1' as ID<AccountID>,
+    id: '1' as AccountID,
     name: '@johndoe@example.com',
     bio: '',
     mail: '',
@@ -32,7 +31,7 @@ await accountRepository.create(
 
 await accountRepository.create(
   Account.reconstruct({
-    id: '2' as ID<AccountID>,
+    id: '2' as AccountID,
     name: '@testuser@example.com',
     bio: '',
     mail: '',
@@ -53,16 +52,16 @@ const repository = new InMemoryAccountFollowRepository();
 
 await repository.follow(
   AccountFollow.new({
-    fromID: '1' as ID<AccountID>,
-    targetID: '2' as ID<AccountID>,
+    fromID: '1' as AccountID,
+    targetID: '2' as AccountID,
     createdAt,
   }),
 );
 
 await repository.follow(
   AccountFollow.new({
-    fromID: '2' as ID<AccountID>,
-    targetID: '1' as ID<AccountID>,
+    fromID: '2' as AccountID,
+    targetID: '1' as AccountID,
     createdAt,
   }),
 );
@@ -71,7 +70,7 @@ const service = new FetchFollowService(repository, accountRepository);
 
 describe('FetchFollowService', () => {
   const USER = {
-    id: '1' as ID<AccountID>,
+    id: '1' as AccountID,
     name: '@johndoe@example.com' as const,
   };
 
@@ -83,8 +82,8 @@ describe('FetchFollowService', () => {
 
     expect(resFollows[1]).toStrictEqual([
       AccountFollow.new({
-        fromID: '1' as ID<AccountID>,
-        targetID: '2' as ID<AccountID>,
+        fromID: '1' as AccountID,
+        targetID: '2' as AccountID,
         createdAt,
       }),
     ]);
@@ -98,8 +97,8 @@ describe('FetchFollowService', () => {
 
     expect(resFollows[1]).toStrictEqual([
       AccountFollow.new({
-        fromID: '1' as ID<AccountID>,
-        targetID: '2' as ID<AccountID>,
+        fromID: '1' as AccountID,
+        targetID: '2' as AccountID,
         createdAt,
       }),
     ]);
@@ -113,8 +112,8 @@ describe('FetchFollowService', () => {
 
     expect(resFollows[1]).toStrictEqual([
       AccountFollow.new({
-        fromID: '2' as ID<AccountID>,
-        targetID: '1' as ID<AccountID>,
+        fromID: '2' as AccountID,
+        targetID: '1' as AccountID,
         createdAt,
       }),
     ]);
@@ -128,8 +127,8 @@ describe('FetchFollowService', () => {
 
     expect(resFollows[1]).toStrictEqual([
       AccountFollow.new({
-        fromID: '2' as ID<AccountID>,
-        targetID: '1' as ID<AccountID>,
+        fromID: '2' as AccountID,
+        targetID: '1' as AccountID,
         createdAt,
       }),
     ]);

--- a/pkg/accounts/service/fetchFollow.ts
+++ b/pkg/accounts/service/fetchFollow.ts
@@ -1,13 +1,12 @@
 import { Cat, Ether, Option, Result } from '@mikuroxina/mini-fn';
 
-import type { ID } from '../../id/type.js';
 import type { AccountID, AccountName } from '../model/account.js';
 import type { AccountFollow } from '../model/follow.js';
 import {
-  accountRepoSymbol,
-  followRepoSymbol,
   type AccountFollowRepository,
   type AccountRepository,
+  accountRepoSymbol,
+  followRepoSymbol,
 } from '../model/repository.js';
 
 export class FetchFollowService {
@@ -17,7 +16,7 @@ export class FetchFollowService {
   ) {}
 
   async fetchFollowingsByID(
-    id: ID<AccountID>,
+    id: AccountID,
   ): Promise<Result.Result<Error, AccountFollow[]>> {
     return this.accountFollowRepository.fetchAllFollowing(id);
   }
@@ -37,7 +36,7 @@ export class FetchFollowService {
   }
 
   async fetchFollowersByID(
-    id: ID<AccountID>,
+    id: AccountID,
   ): Promise<Result.Result<Error, AccountFollow[]>> {
     return this.accountFollowRepository.fetchAllFollowers(id);
   }

--- a/pkg/accounts/service/follow.test.ts
+++ b/pkg/accounts/service/follow.test.ts
@@ -1,7 +1,6 @@
 import { Option, Result } from '@mikuroxina/mini-fn';
 import { describe, expect, it } from 'vitest';
 
-import type { ID } from '../../id/type.js';
 import {
   InMemoryAccountFollowRepository,
   InMemoryAccountRepository,
@@ -12,7 +11,7 @@ import { FollowService } from './follow.js';
 const accountRepository = new InMemoryAccountRepository();
 await accountRepository.create(
   Account.reconstruct({
-    id: '1' as ID<AccountID>,
+    id: '1' as AccountID,
     name: '@johndoe@example.com',
     bio: '',
     mail: '',
@@ -29,7 +28,7 @@ await accountRepository.create(
 );
 await accountRepository.create(
   Account.reconstruct({
-    id: '2' as ID<AccountID>,
+    id: '2' as AccountID,
     name: '@testuser@example.com',
     bio: '',
     mail: '',
@@ -55,8 +54,8 @@ describe('FollowService', () => {
     );
 
     expect(Result.isErr(res)).toBe(false);
-    expect(Result.unwrap(res).getFromID()).toBe('1' as ID<AccountID>);
-    expect(Result.unwrap(res).getTargetID()).toBe('2' as ID<AccountID>);
+    expect(Result.unwrap(res).getFromID()).toBe('1' as AccountID);
+    expect(Result.unwrap(res).getTargetID()).toBe('2' as AccountID);
     expect(Result.unwrap(res).getDeletedAt()).toStrictEqual(Option.none());
   });
 });

--- a/pkg/accounts/service/freeze.test.ts
+++ b/pkg/accounts/service/freeze.test.ts
@@ -1,7 +1,6 @@
 import { Option } from '@mikuroxina/mini-fn';
 import { afterEach, describe, expect, it } from 'vitest';
 
-import type { ID } from '../../id/type.js';
 import { InMemoryAccountRepository } from '../adaptor/repository/dummy.js';
 import { Account, type AccountID } from '../model/account.js';
 import { FreezeService } from './freeze.js';
@@ -9,7 +8,7 @@ import { FreezeService } from './freeze.js';
 const repository = new InMemoryAccountRepository();
 await repository.create(
   Account.new({
-    id: '1' as ID<AccountID>,
+    id: '1' as AccountID,
     name: '@john@example.com',
     mail: 'johndoe@example.com',
     nickname: 'John Doe',

--- a/pkg/accounts/service/register.ts
+++ b/pkg/accounts/service/register.ts
@@ -10,7 +10,6 @@ import {
 } from '../../password/mod.js';
 import {
   Account,
-  type AccountID,
   type AccountName,
   type AccountRole,
 } from '../model/account.js';
@@ -71,7 +70,7 @@ export class RegisterService {
     }
     const passphraseHash =
       await this.passwordEncoder.encodePassword(passphrase);
-    const generatedID = this.snowflakeIDGenerator.generate<AccountID>();
+    const generatedID = this.snowflakeIDGenerator.generate<Account>();
     if (Result.isErr(generatedID)) {
       return Result.err(generatedID[1]);
     }

--- a/pkg/accounts/service/resendToken.test.ts
+++ b/pkg/accounts/service/resendToken.test.ts
@@ -2,7 +2,6 @@ import { Option } from '@mikuroxina/mini-fn';
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { MockClock } from '../../id/mod.js';
-import { type ID } from '../../id/type.js';
 import {
   InMemoryAccountRepository,
   InMemoryAccountVerifyTokenRepository,
@@ -15,7 +14,7 @@ import { VerifyAccountTokenService } from './verifyToken.js';
 const repository = new InMemoryAccountRepository();
 await repository.create(
   Account.new({
-    id: '1' as ID<AccountID>,
+    id: '1' as AccountID,
     name: '@john@example.com',
     mail: 'johndoe@example.com',
     nickname: 'John Doe',
@@ -32,7 +31,7 @@ const verifyRepository = new InMemoryAccountVerifyTokenRepository();
 const accountRepository = new InMemoryAccountRepository();
 await accountRepository.create(
   Account.reconstruct({
-    id: '1' as ID<AccountID>,
+    id: '1' as AccountID,
     name: '@john@example.com',
     bio: '',
     frozen: 'normal',

--- a/pkg/accounts/service/silence.test.ts
+++ b/pkg/accounts/service/silence.test.ts
@@ -1,7 +1,6 @@
 import { Option } from '@mikuroxina/mini-fn';
 import { afterEach, describe, expect, it } from 'vitest';
 
-import type { ID } from '../../id/type.js';
 import { InMemoryAccountRepository } from '../adaptor/repository/dummy.js';
 import { Account, type AccountID } from '../model/account.js';
 import { SilenceService } from './silence.js';
@@ -9,7 +8,7 @@ import { SilenceService } from './silence.js';
 const repository = new InMemoryAccountRepository();
 await repository.create(
   Account.new({
-    id: '1' as ID<AccountID>,
+    id: '1' as AccountID,
     name: '@john@example.com',
     mail: 'johndoe@example.com',
     nickname: 'John Doe',

--- a/pkg/accounts/service/unfollow.test.ts
+++ b/pkg/accounts/service/unfollow.test.ts
@@ -1,7 +1,6 @@
 import { Option } from '@mikuroxina/mini-fn';
 import { describe, expect, it } from 'vitest';
 
-import type { ID } from '../../id/type.js';
 import {
   InMemoryAccountFollowRepository,
   InMemoryAccountRepository,
@@ -13,7 +12,7 @@ import { UnfollowService } from './unfollow.js';
 const accountRepository = new InMemoryAccountRepository();
 await accountRepository.create(
   Account.reconstruct({
-    id: '1' as ID<AccountID>,
+    id: '1' as AccountID,
     name: '@johndoe@example.com',
     bio: '',
     mail: '',
@@ -30,7 +29,7 @@ await accountRepository.create(
 );
 await accountRepository.create(
   Account.reconstruct({
-    id: '2' as ID<AccountID>,
+    id: '2' as AccountID,
     name: '@testuser@example.com',
     bio: '',
     mail: '',
@@ -47,8 +46,8 @@ await accountRepository.create(
 );
 const repository = new InMemoryAccountFollowRepository([
   AccountFollow.new({
-    fromID: '1' as ID<AccountID>,
-    targetID: '2' as ID<AccountID>,
+    fromID: '1' as AccountID,
+    targetID: '2' as AccountID,
     createdAt: new Date(),
   }),
 ]);

--- a/pkg/accounts/service/verifyToken.test.ts
+++ b/pkg/accounts/service/verifyToken.test.ts
@@ -2,7 +2,6 @@ import { Result } from '@mikuroxina/mini-fn';
 import { describe, expect, it } from 'vitest';
 
 import { MockClock } from '../../id/mod.js';
-import { type ID } from '../../id/type.js';
 import {
   InMemoryAccountRepository,
   InMemoryAccountVerifyTokenRepository,
@@ -14,7 +13,7 @@ const repository = new InMemoryAccountVerifyTokenRepository();
 const accountRepository = new InMemoryAccountRepository();
 await accountRepository.create(
   Account.reconstruct({
-    id: '1' as ID<AccountID>,
+    id: '1' as AccountID,
     name: '@johndoe@example.com',
     nickname: '',
     mail: '',

--- a/pkg/drive/service/upload.ts
+++ b/pkg/drive/service/upload.ts
@@ -57,7 +57,7 @@ export class UploadMediaService {
     );
 
     const medium = Medium.new({
-      id: id[1],
+      id: id[1] as ID<(typeof id)[1]>,
       name: args.name,
       authorId: args.authorId,
       nsfw: args.nsfw,

--- a/pkg/drive/service/upload.ts
+++ b/pkg/drive/service/upload.ts
@@ -57,7 +57,7 @@ export class UploadMediaService {
     );
 
     const medium = Medium.new({
-      id: id[1] as ID<(typeof id)[1]>,
+      id: id[1] as ID<MediumID>,
       name: args.name,
       authorId: args.authorId,
       nsfw: args.nsfw,

--- a/pkg/id/mod.test.ts
+++ b/pkg/id/mod.test.ts
@@ -1,7 +1,7 @@
 import { Result } from '@mikuroxina/mini-fn';
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
-import { IDSchema, type Clock, SnowflakeIDGenerator } from './mod.js';
+import { type Clock, IDSchema, SnowflakeIDGenerator } from './mod.js';
 
 class DummyClock implements Clock {
   now(): bigint {
@@ -25,7 +25,7 @@ describe('SnowflakeIDGenerator', () => {
   it('generate at the same time but do not output the same ID', () => {
     let oldID = '';
     for (let i = 0; i < 4095; i++) {
-      const newID = generator.generate();
+      const newID = generator.generate<string>();
 
       if (Result.isOk(newID)) {
         expect(newID[1]).not.toBe(oldID);

--- a/pkg/id/mod.ts
+++ b/pkg/id/mod.ts
@@ -45,7 +45,7 @@ export class SnowflakeIDGenerator {
   /**
    * @returns SnowflakeID (string)
    */
-  public generate<T>(): Result.Result<Error, ID<T>> {
+  public generate<T>(): Result.Result<Error, T> {
     const now = this.clock.now();
     const timeFromEpoch = now - OFFSET_FROM_UNIX_EPOCH;
     if (timeFromEpoch < 0) {
@@ -69,7 +69,7 @@ export class SnowflakeIDGenerator {
       (this.workerID << this.INCREMENTAL_BIT_LENGTH) |
       this.incremental;
 
-    return Result.ok(id.toString() as ID<T>);
+    return Result.ok(id.toString() as T);
   }
 }
 export const snowflakeIDGeneratorSymbol =

--- a/pkg/id/mod.ts
+++ b/pkg/id/mod.ts
@@ -45,7 +45,7 @@ export class SnowflakeIDGenerator {
   /**
    * @returns SnowflakeID (string)
    */
-  public generate<T>(): Result.Result<Error, T> {
+  public generate<T>(): Result.Result<Error, ID<T>> {
     const now = this.clock.now();
     const timeFromEpoch = now - OFFSET_FROM_UNIX_EPOCH;
     if (timeFromEpoch < 0) {
@@ -69,7 +69,7 @@ export class SnowflakeIDGenerator {
       (this.workerID << this.INCREMENTAL_BIT_LENGTH) |
       this.incremental;
 
-    return Result.ok(id.toString() as T);
+    return Result.ok(id.toString() as ID<T>);
   }
 }
 export const snowflakeIDGeneratorSymbol =

--- a/pkg/intermodule/account.ts
+++ b/pkg/intermodule/account.ts
@@ -11,10 +11,9 @@ import {
   type AccountSilenced,
   type AccountStatus,
 } from '../accounts/model/account.js';
-import type { ID } from '../id/type.js';
 
 export interface PartialAccount {
-  id: ID<AccountID>;
+  id: AccountID;
   name: AccountName;
   nickname: string;
   bio: string;
@@ -29,9 +28,7 @@ export class AccountModule {
 
   constructor() {}
 
-  async fetchAccount(
-    id: ID<AccountID>,
-  ): Promise<Result.Result<Error, Account>> {
+  async fetchAccount(id: AccountID): Promise<Result.Result<Error, Account>> {
     const res = await this.client.accounts[':id'].$get({
       param: { id },
     });
@@ -46,7 +43,7 @@ export class AccountModule {
     }
 
     const account = Account.new({
-      id: body.id as ID<AccountID>,
+      id: body.id as AccountID,
       mail: body.email as string,
       name: body.name as AccountName,
       nickname: body.nickname,
@@ -63,7 +60,7 @@ export class AccountModule {
   }
 
   async fetchFollowings(
-    id: ID<AccountID>,
+    id: AccountID,
   ): Promise<Result.Result<Error, PartialAccount[]>> {
     const res = await this.client.accounts[':id'].following.$get({
       param: { id },
@@ -79,7 +76,7 @@ export class AccountModule {
     return Result.ok(
       body.map((v): PartialAccount => {
         return {
-          id: v.id as ID<AccountID>,
+          id: v.id as AccountID,
           name: v.name as AccountName,
           nickname: v.nickname,
           bio: v.bio,
@@ -89,7 +86,7 @@ export class AccountModule {
   }
 
   async fetchFollowers(
-    id: ID<AccountID>,
+    id: AccountID,
   ): Promise<Result.Result<Error, PartialAccount[]>> {
     const res = await this.client.accounts[':id'].follower.$get({
       param: { id },
@@ -105,7 +102,7 @@ export class AccountModule {
     return Result.ok(
       body.map((v): PartialAccount => {
         return {
-          id: v.id as ID<AccountID>,
+          id: v.id as AccountID,
           name: v.name as AccountName,
           nickname: v.nickname,
           bio: v.bio,

--- a/pkg/notes/adaptor/controller/bookmark.ts
+++ b/pkg/notes/adaptor/controller/bookmark.ts
@@ -1,5 +1,5 @@
 import type { z } from '@hono/zod-openapi';
-import { Result, type Option } from '@mikuroxina/mini-fn';
+import { type Option, Result } from '@mikuroxina/mini-fn';
 
 import type { AccountID } from '../../../accounts/model/account.js';
 import type { ID } from '../../../id/type.js';
@@ -25,7 +25,7 @@ export class BookmarkController {
   > {
     const res = await this.createBookmarkService.handle(
       noteID as ID<NoteID>,
-      accountID as ID<AccountID>,
+      accountID as AccountID,
     );
 
     if (Result.isErr(res)) {
@@ -48,7 +48,7 @@ export class BookmarkController {
   ): Promise<Option.Option<Bookmark>> {
     const res = await this.fetchBookmarkService.fetchBookmarkByID(
       noteID as ID<NoteID>,
-      accountID as ID<AccountID>,
+      accountID as AccountID,
     );
 
     return res;
@@ -58,7 +58,7 @@ export class BookmarkController {
     accountID: string,
   ): Promise<Option.Option<Bookmark[]>> {
     const res = await this.fetchBookmarkService.fetchBookmarkByAccountID(
-      accountID as ID<AccountID>,
+      accountID as AccountID,
     );
 
     return res;
@@ -70,7 +70,7 @@ export class BookmarkController {
   ): Promise<Result.Result<Error, void>> {
     const res = await this.deleteBookmarkService.handle(
       noteID as ID<NoteID>,
-      accountID as ID<AccountID>,
+      accountID as AccountID,
     );
 
     return Result.map(() => undefined)(res);

--- a/pkg/notes/adaptor/controller/note.ts
+++ b/pkg/notes/adaptor/controller/note.ts
@@ -4,7 +4,7 @@ import { Option, Result } from '@mikuroxina/mini-fn';
 import type { AccountID } from '../../../accounts/model/account.js';
 import type { ID } from '../../../id/type.js';
 import type { AccountModule } from '../../../intermodule/account.js';
-import type { NoteVisibility } from '../../model/note.js';
+import type { NoteID, NoteVisibility } from '../../model/note.js';
 import type { CreateService } from '../../service/create.js';
 import type { FetchService } from '../../service/fetch.js';
 import type { RenoteService } from '../../service/renote.js';
@@ -32,8 +32,8 @@ export class NoteController {
     const res = await this.createService.handle(
       content,
       contentsWarningComment,
-      !sendTo ? Option.none() : Option.some(sendTo as ID<AccountID>),
-      authorID as ID<AccountID>,
+      !sendTo ? Option.none() : Option.some(sendTo as AccountID),
+      authorID as AccountID,
       visibility as NoteVisibility,
     );
     if (Result.isErr(res)) {
@@ -56,7 +56,7 @@ export class NoteController {
   async getNoteByID(
     noteID: string,
   ): Promise<Result.Result<Error, z.infer<typeof GetNoteResponseSchema>>> {
-    const res = await this.fetchService.fetchNoteByID(noteID as ID<AccountID>);
+    const res = await this.fetchService.fetchNoteByID(noteID as ID<NoteID>);
     if (Option.isNone(res)) {
       return Result.err(new Error('Note not found'));
     }
@@ -99,10 +99,10 @@ export class NoteController {
     contentsWarningComment: string,
   ): Promise<Result.Result<Error, z.infer<typeof RenoteResponseSchema>>> {
     const res = await this.renoteService.handle(
-      originalNoteID as ID<AccountID>,
+      originalNoteID as ID<NoteID>,
       content,
       contentsWarningComment,
-      authorID as ID<AccountID>,
+      authorID as AccountID,
       visibility as NoteVisibility,
     );
     if (Result.isErr(res)) {

--- a/pkg/notes/adaptor/repository/dummy.ts
+++ b/pkg/notes/adaptor/repository/dummy.ts
@@ -32,11 +32,11 @@ export class InMemoryNoteRepository implements NoteRepository {
   }
 
   findByAuthorID(
-    authorID: ID<AccountID>,
+    authorID: AccountID,
     limit: number,
   ): Promise<Option.Option<Note[]>> {
     const res = [...this.notes.values()].filter(
-      (note) => note.getID() === authorID,
+      (note) => note.getAuthorID() === authorID,
     );
     if (res.length === 0) {
       return Promise.resolve(Option.none());
@@ -60,11 +60,11 @@ export class InMemoryNoteRepository implements NoteRepository {
 }
 
 export class InMemoryBookmarkRepository implements BookmarkRepository {
-  private readonly bookmarks: Map<[ID<NoteID>, ID<AccountID>], Bookmark>;
+  private readonly bookmarks: Map<[ID<NoteID>, AccountID], Bookmark>;
 
   private equalID(
-    a: [ID<NoteID>, ID<AccountID>],
-    b: [ID<NoteID>, ID<AccountID>],
+    a: [ID<NoteID>, AccountID],
+    b: [ID<NoteID>, AccountID],
   ): boolean {
     return a[0] === b[0] && a[1] === b[1];
   }
@@ -80,7 +80,7 @@ export class InMemoryBookmarkRepository implements BookmarkRepository {
 
   async create(id: {
     noteID: ID<NoteID>;
-    accountID: ID<AccountID>;
+    accountID: AccountID;
   }): Promise<Result.Result<Error, void>> {
     const bookmark = Bookmark.new(id);
     this.bookmarks.set([id.noteID, id.accountID], bookmark);
@@ -89,7 +89,7 @@ export class InMemoryBookmarkRepository implements BookmarkRepository {
 
   async deleteByID(id: {
     noteID: ID<NoteID>;
-    accountID: ID<AccountID>;
+    accountID: AccountID;
   }): Promise<Result.Result<Error, void>> {
     const key = Array.from(this.bookmarks.keys()).find((k) =>
       this.equalID(k, [id.noteID, id.accountID]),
@@ -105,7 +105,7 @@ export class InMemoryBookmarkRepository implements BookmarkRepository {
 
   async findByID(id: {
     noteID: ID<NoteID>;
-    accountID: ID<AccountID>;
+    accountID: AccountID;
   }): Promise<Option.Option<Bookmark>> {
     const bookmark = Array.from(this.bookmarks.entries()).find((v) =>
       this.equalID(v[0], [id.noteID, id.accountID]),
@@ -116,7 +116,7 @@ export class InMemoryBookmarkRepository implements BookmarkRepository {
     return Promise.resolve(Option.some(bookmark[1]));
   }
 
-  async findByAccountID(id: ID<AccountID>): Promise<Option.Option<Bookmark[]>> {
+  async findByAccountID(id: AccountID): Promise<Option.Option<Bookmark[]>> {
     const bookmarks = Array.from(this.bookmarks.entries())
       .filter((v) => v[0][1] === id)
       .map((v) => v[1]);

--- a/pkg/notes/adaptor/repository/prisma.ts
+++ b/pkg/notes/adaptor/repository/prisma.ts
@@ -69,7 +69,7 @@ export class PrismaNoteRepository implements NoteRepository {
     return Note.reconstruct({
       id: data.id as ID<NoteID>,
       content: data.text,
-      authorID: data.authorId as ID<AccountID>,
+      authorID: data.authorId as AccountID,
       createdAt: data.createdAt,
       deletedAt: !data.deletedAt ? Option.none() : Option.some(data.deletedAt),
       contentsWarningComment: '',
@@ -114,7 +114,7 @@ export class PrismaNoteRepository implements NoteRepository {
   }
 
   async findByAuthorID(
-    authorId: ID<AccountID>,
+    authorId: AccountID,
     limit: number,
   ): Promise<Option.Option<Note[]>> {
     try {
@@ -156,7 +156,7 @@ export class PrismaBookmarkRepository implements BookmarkRepository {
 
   async create(id: {
     noteID: ID<NoteID>;
-    accountID: ID<AccountID>;
+    accountID: AccountID;
   }): Promise<Result.Result<Error, void>> {
     try {
       await this.client.bookmark.create({
@@ -173,7 +173,7 @@ export class PrismaBookmarkRepository implements BookmarkRepository {
 
   async deleteByID(id: {
     noteID: ID<NoteID>;
-    accountID: ID<AccountID>;
+    accountID: AccountID;
   }): Promise<Result.Result<Error, void>> {
     try {
       await this.client.bookmark.update({
@@ -193,7 +193,7 @@ export class PrismaBookmarkRepository implements BookmarkRepository {
     }
   }
 
-  async findByAccountID(id: ID<AccountID>): Promise<Option.Option<Bookmark[]>> {
+  async findByAccountID(id: AccountID): Promise<Option.Option<Bookmark[]>> {
     try {
       const res = await this.client.bookmark.findMany({
         where: {
@@ -205,7 +205,7 @@ export class PrismaBookmarkRepository implements BookmarkRepository {
         res.map((v) =>
           Bookmark.new({
             noteID: v.noteId as ID<NoteID>,
-            accountID: v.accountId as ID<AccountID>,
+            accountID: v.accountId as AccountID,
           }),
         ),
       );
@@ -216,7 +216,7 @@ export class PrismaBookmarkRepository implements BookmarkRepository {
 
   async findByID(id: {
     noteID: ID<NoteID>;
-    accountID: ID<AccountID>;
+    accountID: AccountID;
   }): Promise<Option.Option<Bookmark>> {
     try {
       const res = await this.client.bookmark.findUniqueOrThrow({
@@ -231,7 +231,7 @@ export class PrismaBookmarkRepository implements BookmarkRepository {
       return Option.some(
         Bookmark.new({
           noteID: res.noteId as ID<NoteID>,
-          accountID: res.accountId as ID<AccountID>,
+          accountID: res.accountId as AccountID,
         }),
       );
     } catch {

--- a/pkg/notes/model/bookmark.test.ts
+++ b/pkg/notes/model/bookmark.test.ts
@@ -1,12 +1,13 @@
 import { describe, expect, it } from 'vitest';
 
+import type { AccountID } from '../../accounts/model/account.js';
 import type { ID } from '../../id/type.js';
 import { Bookmark, type CreateBookmarkArgs } from './bookmark.js';
 import { type NoteID } from './note.js';
 
 const exampleInput: CreateBookmarkArgs = {
   noteID: '1' as ID<NoteID>,
-  accountID: '2' as ID<'account'>,
+  accountID: '2' as AccountID,
 };
 
 describe('Bookmark', () => {

--- a/pkg/notes/model/bookmark.ts
+++ b/pkg/notes/model/bookmark.ts
@@ -4,7 +4,7 @@ import type { NoteID } from './note.js';
 
 export interface CreateBookmarkArgs {
   noteID: ID<NoteID>;
-  accountID: ID<AccountID>;
+  accountID: AccountID;
 }
 
 export class Bookmark {
@@ -23,9 +23,9 @@ export class Bookmark {
     return this.noteID;
   }
 
-  private readonly accountID: ID<AccountID>;
+  private readonly accountID: AccountID;
 
-  getAccountID(): ID<AccountID> {
+  getAccountID(): AccountID {
     return this.accountID;
   }
 }

--- a/pkg/notes/model/note.test.ts
+++ b/pkg/notes/model/note.test.ts
@@ -1,12 +1,13 @@
 import { Option } from '@mikuroxina/mini-fn';
 import { describe, expect, it } from 'vitest';
 
+import type { AccountID } from '../../accounts/model/account.js';
 import type { ID } from '../../id/type.js';
 import { type CreateNoteArgs, Note, type NoteID } from './note.js';
 
 const exampleInput: CreateNoteArgs = {
   id: '1' as ID<NoteID>,
-  authorID: '2' as ID<'account'>,
+  authorID: '2' as AccountID,
   content: 'hello world!',
   createdAt: new Date('2023-09-10T00:00:00.000Z'),
   visibility: 'PUBLIC',

--- a/pkg/notes/model/note.ts
+++ b/pkg/notes/model/note.ts
@@ -8,11 +8,11 @@ export type NoteVisibility = 'PUBLIC' | 'HOME' | 'FOLLOWERS' | 'DIRECT';
 
 export interface CreateNoteArgs {
   id: ID<NoteID>;
-  authorID: ID<AccountID>;
+  authorID: AccountID;
   content: string;
   visibility: NoteVisibility;
   contentsWarningComment: string;
-  sendTo: Option.Option<ID<AccountID>>;
+  sendTo: Option.Option<AccountID>;
   originalNoteID: Option.Option<ID<NoteID>>;
   createdAt: Date;
   updatedAt: Option.Option<Date>;
@@ -57,8 +57,8 @@ export class Note {
     return this.id;
   }
 
-  private readonly authorID: ID<AccountID>;
-  getAuthorID(): ID<AccountID> {
+  private readonly authorID: AccountID;
+  getAuthorID(): AccountID {
     return this.authorID;
   }
 
@@ -77,8 +77,8 @@ export class Note {
     return this.contentsWarningComment;
   }
 
-  private readonly sendTo: Option.Option<ID<AccountID>>;
-  getSendTo(): Option.Option<ID<AccountID>> {
+  private readonly sendTo: Option.Option<AccountID>;
+  getSendTo(): Option.Option<AccountID> {
     return this.sendTo;
   }
 

--- a/pkg/notes/model/repository.ts
+++ b/pkg/notes/model/repository.ts
@@ -8,7 +8,7 @@ import type { Note, NoteID } from './note.js';
 export interface NoteRepository {
   create(note: Note): Promise<Result.Result<Error, void>>;
   findByAuthorID(
-    authorID: ID<AccountID>,
+    authorID: AccountID,
     limit: number,
   ): Promise<Option.Option<Note[]>>;
   findByID(id: ID<NoteID>): Promise<Option.Option<Note>>;
@@ -18,15 +18,15 @@ export interface NoteRepository {
 export interface BookmarkRepository {
   create(id: {
     noteID: ID<NoteID>;
-    accountID: ID<AccountID>;
+    accountID: AccountID;
   }): Promise<Result.Result<Error, void>>;
   findByID(id: {
     noteID: ID<NoteID>;
-    accountID: ID<AccountID>;
+    accountID: AccountID;
   }): Promise<Option.Option<Bookmark>>;
-  findByAccountID(id: ID<AccountID>): Promise<Option.Option<Bookmark[]>>;
+  findByAccountID(id: AccountID): Promise<Option.Option<Bookmark[]>>;
   deleteByID(id: {
     noteID: ID<NoteID>;
-    accountID: ID<AccountID>;
+    accountID: AccountID;
   }): Promise<Result.Result<Error, void>>;
 }

--- a/pkg/notes/service/create.test.ts
+++ b/pkg/notes/service/create.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it } from 'vitest';
 
 import type { AccountID } from '../../accounts/model/account.js';
 import { SnowflakeIDGenerator } from '../../id/mod.js';
-import type { ID } from '../../id/type.js';
 import { InMemoryNoteRepository } from '../adaptor/repository/dummy.js';
 import { CreateService } from './create.js';
 
@@ -21,7 +20,7 @@ describe('CreateService', () => {
       'Hello world',
       '',
       Option.none(),
-      '1' as ID<AccountID>,
+      '1' as AccountID,
       'PUBLIC',
     );
 
@@ -33,7 +32,7 @@ describe('CreateService', () => {
       'a'.repeat(3001),
       '',
       Option.none(),
-      '1' as ID<AccountID>,
+      '1' as AccountID,
       'PUBLIC',
     );
 
@@ -45,7 +44,7 @@ describe('CreateService', () => {
       'Hello world',
       '',
       Option.none(),
-      '1' as ID<AccountID>,
+      '1' as AccountID,
       'DIRECT',
     );
 

--- a/pkg/notes/service/create.ts
+++ b/pkg/notes/service/create.ts
@@ -20,8 +20,7 @@ export class CreateService {
     }
     try {
       const note = Note.new({
-        // ToDo: Replace here
-        id: id[1] as ID<(typeof id)[1]>,
+        id: id[1] as ID<NoteID>,
         content: content,
         contentsWarningComment: contentsWarningComment,
         createdAt: new Date(),

--- a/pkg/notes/service/create.ts
+++ b/pkg/notes/service/create.ts
@@ -10,8 +10,8 @@ export class CreateService {
   async handle(
     content: string,
     contentsWarningComment: string,
-    sendTo: Option.Option<ID<AccountID>>,
-    authorID: ID<AccountID>,
+    sendTo: Option.Option<AccountID>,
+    authorID: AccountID,
     visibility: NoteVisibility,
   ): Promise<Result.Result<Error, Note>> {
     const id = this.idGenerator.generate<NoteID>();
@@ -20,7 +20,8 @@ export class CreateService {
     }
     try {
       const note = Note.new({
-        id: id[1],
+        // ToDo: Replace here
+        id: id[1] as ID<(typeof id)[1]>,
         content: content,
         contentsWarningComment: contentsWarningComment,
         createdAt: new Date(),

--- a/pkg/notes/service/createBookmark.test.ts
+++ b/pkg/notes/service/createBookmark.test.ts
@@ -1,4 +1,4 @@
-import { Result, Option } from '@mikuroxina/mini-fn';
+import { Option, Result } from '@mikuroxina/mini-fn';
 import { describe, expect, it } from 'vitest';
 
 import type { AccountID } from '../../accounts/model/account.js';
@@ -12,14 +12,14 @@ import { CreateBookmarkService } from './createBookmark.js';
 
 const noteID = 'noteID_1' as ID<NoteID>;
 const anotherNoteID = 'noteID_2' as ID<NoteID>;
-const accountID = 'accountID_1' as ID<AccountID>;
-const anotherAccountID = 'accountID_2' as ID<AccountID>;
+const accountID = 'accountID_1' as AccountID;
+const anotherAccountID = 'accountID_2' as AccountID;
 
 const bookmarkRepository = new InMemoryBookmarkRepository();
 const noteRepository = new InMemoryNoteRepository([
   Note.new({
     id: 'noteID_1' as ID<NoteID>,
-    authorID: '3' as ID<AccountID>,
+    authorID: '3' as AccountID,
     content: 'Hello world',
     contentsWarningComment: '',
     createdAt: new Date('2023-09-10T00:00:00Z'),
@@ -29,7 +29,7 @@ const noteRepository = new InMemoryNoteRepository([
   }),
   Note.new({
     id: 'noteID_2' as ID<NoteID>,
-    authorID: '3' as ID<AccountID>,
+    authorID: '3' as AccountID,
     content: 'Another note',
     contentsWarningComment: '',
     createdAt: new Date('2023-09-10T00:00:00Z'),

--- a/pkg/notes/service/createBookmark.ts
+++ b/pkg/notes/service/createBookmark.ts
@@ -16,7 +16,7 @@ export class CreateBookmarkService {
 
   async handle(
     noteID: ID<NoteID>,
-    accountID: ID<AccountID>,
+    accountID: AccountID,
   ): Promise<Result.Result<Error, Note>> {
     const note = await this.noteRepository.findByID(noteID);
     if (Option.isNone(note)) {

--- a/pkg/notes/service/deleteBookmark.test.ts
+++ b/pkg/notes/service/deleteBookmark.test.ts
@@ -9,7 +9,7 @@ import type { NoteID } from '../model/note.js';
 import { DeleteBookmarkService } from './deleteBookmark.js';
 
 const noteID = '1' as ID<NoteID>;
-const accountID = '1' as ID<AccountID>;
+const accountID = '1' as AccountID;
 
 const bookmarkRepository = new InMemoryBookmarkRepository([
   Bookmark.new({ noteID, accountID }),

--- a/pkg/notes/service/deleteBookmark.ts
+++ b/pkg/notes/service/deleteBookmark.ts
@@ -10,7 +10,7 @@ export class DeleteBookmarkService {
 
   async handle(
     noteID: ID<NoteID>,
-    accountID: ID<AccountID>,
+    accountID: AccountID,
   ): Promise<Result.Result<Error, void>> {
     return await this.bookmarkRepository.deleteByID({ noteID, accountID });
   }

--- a/pkg/notes/service/fetch.test.ts
+++ b/pkg/notes/service/fetch.test.ts
@@ -11,7 +11,7 @@ import { FetchService } from './fetch.js';
 
 const testNote = Note.new({
   id: '1' as ID<NoteID>,
-  authorID: '3' as ID<AccountID>,
+  authorID: '3' as AccountID,
   content: 'Hello world',
   contentsWarningComment: '',
   createdAt: new Date('2023-09-10T00:00:00Z'),
@@ -21,7 +21,7 @@ const testNote = Note.new({
 });
 const deletedNote = Note.reconstruct({
   id: '2' as ID<NoteID>,
-  authorID: '3' as ID<AccountID>,
+  authorID: '3' as AccountID,
   content: 'Hello world',
   contentsWarningComment: '',
   createdAt: new Date('2023-09-10T00:00:00Z'),
@@ -33,7 +33,7 @@ const deletedNote = Note.reconstruct({
 });
 const frozenUserNote = Note.reconstruct({
   id: '5' as ID<NoteID>,
-  authorID: '4' as ID<AccountID>,
+  authorID: '4' as AccountID,
   content: 'Hello world',
   contentsWarningComment: '',
   createdAt: new Date('2023-09-10T00:00:00Z'),
@@ -44,7 +44,7 @@ const frozenUserNote = Note.reconstruct({
   updatedAt: Option.none(),
 });
 const testAccount = Account.reconstruct({
-  id: '3' as ID<AccountID>,
+  id: '3' as AccountID,
   bio: '',
   frozen: 'normal',
   mail: '',
@@ -59,7 +59,7 @@ const testAccount = Account.reconstruct({
   updatedAt: undefined,
 });
 const frozenAccount = Account.reconstruct({
-  id: '4' as ID<AccountID>,
+  id: '4' as AccountID,
   bio: '',
   frozen: 'frozen',
   mail: '',

--- a/pkg/notes/service/fetchBookmark.test.ts
+++ b/pkg/notes/service/fetchBookmark.test.ts
@@ -11,15 +11,15 @@ import { FetchBookmarkService } from './fetchBookmark.js';
 const bookmarkRepository = new InMemoryBookmarkRepository([
   Bookmark.new({
     noteID: '1' as ID<NoteID>,
-    accountID: '10' as ID<AccountID>,
+    accountID: '10' as AccountID,
   }),
   Bookmark.new({
     noteID: '2' as ID<NoteID>,
-    accountID: '10' as ID<AccountID>,
+    accountID: '10' as AccountID,
   }),
   Bookmark.new({
     noteID: '2' as ID<NoteID>,
-    accountID: '20' as ID<AccountID>,
+    accountID: '20' as AccountID,
   }),
 ]);
 const fetchBookmarkService = new FetchBookmarkService(bookmarkRepository);
@@ -28,14 +28,14 @@ describe('FetchBookmarkService', () => {
   it('should fetch bookmark', async () => {
     const res = await fetchBookmarkService.fetchBookmarkByID(
       '1' as ID<NoteID>,
-      '10' as ID<AccountID>,
+      '10' as AccountID,
     );
     expect(Option.isSome(res)).toBe(true);
   });
 
   it('should fetch bookmarks by AccountID', async () => {
     const res = await fetchBookmarkService.fetchBookmarkByAccountID(
-      '10' as ID<AccountID>,
+      '10' as AccountID,
     );
     expect(Option.isSome(res)).toBe(true);
     expect(Option.unwrap(res).length).toBe(2);
@@ -44,7 +44,7 @@ describe('FetchBookmarkService', () => {
   it('bookmark not found', async () => {
     const res = await fetchBookmarkService.fetchBookmarkByID(
       '42' as ID<NoteID>,
-      '10' as ID<AccountID>,
+      '10' as AccountID,
     );
     expect(Option.isNone(res)).toBe(true);
   });

--- a/pkg/notes/service/fetchBookmark.ts
+++ b/pkg/notes/service/fetchBookmark.ts
@@ -11,7 +11,7 @@ export class FetchBookmarkService {
 
   async fetchBookmarkByID(
     noteID: ID<NoteID>,
-    accountID: ID<AccountID>,
+    accountID: AccountID,
   ): Promise<Option.Option<Bookmark>> {
     const bookmark = await this.bookmarkRepository.findByID({
       noteID,
@@ -25,7 +25,7 @@ export class FetchBookmarkService {
   }
 
   async fetchBookmarkByAccountID(
-    accountID: ID<AccountID>,
+    accountID: AccountID,
   ): Promise<Option.Option<Bookmark[]>> {
     const bookmarks = await this.bookmarkRepository.findByAccountID(accountID);
 

--- a/pkg/notes/service/renote.test.ts
+++ b/pkg/notes/service/renote.test.ts
@@ -10,7 +10,7 @@ import { RenoteService } from './renote.js';
 
 const originalNote = Note.new({
   id: '2' as ID<NoteID>,
-  authorID: '1' as ID<AccountID>,
+  authorID: '1' as AccountID,
   content: 'original note',
   contentsWarningComment: '',
   createdAt: new Date(),
@@ -32,7 +32,7 @@ describe('RenoteService', () => {
       '2' as ID<NoteID>,
       'renote',
       '',
-      '1' as ID<AccountID>,
+      '1' as AccountID,
       'PUBLIC',
     );
 
@@ -49,7 +49,7 @@ describe('RenoteService', () => {
       '2' as ID<NoteID>,
       'direct renote',
       '',
-      '1' as ID<AccountID>,
+      '1' as AccountID,
       'DIRECT',
     );
 
@@ -61,7 +61,7 @@ describe('RenoteService', () => {
       '3' as ID<NoteID>,
       'renote',
       '',
-      '1' as ID<AccountID>,
+      '1' as AccountID,
       'PUBLIC',
     );
 
@@ -80,7 +80,7 @@ describe('RenoteService', () => {
       '3' as ID<NoteID>,
       'renote',
       '',
-      '1' as ID<AccountID>,
+      '1' as AccountID,
       'PUBLIC',
     );
 
@@ -96,7 +96,7 @@ describe('RenoteService', () => {
       '2' as ID<NoteID>,
       'renote',
       '',
-      '1' as ID<AccountID>,
+      '1' as AccountID,
       'PUBLIC',
     );
 

--- a/pkg/notes/service/renote.ts
+++ b/pkg/notes/service/renote.ts
@@ -36,7 +36,7 @@ export class RenoteService {
     }
 
     const renote = Note.new({
-      id: Result.unwrap(id) as ID<(typeof id)[1]>,
+      id: Result.unwrap(id) as ID<NoteID>,
       authorID: authorID,
       content: content,
       contentsWarningComment: contentsWarningComment,

--- a/pkg/notes/service/renote.ts
+++ b/pkg/notes/service/renote.ts
@@ -17,7 +17,7 @@ export class RenoteService {
     originalNoteID: ID<NoteID>,
     content: string,
     contentsWarningComment: string,
-    authorID: ID<AccountID>,
+    authorID: AccountID,
     visibility: NoteVisibility,
   ): Promise<Result.Result<Error, Note>> {
     if (visibility === 'DIRECT') {
@@ -36,7 +36,7 @@ export class RenoteService {
     }
 
     const renote = Note.new({
-      id: Result.unwrap(id),
+      id: Result.unwrap(id) as ID<(typeof id)[1]>,
       authorID: authorID,
       content: content,
       contentsWarningComment: contentsWarningComment,

--- a/pkg/timeline/adaptor/controller/timeline.ts
+++ b/pkg/timeline/adaptor/controller/timeline.ts
@@ -31,9 +31,9 @@ export class TimelineController {
     Result.Result<Error, z.infer<typeof GetAccountTimelineResponseSchema>>
   > {
     const res = await this.accountTimelineService.handle(
-      targetId as ID<AccountID>,
+      targetId as AccountID,
       {
-        id: fromId as ID<AccountID>,
+        id: fromId as AccountID,
         hasAttachment,
         noNsfw,
         beforeId: beforeId as ID<string>,
@@ -44,7 +44,7 @@ export class TimelineController {
     }
     const accountNotes = Result.unwrap(res);
 
-    const accountIDSet = new Set<ID<AccountID>>(
+    const accountIDSet = new Set<AccountID>(
       accountNotes.map((v) => v.getAuthorID()),
     );
     const accountData = await Promise.all(
@@ -55,7 +55,7 @@ export class TimelineController {
     const accounts = accountData
       .filter((v) => Result.isOk(v))
       .map((v) => Result.unwrap(v));
-    const accountsMap = new Map<ID<AccountID>, Account>(
+    const accountsMap = new Map<AccountID, Account>(
       accounts.map((v) => [v.getID(), v]),
     );
 

--- a/pkg/timeline/adaptor/repository/dummy.ts
+++ b/pkg/timeline/adaptor/repository/dummy.ts
@@ -1,7 +1,6 @@
 import { Result } from '@mikuroxina/mini-fn';
 
 import type { AccountID } from '../../../accounts/model/account.js';
-import type { ID } from '../../../id/type.js';
 import type { Note } from '../../../notes/model/note.js';
 import type {
   FetchAccountTimelineFilter,
@@ -16,7 +15,7 @@ export class InMemoryTimelineRepository implements TimelineRepository {
   }
 
   async getAccountTimeline(
-    accountId: ID<AccountID>,
+    accountId: AccountID,
     filter: FetchAccountTimelineFilter,
   ): Promise<Result.Result<Error, Note[]>> {
     const accountNotes = [...this.data].filter(

--- a/pkg/timeline/adaptor/repository/prisma.ts
+++ b/pkg/timeline/adaptor/repository/prisma.ts
@@ -37,7 +37,7 @@ export class PrismaTimelineRepository implements TimelineRepository {
       return Note.reconstruct({
         id: v.id as ID<NoteID>,
         content: v.text,
-        authorID: v.authorId as ID<AccountID>,
+        authorID: v.authorId as AccountID,
         createdAt: v.createdAt,
         deletedAt: !v.deletedAt ? Option.none() : Option.some(v.deletedAt),
         contentsWarningComment: '',
@@ -53,7 +53,7 @@ export class PrismaTimelineRepository implements TimelineRepository {
   }
 
   async getAccountTimeline(
-    accountId: ID<AccountID>,
+    accountId: AccountID,
     filter: FetchAccountTimelineFilter,
   ): Promise<Result.Result<Error, Note[]>> {
     console.log(filter);

--- a/pkg/timeline/model/repository.ts
+++ b/pkg/timeline/model/repository.ts
@@ -5,7 +5,7 @@ import type { ID } from '../../id/type.js';
 import type { Note, NoteID } from '../../notes/model/note.js';
 
 export interface FetchAccountTimelineFilter {
-  id: ID<AccountID>;
+  id: AccountID;
   /** @default false */
   hasAttachment: boolean;
   /** @default false */
@@ -22,7 +22,7 @@ export interface TimelineRepository {
    * @param filter Filter for fetching notes
    * */
   getAccountTimeline(
-    accountId: ID<AccountID>,
+    accountId: AccountID,
     filter: FetchAccountTimelineFilter,
   ): Promise<Result.Result<Error, Note[]>>;
 }

--- a/pkg/timeline/service/account.test.ts
+++ b/pkg/timeline/service/account.test.ts
@@ -18,7 +18,7 @@ describe('AccountTimelineService', () => {
 
   const dummyPublicNote = Note.new({
     id: '1' as ID<NoteID>,
-    authorID: '100' as ID<AccountID>,
+    authorID: '100' as AccountID,
     content: 'Hello world',
     contentsWarningComment: '',
     createdAt: new Date(),
@@ -28,7 +28,7 @@ describe('AccountTimelineService', () => {
   });
   const dummyHomeNote = Note.new({
     id: '2' as ID<NoteID>,
-    authorID: '100' as ID<AccountID>,
+    authorID: '100' as AccountID,
     content: 'Hello world to Home',
     contentsWarningComment: '',
     createdAt: new Date(),
@@ -38,7 +38,7 @@ describe('AccountTimelineService', () => {
   });
   const dummyFollowersNote = Note.new({
     id: '3' as ID<NoteID>,
-    authorID: '100' as ID<AccountID>,
+    authorID: '100' as AccountID,
     content: 'Hello world to followers',
     contentsWarningComment: '',
     createdAt: new Date(),
@@ -48,16 +48,16 @@ describe('AccountTimelineService', () => {
   });
   const dummyDirectNote = Note.new({
     id: '4' as ID<NoteID>,
-    authorID: '100' as ID<AccountID>,
+    authorID: '100' as AccountID,
     content: 'Hello world to direct',
     contentsWarningComment: '',
     createdAt: new Date(),
     originalNoteID: Option.none(),
-    sendTo: Option.some('101' as ID<AccountID>),
+    sendTo: Option.some('101' as AccountID),
     visibility: 'DIRECT',
   });
   const dummyAccount1 = Account.new({
-    id: '101' as ID<AccountID>,
+    id: '101' as AccountID,
     bio: 'this is test user',
     mail: 'john@example.com',
     name: '@john@example.com',
@@ -91,8 +91,8 @@ describe('AccountTimelineService', () => {
     vi.spyOn(accountModule, 'fetchFollowers').mockImplementation(async () => {
       return Result.ok([partialAccount1]);
     });
-    const res = await accountTimelineService.handle('100' as ID<AccountID>, {
-      id: '101' as ID<AccountID>,
+    const res = await accountTimelineService.handle('100' as AccountID, {
+      id: '101' as AccountID,
       hasAttachment: false,
       noNsfw: false,
     });
@@ -109,8 +109,8 @@ describe('AccountTimelineService', () => {
     vi.spyOn(accountModule, 'fetchFollowers').mockImplementation(async () => {
       return Result.ok([partialAccount1]);
     });
-    const res = await accountTimelineService.handle('100' as ID<AccountID>, {
-      id: '0' as ID<AccountID>,
+    const res = await accountTimelineService.handle('100' as AccountID, {
+      id: '0' as AccountID,
       hasAttachment: false,
       noNsfw: false,
     });

--- a/pkg/timeline/service/account.ts
+++ b/pkg/timeline/service/account.ts
@@ -1,7 +1,6 @@
 import { Ether, Result } from '@mikuroxina/mini-fn';
 
 import type { AccountID } from '../../accounts/model/account.js';
-import type { ID } from '../../id/type.js';
 import type { Note } from '../../notes/model/note.js';
 import {
   type FetchAccountTimelineFilter,
@@ -26,7 +25,7 @@ export class AccountTimelineService {
   }
 
   async handle(
-    targetId: ID<AccountID>,
+    targetId: AccountID,
     filter: FetchAccountTimelineFilter,
   ): Promise<Result.Result<Error, Note[]>> {
     const res = await this.timelineRepository.getAccountTimeline(

--- a/pkg/timeline/service/noteVisibility.test.ts
+++ b/pkg/timeline/service/noteVisibility.test.ts
@@ -16,7 +16,7 @@ describe('NoteVisibilityService', () => {
 
   const dummyPublicNote = Note.new({
     id: '1' as ID<NoteID>,
-    authorID: '100' as ID<AccountID>,
+    authorID: '100' as AccountID,
     content: 'Hello world',
     contentsWarningComment: '',
     createdAt: new Date(),
@@ -26,7 +26,7 @@ describe('NoteVisibilityService', () => {
   });
   const dummyHomeNote = Note.new({
     id: '2' as ID<NoteID>,
-    authorID: '100' as ID<AccountID>,
+    authorID: '100' as AccountID,
     content: 'Hello world to Home',
     contentsWarningComment: '',
     createdAt: new Date(),
@@ -36,7 +36,7 @@ describe('NoteVisibilityService', () => {
   });
   const dummyFollowersNote = Note.new({
     id: '3' as ID<NoteID>,
-    authorID: '100' as ID<AccountID>,
+    authorID: '100' as AccountID,
     content: 'Hello world to followers',
     contentsWarningComment: '',
     createdAt: new Date(),
@@ -46,16 +46,16 @@ describe('NoteVisibilityService', () => {
   });
   const dummyDirectNote = Note.new({
     id: '4' as ID<NoteID>,
-    authorID: '100' as ID<AccountID>,
+    authorID: '100' as AccountID,
     content: 'Hello world to direct',
     contentsWarningComment: '',
     createdAt: new Date(),
     originalNoteID: Option.none(),
-    sendTo: Option.some('101' as ID<AccountID>),
+    sendTo: Option.some('101' as AccountID),
     visibility: 'DIRECT',
   });
   const dummyAccount1 = Account.new({
-    id: '101' as ID<AccountID>,
+    id: '101' as AccountID,
     bio: 'this is test user',
     mail: 'john@example.com',
     name: '@john@example.com',
@@ -88,7 +88,7 @@ describe('NoteVisibilityService', () => {
     for (const note of testObjects) {
       expect(
         await visibilityService.handle({
-          accountID: '100' as ID<AccountID>,
+          accountID: '100' as AccountID,
           note,
         }),
       ).toBe(true);
@@ -101,13 +101,13 @@ describe('NoteVisibilityService', () => {
     });
 
     const res = await visibilityService.handle({
-      accountID: '101' as ID<AccountID>,
+      accountID: '101' as AccountID,
       note: dummyDirectNote,
     });
     expect(res).toBe(true);
 
     const res2 = await visibilityService.handle({
-      accountID: '0' as ID<AccountID>,
+      accountID: '0' as AccountID,
       note: dummyDirectNote,
     });
     expect(res2).toBe(false);
@@ -120,21 +120,21 @@ describe('NoteVisibilityService', () => {
     // public
     expect(
       await visibilityService.handle({
-        accountID: '101' as ID<AccountID>,
+        accountID: '101' as AccountID,
         note: dummyPublicNote,
       }),
     ).toBe(true);
     // home
     expect(
       await visibilityService.handle({
-        accountID: '101' as ID<AccountID>,
+        accountID: '101' as AccountID,
         note: dummyHomeNote,
       }),
     ).toBe(true);
     // followers
     expect(
       await visibilityService.handle({
-        accountID: '101' as ID<AccountID>,
+        accountID: '101' as AccountID,
         note: dummyFollowersNote,
       }),
     ).toBe(true);
@@ -147,20 +147,20 @@ describe('NoteVisibilityService', () => {
 
     expect(
       await visibilityService.handle({
-        accountID: '102' as ID<AccountID>,
+        accountID: '102' as AccountID,
         note: dummyPublicNote,
       }),
     ).toBe(true);
     expect(
       await visibilityService.handle({
-        accountID: '102' as ID<AccountID>,
+        accountID: '102' as AccountID,
         note: dummyHomeNote,
       }),
     ).toBe(true);
 
     expect(
       await visibilityService.handle({
-        accountID: '102' as ID<AccountID>,
+        accountID: '102' as AccountID,
         note: dummyFollowersNote,
       }),
     ).toBe(false);
@@ -172,7 +172,7 @@ describe('NoteVisibilityService', () => {
     });
 
     const res = await visibilityService.handle({
-      accountID: '0' as ID<AccountID>,
+      accountID: '0' as AccountID,
       note: dummyPublicNote,
     });
     expect(res).toBe(true);

--- a/pkg/timeline/service/noteVisibility.ts
+++ b/pkg/timeline/service/noteVisibility.ts
@@ -1,13 +1,12 @@
 import { Ether, Option, Result } from '@mikuroxina/mini-fn';
 
 import type { AccountID } from '../../accounts/model/account.js';
-import type { ID } from '../../id/type.js';
 import { type AccountModule } from '../../intermodule/account.js';
 import type { Note } from '../../notes/model/note.js';
 
 export interface NoteVisibilityCheckArgs {
   // account id of the user who is trying to see the note
-  accountID: ID<AccountID>;
+  accountID: AccountID;
   note: Note;
 }
 


### PR DESCRIPTION
## What does this PR do?
- `ID<AccountID>`を`AccountID`に置き換え
  - `type AccountID = ID<Account>`になっています

## Additional information
- idgeneratorの型を変更しました.他のID系のリプレースが終わったら修正します
