### PR TITLE
feat: implement PrismaMediumRepository

### DIFF
--- a/pkg/drive/adaptor/repository/prisma.ts
+++ b/pkg/drive/adaptor/repository/prisma.ts
@@ -1,0 +1,95 @@
+import { Option, Result } from '@mikuroxina/mini-fn';
+import { type Prisma, type PrismaClient } from '@prisma/client';
+
+import type { AccountID } from '../../../accounts/model/account.js';
+import type { prismaClient } from '../../../adaptors/prisma.js';
+import type { ID } from '../../../id/type.js';
+import { Medium, type MediumID } from '../../model/medium.js';
+import type { MediaRepository } from '../../model/repository.js';
+
+type MediumPrismaArgs = Prisma.PromiseReturnType<
+  typeof prismaClient.medium.findUnique
+>;
+
+export class PrismaMediaRepository implements MediaRepository {
+  constructor(private readonly prisma: PrismaClient) {}
+  async create(medium: Medium): Promise<Result.Result<Error, void>> {
+    try {
+      await this.prisma.medium.create({
+        data: {
+          ...this.toPrismaArgs(medium),
+        },
+      });
+    } catch (e) {
+      return Result.err(e as Error);
+    }
+
+    return Result.ok(undefined);
+  }
+
+  async findById(id: MediumID): Promise<Option.Option<Medium>> {
+    const res = await this.prisma.medium.findUnique({
+      where: {
+        id,
+      },
+    });
+
+    if (!res) {
+      return Option.none();
+    }
+
+    return Option.some(this.fromPrismaArgs(res));
+  }
+
+  async findByAuthor(
+    authorId: ID<AccountID>,
+  ): Promise<Option.Option<Medium[]>> {
+    try {
+      const res = await this.prisma.medium.findMany({
+        where: {
+          authorId,
+        },
+        orderBy: {
+          createdAt: 'desc',
+        },
+      });
+      return Option.some(res.map((v) => this.fromPrismaArgs(v)));
+    } catch {
+      return Option.none();
+    }
+  }
+
+  private toPrismaArgs(medium: Medium): Prisma.MediumCreateInput {
+    return {
+      id: medium.getId(),
+      name: medium.getName(),
+      author: {
+        connect: {
+          id: medium.getAuthorId(),
+        },
+      },
+      hash: medium.getHash(),
+      mime: medium.getMime(),
+      nsfw: medium.isNsfw(),
+      url: medium.getUrl(),
+      thumbnailUrl: medium.getThumbnailUrl(),
+    };
+  }
+
+  private fromPrismaArgs(args: MediumPrismaArgs): Medium {
+    if (args === null) {
+      throw new Error('failed to serialize');
+    }
+
+    return Medium.reconstruct({
+      id: args.id as ID<MediumID>,
+      name: args.name,
+      authorId: args.authorId as ID<AccountID>,
+      hash: args.hash,
+      mime: args.mime,
+      nsfw: args.nsfw,
+      url: args.url,
+      thumbnailUrl: args.thumbnailUrl,
+    });
+  }
+}

--- a/prisma/migrations/20240616102542_add_medium_columns/migration.sql
+++ b/prisma/migrations/20240616102542_add_medium_columns/migration.sql
@@ -1,0 +1,12 @@
+/*
+  Warnings:
+
+  - Added the required column `hash` to the `medium` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `nsfw` to the `medium` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `thumbnailUrl` to the `medium` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "medium" ADD COLUMN     "hash" TEXT NOT NULL,
+ADD COLUMN     "nsfw" BOOLEAN NOT NULL,
+ADD COLUMN     "thumbnailUrl" TEXT NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -131,8 +131,11 @@ model Medium {
   id             String           @id
   name           String
   mime           String
+  hash           String
+  nsfw           Boolean
   authorId       String           @map("author_id")
   author         Account          @relation(fields: [authorId], references: [id])
+  thumbnailUrl   String
   url            String
   createdAt      DateTime         @default(now()) @map("created_at")
   deletedAt      DateTime?        @map("deleted_at")


### PR DESCRIPTION
## What does this PR do?

-`PrismaMediumRepository`の実装
- Prismaのスキーマに追加されていなかったレコードを追加，マイグレーション