### PR TITLE
feat: impl CreateList API Endpoint

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -6,9 +6,10 @@ import { cors } from 'hono/cors';
 import { accounts } from './pkg/accounts/mod.js';
 import { drive } from './pkg/drive/mod.js';
 import { noteHandlers } from './pkg/notes/mod.js';
+import { timeline } from './pkg/timeline/mod.js';
 
 export const app = new Hono().get('/doc', async (c) => {
-  const modulePath: string[] = ['accounts', 'notes', 'drive'];
+  const modulePath: string[] = ['accounts', 'notes', 'drive', 'timeline'];
   const basePath = 'http://localhost:3000/';
   const openAPIBase = {
     openapi: '3.0.0',
@@ -65,6 +66,7 @@ All routes must be "/"
 app.route('/', noteHandlers);
 app.route('/', accounts);
 app.route('/', drive);
+app.route('/', timeline);
 
 app.get(
   '/reference',

--- a/pkg/timeline/adaptor/controller/timeline.ts
+++ b/pkg/timeline/adaptor/controller/timeline.ts
@@ -6,9 +6,9 @@ import type { AccountModule } from '../../../intermodule/account.js';
 import type { NoteID } from '../../../notes/model/note.js';
 import type { AccountTimelineService } from '../../service/account.js';
 import type { CreateListService } from '../../service/createList.js';
-import {
-  type CreateListResponseSchema,
-  type GetAccountTimelineResponseSchema,
+import type {
+  CreateListResponseSchema,
+  GetAccountTimelineResponseSchema,
 } from '../validator/timeline.js';
 
 export class TimelineController {

--- a/pkg/timeline/adaptor/controller/timeline.ts
+++ b/pkg/timeline/adaptor/controller/timeline.ts
@@ -5,17 +5,24 @@ import type { Account, AccountID } from '../../../accounts/model/account.js';
 import type { AccountModule } from '../../../intermodule/account.js';
 import type { NoteID } from '../../../notes/model/note.js';
 import type { AccountTimelineService } from '../../service/account.js';
-import type { GetAccountTimelineResponseSchema } from '../validator/timeline.js';
+import type { CreateListService } from '../../service/createList.js';
+import {
+  type CreateListResponseSchema,
+  type GetAccountTimelineResponseSchema,
+} from '../validator/timeline.js';
 
 export class TimelineController {
   private readonly accountTimelineService: AccountTimelineService;
   private readonly accountModule: AccountModule;
+  private readonly createListService: CreateListService;
   constructor(args: {
     accountTimelineService: AccountTimelineService;
     accountModule: AccountModule;
+    createListService: CreateListService;
   }) {
     this.accountTimelineService = args.accountTimelineService;
     this.accountModule = args.accountModule;
+    this.createListService = args.createListService;
   }
 
   async getAccountTimeline(
@@ -82,5 +89,27 @@ export class TimelineController {
       });
 
     return Result.ok(result);
+  }
+
+  async createList(
+    title: string,
+    isPublic: boolean,
+    ownerId: string,
+  ): Promise<Result.Result<Error, z.infer<typeof CreateListResponseSchema>>> {
+    const res = await this.createListService.handle(
+      title,
+      isPublic,
+      ownerId as AccountID,
+    );
+    if (Result.isErr(res)) {
+      return res;
+    }
+
+    const unwrapped = Result.unwrap(res);
+    return Result.ok({
+      id: unwrapped.getId(),
+      title: unwrapped.getTitle(),
+      public: unwrapped.isPublic(),
+    });
   }
 }

--- a/pkg/timeline/adaptor/repository/dummy.test.ts
+++ b/pkg/timeline/adaptor/repository/dummy.test.ts
@@ -97,6 +97,23 @@ describe('InMemoryTimelineRepository', () => {
         .includes('DIRECT'),
     ).toBe(false);
   });
+
+  it('should fetch list timeline', async () => {
+    const actual = await repository.fetchListTimeline(['1' as NoteID]);
+    expect(Result.isOk(actual)).toBe(true);
+  });
+
+  it('should not return DIRECT notes', async () => {
+    const actual = await repository.fetchListTimeline([
+      '1' as NoteID,
+      '4' as NoteID,
+    ]);
+    expect(Result.unwrap(actual)).toStrictEqual([dummyPublicNote]);
+    expect(Result.unwrap(actual)).not.toStrictEqual([
+      dummyPublicNote,
+      dummyDirectNote,
+    ]);
+  });
 });
 
 describe('InMemoryListRepository', () => {
@@ -181,23 +198,6 @@ describe('InMemoryListRepository', () => {
     expect(Result.unwrap(actual)).toStrictEqual([
       '100' as AccountID,
       '101' as AccountID,
-    ]);
-  });
-
-  it('should fetch list timeline', async () => {
-    const actual = await repository.fetchListTimeline(['10' as NoteID]);
-    expect(Result.isOk(actual)).toBe(true);
-  });
-
-  it('should not return DIRECT notes', async () => {
-    const actual = await repository.fetchListTimeline([
-      '10' as NoteID,
-      '14' as NoteID,
-    ]);
-    expect(Result.unwrap(actual)).toStrictEqual([dummyPublicNote]);
-    expect(Result.unwrap(actual)).not.toStrictEqual([
-      dummyPublicNote,
-      dummyDirectNote,
     ]);
   });
 });

--- a/pkg/timeline/adaptor/repository/dummy.ts
+++ b/pkg/timeline/adaptor/repository/dummy.ts
@@ -2,9 +2,11 @@ import { Result } from '@mikuroxina/mini-fn';
 
 import type { AccountID } from '../../../accounts/model/account.js';
 import type { Note, NoteID } from '../../../notes/model/note.js';
+import type { List, ListID } from '../../model/list.js';
 import type {
   FetchAccountTimelineFilter,
   FetchHomeTimelineFilter,
+  ListRepository,
   TimelineRepository,
 } from '../../model/repository.js';
 
@@ -68,5 +70,76 @@ export class InMemoryTimelineRepository implements TimelineRepository {
   reset(data: readonly Note[] = []) {
     this.data.clear();
     this.data = new Map(data.map((v) => [v.getID(), v]));
+  }
+}
+
+export class InMemoryListRepository implements ListRepository {
+  private listData: Map<ListID, List>;
+  private notes: Map<NoteID, Note>;
+
+  constructor(data: readonly List[] = [], notes: readonly Note[] = []) {
+    this.listData = new Map(data.map((v) => [v.getId(), v]));
+    this.notes = new Map(notes.map((v) => [v.getID(), v]));
+  }
+
+  async create(list: List): Promise<Result.Result<Error, void>> {
+    if (this.listData.has(list.getId())) {
+      return Result.err(new Error('List already exists'));
+    }
+    this.listData.set(list.getId(), list);
+    return Result.ok(undefined);
+  }
+
+  async fetchList(listId: ListID): Promise<Result.Result<Error, List>> {
+    const list = this.listData.get(listId);
+    if (!list) {
+      return Result.err(new Error('Not found'));
+    }
+    return Result.ok(list);
+  }
+
+  async fetchListsByOwnerId(
+    ownerId: AccountID,
+  ): Promise<Result.Result<Error, List[]>> {
+    const lists = [...this.listData].filter(
+      (list) => list[1].getOwnerId() === ownerId,
+    );
+    return Result.ok(lists.map((list) => list[1]));
+  }
+
+  async fetchListMembers(
+    listId: ListID,
+  ): Promise<Result.Result<Error, AccountID[]>> {
+    const list = this.listData.get(listId);
+    if (!list) {
+      return Result.err(new Error('Not found'));
+    }
+    return Result.ok(list.getMemberIds() as AccountID[]);
+  }
+
+  async fetchListTimeline(
+    noteId: NoteID[],
+  ): Promise<Result.Result<Error, Note[]>> {
+    const notes: Note[] = [];
+    for (const noteID of noteId) {
+      const n = this.notes.get(noteID);
+      if (!n) {
+        return Result.err(new Error('Not found'));
+      }
+      notes.push(n);
+    }
+
+    // NOTE: filter out DIRECT notes
+    // ToDo: Consider whether to filter out when Visibility is ‘FOLLOWERS’.
+    const filtered = notes.filter((note) => note.getVisibility() !== 'DIRECT');
+
+    return Result.ok(filtered);
+  }
+
+  reset(data: readonly List[] = [], notes: readonly Note[] = []) {
+    this.listData.clear();
+    this.notes.clear();
+    this.listData = new Map(data.map((v) => [v.getId(), v]));
+    this.notes = new Map(notes.map((v) => [v.getID(), v]));
   }
 }

--- a/pkg/timeline/adaptor/repository/dummy.ts
+++ b/pkg/timeline/adaptor/repository/dummy.ts
@@ -68,7 +68,7 @@ export class InMemoryTimelineRepository implements TimelineRepository {
   }
 
   async fetchListTimeline(
-    noteId: NoteID[],
+    noteId: readonly NoteID[],
   ): Promise<Result.Result<Error, Note[]>> {
     const notes: Note[] = [];
     for (const noteID of noteId) {

--- a/pkg/timeline/adaptor/repository/dummy.ts
+++ b/pkg/timeline/adaptor/repository/dummy.ts
@@ -67,6 +67,25 @@ export class InMemoryTimelineRepository implements TimelineRepository {
     return Result.ok(filtered.slice(0, beforeIndex));
   }
 
+  async fetchListTimeline(
+    noteId: NoteID[],
+  ): Promise<Result.Result<Error, Note[]>> {
+    const notes: Note[] = [];
+    for (const noteID of noteId) {
+      const n = this.data.get(noteID);
+      if (!n) {
+        return Result.err(new Error('Not found'));
+      }
+      notes.push(n);
+    }
+
+    // NOTE: filter out DIRECT notes
+    // ToDo: Consider whether to filter out when Visibility is ‘FOLLOWERS’.
+    const filtered = notes.filter((note) => note.getVisibility() !== 'DIRECT');
+
+    return Result.ok(filtered);
+  }
+
   reset(data: readonly Note[] = []) {
     this.data.clear();
     this.data = new Map(data.map((v) => [v.getID(), v]));
@@ -115,25 +134,6 @@ export class InMemoryListRepository implements ListRepository {
       return Result.err(new Error('Not found'));
     }
     return Result.ok(list.getMemberIds() as AccountID[]);
-  }
-
-  async fetchListTimeline(
-    noteId: NoteID[],
-  ): Promise<Result.Result<Error, Note[]>> {
-    const notes: Note[] = [];
-    for (const noteID of noteId) {
-      const n = this.notes.get(noteID);
-      if (!n) {
-        return Result.err(new Error('Not found'));
-      }
-      notes.push(n);
-    }
-
-    // NOTE: filter out DIRECT notes
-    // ToDo: Consider whether to filter out when Visibility is ‘FOLLOWERS’.
-    const filtered = notes.filter((note) => note.getVisibility() !== 'DIRECT');
-
-    return Result.ok(filtered);
   }
 
   reset(data: readonly List[] = [], notes: readonly Note[] = []) {

--- a/pkg/timeline/adaptor/repository/prisma.ts
+++ b/pkg/timeline/adaptor/repository/prisma.ts
@@ -92,4 +92,21 @@ export class PrismaTimelineRepository implements TimelineRepository {
     });
     return Result.ok(this.deserialize(homeNotes));
   }
+
+  async fetchListTimeline(
+    noteIDs: NoteID[],
+  ): Promise<Result.Result<Error, Note[]>> {
+    // ToDo: Add filter
+    const listNotes = await this.prisma.note.findMany({
+      where: {
+        id: {
+          in: noteIDs,
+        },
+      },
+      orderBy: {
+        createdAt: 'desc',
+      },
+    });
+    return Result.ok(this.deserialize(listNotes));
+  }
 }

--- a/pkg/timeline/adaptor/repository/prisma.ts
+++ b/pkg/timeline/adaptor/repository/prisma.ts
@@ -94,13 +94,14 @@ export class PrismaTimelineRepository implements TimelineRepository {
   }
 
   async fetchListTimeline(
-    noteIDs: NoteID[],
+    noteIDs: readonly NoteID[],
   ): Promise<Result.Result<Error, Note[]>> {
     // ToDo: Add filter
     const listNotes = await this.prisma.note.findMany({
       where: {
         id: {
-          in: noteIDs,
+          // NOTE: prisma requires non-readonly Array in here
+          in: noteIDs as NoteID[],
         },
       },
       orderBy: {

--- a/pkg/timeline/adaptor/validator/timeline.ts
+++ b/pkg/timeline/adaptor/validator/timeline.ts
@@ -36,3 +36,34 @@ export const GetAccountTimelineResponseSchema = z
     }),
   )
   .openapi('GetAccountTimelineResponse');
+
+export const CreateListRequestSchema = z
+  .object({
+    title: z.string().openapi({
+      example: 'Pulsate developers',
+      description: 'List title (1-100 characters)',
+    }),
+    public: z.boolean().pipe(z.coerce.boolean().default(false)).openapi({
+      type: 'boolean',
+      example: false,
+      description: 'If true, list is public',
+    }),
+  })
+  .openapi('CreateListRequest');
+export const CreateListResponseSchema = z
+  .object({
+    id: z.string().openapi({
+      example: '38477395',
+      description: 'List ID',
+    }),
+    title: z.string().openapi({
+      example: 'Pulsate developers',
+      description: 'List title',
+    }),
+    public: z.boolean().pipe(z.coerce.boolean().default(false)).openapi({
+      type: 'boolean',
+      example: false,
+      description: 'If true, list is public',
+    }),
+  })
+  .openapi('CreateListResponse');

--- a/pkg/timeline/model/repository.ts
+++ b/pkg/timeline/model/repository.ts
@@ -2,6 +2,8 @@ import { Ether, type Result } from '@mikuroxina/mini-fn';
 
 import type { AccountID } from '../../accounts/model/account.js';
 import type { Note, NoteID } from '../../notes/model/note.js';
+import type { ListID } from './list.js';
+import { type List } from './list.js';
 
 export interface FetchAccountTimelineFilter {
   id: AccountID;
@@ -51,3 +53,13 @@ export interface TimelineNotesCacheRepository {
 }
 export const timelineNotesCacheRepoSymbol =
   Ether.newEtherSymbol<TimelineNotesCacheRepository>();
+
+export interface ListRepository {
+  create(list: List): Promise<Result.Result<Error, void>>;
+  fetchList(listId: ListID): Promise<Result.Result<Error, List>>;
+  fetchListsByOwnerId(
+    ownerId: AccountID,
+  ): Promise<Result.Result<Error, List[]>>;
+  fetchListMembers(listId: ListID): Promise<Result.Result<Error, AccountID[]>>;
+  fetchListTimeline(noteId: NoteID[]): Promise<Result.Result<Error, Note[]>>;
+}

--- a/pkg/timeline/model/repository.ts
+++ b/pkg/timeline/model/repository.ts
@@ -3,7 +3,7 @@ import { Ether, type Result } from '@mikuroxina/mini-fn';
 import type { AccountID } from '../../accounts/model/account.js';
 import type { Note, NoteID } from '../../notes/model/note.js';
 import type { ListID } from './list.js';
-import { type List } from './list.js';
+import type { List } from './list.js';
 
 export interface FetchAccountTimelineFilter {
   id: AccountID;

--- a/pkg/timeline/model/repository.ts
+++ b/pkg/timeline/model/repository.ts
@@ -2,8 +2,7 @@ import { Ether, type Result } from '@mikuroxina/mini-fn';
 
 import type { AccountID } from '../../accounts/model/account.js';
 import type { Note, NoteID } from '../../notes/model/note.js';
-import type { ListID } from './list.js';
-import type { List } from './list.js';
+import type { List, ListID } from './list.js';
 
 export interface FetchAccountTimelineFilter {
   id: AccountID;
@@ -37,6 +36,12 @@ export interface TimelineRepository {
     noteIDs: readonly NoteID[],
     filter: FetchAccountTimelineFilter,
   ): Promise<Result.Result<Error, Note[]>>;
+
+  /**
+   * @description Fetch list timeline
+   * @param noteId IDs of the notes to be fetched
+   * */
+  fetchListTimeline(noteId: NoteID[]): Promise<Result.Result<Error, Note[]>>;
 }
 export const timelineRepoSymbol = Ether.newEtherSymbol<TimelineRepository>();
 
@@ -61,5 +66,4 @@ export interface ListRepository {
     ownerId: AccountID,
   ): Promise<Result.Result<Error, List[]>>;
   fetchListMembers(listId: ListID): Promise<Result.Result<Error, AccountID[]>>;
-  fetchListTimeline(noteId: NoteID[]): Promise<Result.Result<Error, Note[]>>;
 }

--- a/pkg/timeline/model/repository.ts
+++ b/pkg/timeline/model/repository.ts
@@ -41,7 +41,9 @@ export interface TimelineRepository {
    * @description Fetch list timeline
    * @param noteId IDs of the notes to be fetched
    * */
-  fetchListTimeline(noteId: NoteID[]): Promise<Result.Result<Error, Note[]>>;
+  fetchListTimeline(
+    noteId: readonly NoteID[],
+  ): Promise<Result.Result<Error, Note[]>>;
 }
 export const timelineRepoSymbol = Ether.newEtherSymbol<TimelineRepository>();
 

--- a/pkg/timeline/router.ts
+++ b/pkg/timeline/router.ts
@@ -1,7 +1,11 @@
 import { createRoute, z } from '@hono/zod-openapi';
 
 import { CommonErrorResponseSchema } from '../accounts/adaptor/validator/schema.js';
-import { GetAccountTimelineResponseSchema } from './adaptor/validator/timeline.js';
+import {
+  CreateListRequestSchema,
+  CreateListResponseSchema,
+  GetAccountTimelineResponseSchema,
+} from './adaptor/validator/timeline.js';
 
 export const GetAccountTimelineRoute = createRoute({
   method: 'get',
@@ -104,6 +108,35 @@ export const DropNoteFromTimelineRoute = createRoute({
     },
     500: {
       description: 'Task failed',
+    },
+  },
+});
+
+export const CreateListRoute = createRoute({
+  method: 'post',
+  tags: ['timeline'],
+  path: '/lists',
+  request: {
+    body: {
+      content: { 'application/json': { schema: CreateListRequestSchema } },
+    },
+  },
+  responses: {
+    200: {
+      content: {
+        'application/json': {
+          schema: CreateListResponseSchema,
+        },
+      },
+      description: 'OK',
+    },
+    400: {
+      content: {
+        'application/json': {
+          schema: CommonErrorResponseSchema,
+        },
+      },
+      description: 'TITLE_TOO_LONG',
     },
   },
 });

--- a/pkg/timeline/service/createList.test.ts
+++ b/pkg/timeline/service/createList.test.ts
@@ -1,0 +1,27 @@
+import { Result } from '@mikuroxina/mini-fn';
+import { describe, expect, it } from 'vitest';
+
+import type { AccountID } from '../../accounts/model/account.js';
+import { SnowflakeIDGenerator } from '../../id/mod.js';
+import { InMemoryListRepository } from '../adaptor/repository/dummy.js';
+import { CreateListService } from './createList.js';
+
+describe('CreateListService', () => {
+  const repository = new InMemoryListRepository();
+  const service = new CreateListService(
+    new SnowflakeIDGenerator(0, {
+      now: () => BigInt(Date.UTC(2023, 9, 10, 0, 0)),
+    }),
+    repository,
+  );
+
+  it('should create a list', async () => {
+    const res = await service.handle('Hello world', true, '1' as AccountID);
+
+    expect(Result.isOk(res)).toBe(true);
+    const unwrapped = Result.unwrap(res);
+    expect(unwrapped.getTitle()).toBe('Hello world');
+    expect(unwrapped.isPublic()).toBe(true);
+    expect(unwrapped.getOwnerId()).toBe('1');
+  });
+});

--- a/pkg/timeline/service/createList.ts
+++ b/pkg/timeline/service/createList.ts
@@ -22,7 +22,7 @@ export class CreateListService {
     }
 
     const list = List.new({
-      id: id[1],
+      id: Result.unwrap(id),
       title,
       publicity: isPublic ? 'PUBLIC' : 'PRIVATE',
       ownerId,

--- a/pkg/timeline/service/createList.ts
+++ b/pkg/timeline/service/createList.ts
@@ -1,0 +1,40 @@
+import { Result } from '@mikuroxina/mini-fn';
+
+import type { AccountID } from '../../accounts/model/account.js';
+import type { SnowflakeIDGenerator } from '../../id/mod.js';
+import { List } from '../model/list.js';
+import type { ListRepository } from '../model/repository.js';
+
+export class CreateListService {
+  constructor(
+    private readonly idGenerator: SnowflakeIDGenerator,
+    private readonly listRepository: ListRepository,
+  ) {}
+
+  async handle(
+    title: string,
+    isPublic: boolean,
+    ownerId: AccountID,
+  ): Promise<Result.Result<Error, List>> {
+    const id = this.idGenerator.generate<List>();
+    if (Result.isErr(id)) {
+      return id;
+    }
+
+    const list = List.new({
+      id: id[1],
+      title,
+      publicity: isPublic ? 'PUBLIC' : 'PRIVATE',
+      ownerId,
+      memberIds: [] as const,
+      createdAt: new Date(),
+    });
+
+    const res = await this.listRepository.create(list);
+    if (Result.isErr(res)) {
+      return res;
+    }
+
+    return Result.ok(list);
+  }
+}

--- a/resources/schema.json
+++ b/resources/schema.json
@@ -356,6 +356,134 @@
         "items": {
           "$ref": "#/components/schemas/GetAccountResponse"
         }
+      },
+      "GetAccountTimelineResponse": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "Note ID",
+              "example": "38477395"
+            },
+            "content": {
+              "type": "string",
+              "description": "Note content",
+              "example": "hello world!"
+            },
+            "contents_warning_comment": {
+              "type": "string",
+              "description": "Contents warning comment",
+              "example": "(if length not 0) This note contains sensitive content"
+            },
+            "visibility": {
+              "type": "string",
+              "description": "Note visibility (PUBLIC/HOME/FOLLOWERS/DIRECT)",
+              "example": "PUBLIC"
+            },
+            "created_at": {
+              "type": "string",
+              "format": "date-time",
+              "description": "Note created date",
+              "example": "2021-01-01T00:00:00Z"
+            },
+            "author": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "display_name": {
+                  "type": "string"
+                },
+                "bio": {
+                  "type": "string"
+                },
+                "avatar": {
+                  "type": "string"
+                },
+                "header": {
+                  "type": "string"
+                },
+                "followed_count": {
+                  "type": "number"
+                },
+                "following_count": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "id",
+                "name",
+                "display_name",
+                "bio",
+                "avatar",
+                "header",
+                "followed_count",
+                "following_count"
+              ]
+            }
+          },
+          "required": [
+            "id",
+            "content",
+            "contents_warning_comment",
+            "visibility",
+            "created_at",
+            "author"
+          ]
+        }
+      },
+      "Account ID": {
+        "type": "string"
+      },
+      "CreateListResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "List ID",
+            "example": "38477395"
+          },
+          "title": {
+            "type": "string",
+            "description": "List title",
+            "example": "Pulsate developers"
+          },
+          "public": {
+            "type": "boolean",
+            "description": "If true, list is public",
+            "example": false
+          }
+        },
+        "required": [
+          "id",
+          "title",
+          "public"
+        ]
+      },
+      "CreateListRequest": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "description": "List title (1-100 characters)",
+            "example": "Pulsate developers"
+          },
+          "public": {
+            "type": "boolean",
+            "description": "If true, list is public",
+            "example": false
+          }
+        },
+        "required": [
+          "title",
+          "public"
+        ]
       }
     },
     "parameters": {}
@@ -2223,6 +2351,166 @@
           },
           "404": {
             "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "default": "",
+                      "description": "Error code",
+                      "example": "TEST_ERROR_CODE"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/timeline/accounts/:id": {
+      "get": {
+        "tags": [
+          "timeline"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "$ref": "#/components/schemas/Account ID"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "boolean",
+              "description": "If true, only return notes with attachment"
+            },
+            "required": false,
+            "name": "has_attachment",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "boolean",
+              "description": "If true, only return notes without sensitive content"
+            },
+            "required": false,
+            "name": "no_nsfw",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Return notes before this note ID. specified note ID is not included"
+            },
+            "required": false,
+            "name": "before_id",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetAccountTimelineResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Account not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "default": "",
+                      "description": "Error code",
+                      "example": "TEST_ERROR_CODE"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/timeline/": {
+      "post": {
+        "description": "",
+        "tags": [
+          "timeline"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  },
+                  "authorId": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "id",
+                  "authorId"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/lists": {
+      "post": {
+        "tags": [
+          "timeline"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateListRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateListResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "TITLE_TOO_LONG",
             "content": {
               "application/json": {
                 "schema": {


### PR DESCRIPTION
## What does this PR do?
close #559 
- アカウントリストタイムラインを作成できるように
  - Serviceの実装
  - APIエンドポイントの定義と実装
  - Controllerの追加
- APIスキーマの更新

## Additional information
- Timelineとパスが違う(`/timeline`/`/lists`)が、機能的に一緒なのでTimelineモジュールに置きました
  - Controller等の実装もまとめています
- `ownerId`はダミー値を入れています (maybe fixed by #511 )