### PR TITLE
feat: implement DeleteList API endpoint

### DIFF
--- a/pkg/timeline/adaptor/controller/timeline.ts
+++ b/pkg/timeline/adaptor/controller/timeline.ts
@@ -4,8 +4,10 @@ import { Result } from '@mikuroxina/mini-fn';
 import type { Account, AccountID } from '../../../accounts/model/account.js';
 import type { AccountModule } from '../../../intermodule/account.js';
 import type { NoteID } from '../../../notes/model/note.js';
+import type { ListID } from '../../model/list.js';
 import type { AccountTimelineService } from '../../service/account.js';
 import type { CreateListService } from '../../service/createList.js';
+import type { DeleteListService } from '../../service/deleteList.js';
 import type {
   CreateListResponseSchema,
   GetAccountTimelineResponseSchema,
@@ -15,14 +17,17 @@ export class TimelineController {
   private readonly accountTimelineService: AccountTimelineService;
   private readonly accountModule: AccountModule;
   private readonly createListService: CreateListService;
+  private readonly deleteListService: DeleteListService;
   constructor(args: {
     accountTimelineService: AccountTimelineService;
     accountModule: AccountModule;
     createListService: CreateListService;
+    deleteListService: DeleteListService;
   }) {
     this.accountTimelineService = args.accountTimelineService;
     this.accountModule = args.accountModule;
     this.createListService = args.createListService;
+    this.deleteListService = args.deleteListService;
   }
 
   async getAccountTimeline(
@@ -111,5 +116,10 @@ export class TimelineController {
       title: unwrapped.getTitle(),
       public: unwrapped.isPublic(),
     });
+  }
+
+  async deleteList(id: string): Promise<Result.Result<Error, void>> {
+    const res = await this.deleteListService.handle(id as ListID);
+    return res;
   }
 }

--- a/pkg/timeline/adaptor/repository/dummy.ts
+++ b/pkg/timeline/adaptor/repository/dummy.ts
@@ -109,6 +109,13 @@ export class InMemoryListRepository implements ListRepository {
     return Result.ok(undefined);
   }
 
+  async deleteById(listId: ListID): Promise<Result.Result<Error, void>> {
+    if (!this.listData.delete(listId)) {
+      return Result.err(new Error('List not found'));
+    }
+    return Result.ok(undefined);
+  }
+
   async fetchList(listId: ListID): Promise<Result.Result<Error, List>> {
     const list = this.listData.get(listId);
     if (!list) {

--- a/pkg/timeline/mod.ts
+++ b/pkg/timeline/mod.ts
@@ -13,11 +13,13 @@ import {
 import { InMemoryTimelineCacheRepository } from './adaptor/repository/dummyCache.js';
 import {
   CreateListRoute,
+  DeleteListRoute,
   GetAccountTimelineRoute,
   PushNoteToTimelineRoute,
 } from './router.js';
 import { AccountTimelineService } from './service/account.js';
 import { CreateListService } from './service/createList.js';
+import { DeleteListService } from './service/deleteList.js';
 import { NoteVisibilityService } from './service/noteVisibility.js';
 import { PushTimelineService } from './service/push.js';
 
@@ -36,6 +38,7 @@ const controller = new TimelineController({
     timelineRepository: timelineRepository,
   }),
   createListService: new CreateListService(idGenerator, listRepository),
+  deleteListService: new DeleteListService(listRepository),
   accountModule,
 });
 const pushTimelineService = new PushTimelineService(
@@ -112,4 +115,15 @@ timeline.openapi(CreateListRoute, async (c) => {
   }
 
   return c.json(res[1], 200);
+});
+
+timeline.openapi(DeleteListRoute, async (c) => {
+  const { id } = c.req.valid('param');
+
+  const res = await controller.deleteList(id);
+  if (Result.isErr(res)) {
+    return c.json({ error: res[1].message }, 404);
+  }
+
+  return new Response(undefined, { status: 204 });
 });

--- a/pkg/timeline/model/repository.ts
+++ b/pkg/timeline/model/repository.ts
@@ -68,4 +68,5 @@ export interface ListRepository {
     ownerId: AccountID,
   ): Promise<Result.Result<Error, List[]>>;
   fetchListMembers(listId: ListID): Promise<Result.Result<Error, AccountID[]>>;
+  deleteById(listId: ListID): Promise<Result.Result<Error, void>>;
 }

--- a/pkg/timeline/router.ts
+++ b/pkg/timeline/router.ts
@@ -140,3 +140,27 @@ export const CreateListRoute = createRoute({
     },
   },
 });
+
+export const DeleteListRoute = createRoute({
+  method: 'delete',
+  tags: ['timeline'],
+  path: '/lists',
+  request: {
+    params: z.object({
+      id: z.string().openapi('List ID'),
+    }),
+  },
+  responses: {
+    204: {
+      description: 'OK',
+    },
+    404: {
+      content: {
+        'application/json': {
+          schema: CommonErrorResponseSchema,
+        },
+      },
+      description: 'LIST_NOTFOUND',
+    },
+  },
+});

--- a/pkg/timeline/service/deleteList.test.ts
+++ b/pkg/timeline/service/deleteList.test.ts
@@ -1,0 +1,31 @@
+import { Result } from '@mikuroxina/mini-fn';
+import { describe, expect, it } from 'vitest';
+import type { AccountID } from '../../accounts/model/account.js';
+import { InMemoryListRepository } from '../adaptor/repository/dummy.js';
+import { List, type ListID } from '../model/list.js';
+import { DeleteListService } from './deleteList.js';
+
+const testList = List.new({
+  id: '1' as ListID,
+  createdAt: new Date(2023, 9, 10, 0, 0),
+  memberIds: [],
+  ownerId: '' as AccountID,
+  publicity: 'PUBLIC',
+  title: 'Test List',
+});
+
+describe('DeleteListService', () => {
+  const repository = new InMemoryListRepository([testList]);
+  const service = new DeleteListService(repository);
+
+  it('should delete a list', async () => {
+    const res = await service.handle('1' as ListID);
+
+    expect(Result.isOk(res)).toBe(true);
+  });
+  it('should be error when try delete not existing list', async () => {
+    const res = await service.handle('2' as ListID);
+
+    expect(Result.isErr(res)).toBe(true);
+  });
+});

--- a/pkg/timeline/service/deleteList.ts
+++ b/pkg/timeline/service/deleteList.ts
@@ -1,0 +1,18 @@
+import { Result } from '@mikuroxina/mini-fn';
+import type { ID } from '../../id/type.js';
+import type { List } from '../model/list.js';
+import type { ListRepository } from '../model/repository.js';
+
+export class DeleteListService {
+  constructor(private readonly listRepository: ListRepository) {}
+
+  async handle(listId: ID<List>): Promise<Result.Result<Error, void>> {
+    const res = await this.listRepository.deleteById(listId);
+
+    if (Result.isErr(res)) {
+      return res;
+    }
+
+    return Result.ok(undefined);
+  }
+}

--- a/resources/schema.json
+++ b/resources/schema.json
@@ -484,6 +484,9 @@
           "title",
           "public"
         ]
+      },
+      "List ID": {
+        "type": "string"
       }
     },
     "parameters": {}
@@ -2511,6 +2514,47 @@
           },
           "400": {
             "description": "TITLE_TOO_LONG",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "default": "",
+                      "description": "Error code",
+                      "example": "TEST_ERROR_CODE"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "timeline"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "$ref": "#/components/schemas/List ID"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "OK"
+          },
+          "404": {
+            "description": "LIST_NOTFOUND",
             "content": {
               "application/json": {
                 "schema": {


### PR DESCRIPTION
## What does this PR do?

close #561 

- アカウントリストタイムラインの削除
  - `DeleteListService`の実装 c4dfa63d96d94e3e16d0cfd84525dc3f7a790b91
  - APIエンドポイントの定義・実装 c93ff897852cd0691fcf24cfea5d372ce2cb38ef b2e5739cc4ed61cb11df4e420d94f5493e7e4b81
  - `DeleteListService`をControllerの依存関係に追加 b0e3cfbc756d321b60db4b3aefe51a5cc5abef2f
- APIスキーマの更新
