### PR TITLE
feat: APIで操作したアカウントが空になっているのを修正

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -86,6 +86,4 @@ app.get(
   }),
 );
 
-app.get("/ddoc", swaggerUI({ url: "/doc" }));
-
 serve({ fetch: app.fetch, port: 3000 });

--- a/main.ts
+++ b/main.ts
@@ -7,12 +7,14 @@ import { accounts } from './pkg/accounts/mod.js';
 import { drive } from './pkg/drive/mod.js';
 import { noteHandlers } from './pkg/notes/mod.js';
 import { timeline } from './pkg/timeline/mod.js';
+import { swaggerUI } from '@hono/swagger-ui';
 
 export const app = new Hono().get('/doc', async (c) => {
+  // NOTE: If you create a new module, you must add module API doc base path here.
   const modulePath: string[] = ['accounts', 'notes', 'drive', 'timeline'];
   const basePath = 'http://localhost:3000/';
   const openAPIBase = {
-    openapi: '3.0.0',
+    openapi: '3.1.0',
     info: {
       description: '',
       title: 'Pulsate API Document',
@@ -25,6 +27,12 @@ export const app = new Hono().get('/doc', async (c) => {
       },
     ],
     components: {
+      securitySchemes: {
+        bearer: {
+          type: 'http',
+          scheme: 'bearer',
+        },
+      },
       schemas: {},
       parameters: {},
     },
@@ -77,5 +85,7 @@ app.get(
     },
   }),
 );
+
+app.get("/ddoc", swaggerUI({ url: "/doc" }));
 
 serve({ fetch: app.fetch, port: 3000 });

--- a/pkg/accounts/adaptor/controller/account.ts
+++ b/pkg/accounts/adaptor/controller/account.ts
@@ -254,11 +254,14 @@ export class AccountController {
     return Result.ok(undefined);
   }
 
-  async followAccount(name: string): Promise<Result.Result<Error, void>> {
+  async followAccount(
+    fromName: string,
+    targetName: string,
+  ): Promise<Result.Result<Error, void>> {
     // ToDo: get following account's name from request
     const res = await this.followService.handle(
-      '' as AccountName,
-      name as AccountName,
+      fromName as AccountName,
+      targetName as AccountName,
     );
     if (Result.isErr(res)) {
       return res;
@@ -267,10 +270,13 @@ export class AccountController {
     return Result.ok(undefined);
   }
 
-  async unFollowAccount(name: string): Promise<Result.Result<Error, void>> {
+  async unFollowAccount(
+    fromName: string,
+    targetName: string,
+  ): Promise<Result.Result<Error, void>> {
     const res = await this.unFollowService.handle(
-      name as AccountName,
-      '' as AccountName,
+      fromName as AccountName,
+      targetName as AccountName,
     );
 
     if (Option.isSome(res)) {
@@ -300,6 +306,7 @@ export class AccountController {
     if (Result.isErr(res)) {
       return res;
     }
+    // ToDo: use fetchManyAccountsByID
     const accounts = await Promise.all(
       res[1].map((v) => this.fetchService.fetchAccountByID(v.getTargetID())),
     );

--- a/pkg/accounts/adaptor/repository/prisma.ts
+++ b/pkg/accounts/adaptor/repository/prisma.ts
@@ -288,6 +288,7 @@ export class PrismaAccountFollowRepository implements AccountFollowRepository {
     targetID: AccountID,
   ): Promise<Result.Result<Error, void>> {
     try {
+      // ToDo: use hard delete (Because it is a composite primary key, it will never be possible to follow it back again.)
       await this.prisma.following.update({
         where: {
           fromId_toId: {

--- a/pkg/accounts/mod.ts
+++ b/pkg/accounts/mod.ts
@@ -163,8 +163,13 @@ const AuthMiddleware = await Ether.runEtherT(
   ).value,
 );
 
-accounts.doc('/accounts/doc.json', {
-  openapi: '3.0.0',
+accounts.openAPIRegistry.registerComponent('securitySchemes', 'Bearer', {
+  type: 'http',
+  scheme: 'bearer',
+});
+
+accounts.doc31('/accounts/doc.json', {
+  openapi: '3.1.0',
   info: {
     title: 'Accounts API',
     version: '0.1.0',

--- a/pkg/accounts/mod.ts
+++ b/pkg/accounts/mod.ts
@@ -1,5 +1,5 @@
 import { OpenAPIHono } from '@hono/zod-openapi';
-import { Cat, Ether, Promise, Result } from '@mikuroxina/mini-fn';
+import { Cat, Ether, Option, Promise, Result } from '@mikuroxina/mini-fn';
 
 import {
   type AuthMiddlewareVariable,
@@ -341,9 +341,10 @@ accounts[FollowAccountRoute.method](
   AuthMiddleware.handle({ forceAuthorized: true }),
 );
 accounts.openapi(FollowAccountRoute, async (c) => {
-  const name = c.req.param('name');
+  const targetName = c.req.param('name');
+  const fromName = Option.unwrap(c.get('accountName'));
 
-  const res = await controller.followAccount(name);
+  const res = await controller.followAccount(fromName, targetName);
   if (Result.isErr(res)) {
     return c.json({ error: res[1].message }, 403);
   }
@@ -356,9 +357,10 @@ accounts[UnFollowAccountRoute.method](
   AuthMiddleware.handle({ forceAuthorized: true }),
 );
 accounts.openapi(UnFollowAccountRoute, async (c) => {
-  const name = c.req.param('name');
+  const targetName = c.req.param('name');
+  const fromName = Option.unwrap(c.get('accountName'));
 
-  const res = await controller.unFollowAccount(name);
+  const res = await controller.unFollowAccount(fromName, targetName);
   if (Result.isErr(res)) {
     return c.json({ error: res[1].message }, 400);
   }

--- a/pkg/accounts/router.ts
+++ b/pkg/accounts/router.ts
@@ -60,6 +60,11 @@ export const UpdateAccountRoute = createRoute({
   method: 'patch',
   tags: ['accounts'],
   path: '/accounts/:name',
+  security: [
+    {
+      bearer: [],
+    },
+  ],
   request: {
     // ToDo: define ETag in header
     params: z.object({
@@ -125,6 +130,11 @@ export const FreezeAccountRoute = createRoute({
   method: 'put',
   tags: ['accounts'],
   path: '/accounts/:name/freeze',
+  security: [
+    {
+      bearer: [],
+    },
+  ],
   request: {
     params: z.object({
       name: z.string().min(3).max(64).openapi({
@@ -169,6 +179,11 @@ export const UnFreezeAccountRoute = createRoute({
   method: 'delete',
   tags: ['accounts'],
   path: '/accounts/:name/freeze',
+  security: [
+    {
+      bearer: [],
+    },
+  ],
   request: {
     params: z.object({
       name: z.string().min(3).max(64).openapi({
@@ -413,6 +428,11 @@ export const SilenceAccountRoute = createRoute({
   method: 'put',
   tags: ['accounts'],
   path: '/accounts/:name/silence',
+  security: [
+    {
+      bearer: [],
+    },
+  ],
   request: {
     params: z.object({
       name: z.string().min(3).max(64).openapi({
@@ -457,6 +477,11 @@ export const UnSilenceAccountRoute = createRoute({
   method: 'delete',
   tags: ['accounts'],
   path: '/accounts/:name/silence',
+  security: [
+    {
+      bearer: [],
+    },
+  ],
   request: {
     params: z.object({
       name: z.string().min(3).max(64).openapi({
@@ -501,6 +526,11 @@ export const FollowAccountRoute = createRoute({
   method: 'post',
   tags: ['accounts'],
   path: '/accounts/:name/follow',
+  security: [
+    {
+      bearer: [],
+    },
+  ],
   request: {
     params: z.object({
       name: z.string().min(3).max(64).openapi({
@@ -545,6 +575,11 @@ export const UnFollowAccountRoute = createRoute({
   method: 'delete',
   tags: ['accounts'],
   path: '/accounts/:name/follow',
+  security: [
+    {
+      bearer: [],
+    },
+  ],
   request: {
     params: z.object({
       name: z.string().min(3).max(64).openapi({

--- a/pkg/accounts/service/authenticate.ts
+++ b/pkg/accounts/service/authenticate.ts
@@ -56,6 +56,7 @@ export class AuthenticateService {
       Option.unwrap(account).getID(),
       convertTo(new Date()),
       convertTo(addSecondsToDate(new Date(), 900)),
+      Option.unwrap(account).getName(),
     );
 
     if (Option.isNone(authorizationToken)) {
@@ -66,6 +67,7 @@ export class AuthenticateService {
       Option.unwrap(account).getID(),
       convertTo(new Date()),
       convertTo(addSecondsToDate(new Date(), 2_592_000)),
+      Option.unwrap(account).getName(),
     );
 
     if (Option.isNone(refreshToken)) {

--- a/pkg/accounts/service/authenticate.ts
+++ b/pkg/accounts/service/authenticate.ts
@@ -53,7 +53,7 @@ export class AuthenticateService {
     }
 
     const authorizationToken = await this.authenticationTokenService.generate(
-      Option.unwrap(account).getName(),
+      Option.unwrap(account).getID(),
       convertTo(new Date()),
       convertTo(addSecondsToDate(new Date(), 900)),
     );
@@ -63,7 +63,7 @@ export class AuthenticateService {
     }
 
     const refreshToken = await this.authenticationTokenService.generate(
-      Option.unwrap(account).getName(),
+      Option.unwrap(account).getID(),
       convertTo(new Date()),
       convertTo(addSecondsToDate(new Date(), 2_592_000)),
     );

--- a/pkg/accounts/service/authenticationTokenService.test.ts
+++ b/pkg/accounts/service/authenticationTokenService.test.ts
@@ -12,6 +12,7 @@ describe('AuthenticationTokenService', () => {
       '',
       convertTo(new Date()),
       convertTo(new Date('2099-12-31T12:59:59Z')),
+      '',
     );
     if (Option.isNone(token)) {
       return;
@@ -25,6 +26,7 @@ describe('AuthenticationTokenService', () => {
       '',
       convertTo(new Date('2022-01-01T00:00:00Z')),
       convertTo(new Date('2022-01-02T00:00:00Z')),
+      '',
     );
     if (Option.isNone(expired)) return;
 

--- a/pkg/accounts/service/authenticationTokenService.ts
+++ b/pkg/accounts/service/authenticationTokenService.ts
@@ -27,8 +27,11 @@ export class AuthenticationTokenService {
     subject: string,
     issuedAt: PulsateTime,
     expiredAt: PulsateTime,
+    accountName: string,
   ): Promise<Option.Option<string>> {
-    const token = await new jose.SignJWT()
+    const token = await new jose.SignJWT({
+      accountName: accountName,
+    })
       .setProtectedHeader({ alg: 'ES256' })
       .setIssuedAt(issuedAt)
       .setSubject(subject)

--- a/pkg/accounts/service/freeze.ts
+++ b/pkg/accounts/service/freeze.ts
@@ -16,6 +16,7 @@ export class FreezeService {
   async setFreeze(
     accountName: AccountName,
   ): Promise<Result.Result<Error, boolean>> {
+    // ToDo: Check Account role(permission)
     const account = await this.accountRepository.findByName(accountName);
     if (Option.isNone(account)) {
       return Result.err(new Error('account not found'));
@@ -32,6 +33,7 @@ export class FreezeService {
   async undoFreeze(
     accountName: AccountName,
   ): Promise<Result.Result<Error, boolean>> {
+    // ToDo: Check Account role(permission)
     const account = await this.accountRepository.findByName(accountName);
     if (Option.isNone(account)) {
       return Result.err(new Error('account not found'));

--- a/pkg/adaptors/authenticateMiddleware.ts
+++ b/pkg/adaptors/authenticateMiddleware.ts
@@ -16,7 +16,7 @@ export type AuthMiddlewareVariable = {
   /*
    * @description account name, or none if not authorized
    */
-  accountName: Option.Option<string>;
+  accountID: Option.Option<string>;
 };
 
 export class AuthenticateMiddlewareService {
@@ -71,7 +71,7 @@ export class AuthenticateMiddlewareService {
         return c.json({ error: 'UNAUTHORIZED' }, { status: 401 });
       }
 
-      c.set('accountName', accountName);
+      c.set('accountID', accountName);
       return await next();
     });
   }

--- a/pkg/adaptors/authenticateMiddleware.ts
+++ b/pkg/adaptors/authenticateMiddleware.ts
@@ -14,9 +14,13 @@ export type AuthMiddlewareVariable = {
    */
   token: string;
   /*
-   * @description account name, or none if not authorized
+   * @description account id, or none if not authorized
    */
   accountID: Option.Option<string>;
+  /*
+   * @description account name, or none if not authorized
+   */
+  accountName: Option.Option<string>;
 };
 
 export class AuthenticateMiddlewareService {
@@ -26,15 +30,17 @@ export class AuthenticateMiddlewareService {
     this.authTokenService = authTokenService;
   }
 
-  private parseToken(token: string): Option.Option<string> {
+  private parseToken(
+    token: string,
+  ): Option.Option<{ sub: string; accountName: string }> {
     const split = token.split('.')[1];
     if (!split) {
       return Option.none();
     }
     const payload = JSON.parse(
       Buffer.from(split, 'base64').toString('utf-8'),
-    ) as { sub: string };
-    return Option.some(payload.sub);
+    ) as { sub: string; accountName: string };
+    return Option.some({ sub: payload.sub, accountName: payload.accountName });
   }
 
   /**
@@ -62,16 +68,18 @@ export class AuthenticateMiddlewareService {
       c.set('token', token);
 
       const isValidToken = await this.authTokenService.verify(token);
-      const accountName = this.parseToken(token);
+      const parsed = this.parseToken(token);
       if (!isValidToken) {
         return c.json({ error: 'UNAUTHORIZED' }, { status: 401 });
       }
 
-      if (Option.isNone(accountName)) {
+      if (Option.isNone(parsed)) {
         return c.json({ error: 'UNAUTHORIZED' }, { status: 401 });
       }
 
-      c.set('accountID', accountName);
+      const unwrapped = Option.unwrap(parsed);
+      c.set('accountID', Option.some(unwrapped.sub));
+      c.set('accountName', Option.some(unwrapped.accountName));
       return await next();
     });
   }

--- a/pkg/drive/router.ts
+++ b/pkg/drive/router.ts
@@ -8,6 +8,11 @@ export const GetMediaRoute = createRoute({
   path: '/drive',
   tags: ['drive'],
   summary: 'Get uploaded media',
+  security: [
+    {
+      bearer: [],
+    },
+  ],
   request: {},
   responses: {
     200: {

--- a/pkg/notes/adaptor/controller/bookmark.ts
+++ b/pkg/notes/adaptor/controller/bookmark.ts
@@ -41,6 +41,7 @@ export class BookmarkController {
     });
   }
 
+  // ToDo: add pagination, impl handler function
   async getBookmarkByID(
     noteID: string,
     accountID: string,
@@ -53,6 +54,7 @@ export class BookmarkController {
     return res;
   }
 
+  // ToDo: impl handler function
   async getBookmarkByAccountID(
     accountID: string,
   ): Promise<Option.Option<Bookmark[]>> {

--- a/pkg/notes/router.ts
+++ b/pkg/notes/router.ts
@@ -14,6 +14,11 @@ export const CreateNoteRoute = createRoute({
   method: 'post',
   tags: ['notes'],
   path: '/notes',
+  security: [
+    {
+      bearer: [],
+    },
+  ],
   request: {
     body: {
       content: {
@@ -88,6 +93,11 @@ export const RenoteRoute = createRoute({
   method: 'post',
   tags: ['notes'],
   path: '/notes/:id/renote',
+  security: [
+    {
+      bearer: [],
+    },
+  ],
   request: {
     params: z.object({
       id: z.string().openapi({
@@ -143,6 +153,11 @@ export const CreateBookmarkRoute = createRoute({
   method: 'post',
   tags: ['bookmark'],
   path: '/notes/:id/bookmark',
+  security: [
+    {
+      bearer: [],
+    },
+  ],
   request: {
     params: z.object({
       id: z.string().openapi({
@@ -175,6 +190,11 @@ export const DeleteBookmarkRoute = createRoute({
   method: 'delete',
   tags: ['bookmark'],
   path: '/notes/:id/bookmark',
+  security: [
+    {
+      bearer: [],
+    },
+  ],
   request: {
     params: z.object({
       id: z.string().openapi({

--- a/pkg/timeline/router.ts
+++ b/pkg/timeline/router.ts
@@ -66,6 +66,11 @@ export const CreateListRoute = createRoute({
   method: 'post',
   tags: ['timeline'],
   path: '/lists',
+  security: [
+    {
+      bearer: [],
+    },
+  ],
   request: {
     body: {
       content: { 'application/json': { schema: CreateListRequestSchema } },
@@ -95,6 +100,11 @@ export const DeleteListRoute = createRoute({
   method: 'delete',
   tags: ['timeline'],
   path: '/lists',
+  security: [
+    {
+      bearer: [],
+    },
+  ],
   request: {
     params: z.object({
       id: z.string().openapi('List ID'),

--- a/resources/schema.json
+++ b/resources/schema.json
@@ -1,5 +1,5 @@
 {
-  "openapi": "3.0.0",
+  "openapi": "3.1.0",
   "info": {
     "description": "",
     "title": "Pulsate API Document",
@@ -12,6 +12,12 @@
     }
   ],
   "components": {
+    "securitySchemes": {
+      "bearer": {
+        "type": "http",
+        "scheme": "bearer"
+      }
+    },
     "schemas": {
       "CreateAccountResponse": {
         "type": "object",
@@ -606,6 +612,11 @@
         "tags": [
           "accounts"
         ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
         "parameters": [
           {
             "schema": {
@@ -721,6 +732,11 @@
         "tags": [
           "accounts"
         ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
         "parameters": [
           {
             "schema": {
@@ -807,6 +823,11 @@
       "delete": {
         "tags": [
           "accounts"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
         ],
         "parameters": [
           {
@@ -1145,6 +1166,11 @@
         "tags": [
           "accounts"
         ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
         "parameters": [
           {
             "schema": {
@@ -1217,6 +1243,11 @@
       "delete": {
         "tags": [
           "accounts"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
         ],
         "parameters": [
           {
@@ -1293,6 +1324,11 @@
         "tags": [
           "accounts"
         ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
         "parameters": [
           {
             "schema": {
@@ -1365,6 +1401,11 @@
       "delete": {
         "tags": [
           "accounts"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
         ],
         "parameters": [
           {
@@ -1646,6 +1687,11 @@
       "post": {
         "tags": [
           "notes"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
         ],
         "requestBody": {
           "content": {
@@ -1955,6 +2001,11 @@
         "tags": [
           "notes"
         ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
         "parameters": [
           {
             "schema": {
@@ -2178,6 +2229,11 @@
         "tags": [
           "bookmark"
         ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
         "parameters": [
           {
             "schema": {
@@ -2268,6 +2324,11 @@
         "tags": [
           "bookmark"
         ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
         "parameters": [
           {
             "schema": {
@@ -2314,6 +2375,11 @@
           "drive"
         ],
         "summary": "Get uploaded media",
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
         "responses": {
           "200": {
             "description": "OK",
@@ -2485,44 +2551,15 @@
         }
       }
     },
-    "/timeline/": {
-      "post": {
-        "description": "",
-        "tags": [
-          "timeline"
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "id": {
-                    "type": "string"
-                  },
-                  "authorId": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "id",
-                  "authorId"
-                ]
-              }
-            }
-          }
-        },
-        "responses": {
-          "204": {
-            "description": "OK"
-          }
-        }
-      }
-    },
     "/lists": {
       "post": {
         "tags": [
           "timeline"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
         ],
         "requestBody": {
           "content": {
@@ -2570,6 +2607,11 @@
       "delete": {
         "tags": [
           "timeline"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
         ],
         "parameters": [
           {


### PR DESCRIPTION
## What does this PR do?
close #511 
- APIエンドポイントが認証を要求することを明示的に示すように
 - APIドキュメントの更新
 - OpenAPI Specのバージョンを`3.0.0`から`3.1.0`へ変更
   - `3.0.0`だとAPIリファレンスのページで正しい記載にならないため(ライブラリのバグ？)
- アクセス/リフレッシュトークンの`sub`を`accountID`に、`accountName`を追加
 - それに伴うミドルウェアの更新
- APIハンドラ側で固定 or 空になっていた操作者アカウントID or アカウント名をトークンから取得したものに置き換え

## Additional information

