### PR TITLE
feat: impl push note to list

### DIFF
--- a/pkg/timeline/adaptor/repository/dummy.ts
+++ b/pkg/timeline/adaptor/repository/dummy.ts
@@ -130,7 +130,7 @@ export class InMemoryListRepository implements ListRepository {
     const lists = [...this.listData.values()].filter((list) =>
       list.getMemberIds().includes(accountID),
     );
-    return Result.ok(lists.map((list) => list));
+    return Result.ok(lists);
   }
 
   async fetchListsByOwnerId(

--- a/pkg/timeline/adaptor/repository/dummy.ts
+++ b/pkg/timeline/adaptor/repository/dummy.ts
@@ -124,6 +124,15 @@ export class InMemoryListRepository implements ListRepository {
     return Result.ok(list);
   }
 
+  async fetchListsByMemberAccountID(
+    accountID: AccountID,
+  ): Promise<Result.Result<Error, List[]>> {
+    const lists = [...this.listData].filter((list) =>
+      list[1].getMemberIds().includes(accountID),
+    );
+    return Result.ok(lists.map((list) => list[1]));
+  }
+
   async fetchListsByOwnerId(
     ownerId: AccountID,
   ): Promise<Result.Result<Error, List[]>> {

--- a/pkg/timeline/adaptor/repository/dummy.ts
+++ b/pkg/timeline/adaptor/repository/dummy.ts
@@ -127,10 +127,10 @@ export class InMemoryListRepository implements ListRepository {
   async fetchListsByMemberAccountID(
     accountID: AccountID,
   ): Promise<Result.Result<Error, List[]>> {
-    const lists = [...this.listData].filter((list) =>
-      list[1].getMemberIds().includes(accountID),
+    const lists = [...this.listData.values()].filter((list) =>
+      list.getMemberIds().includes(accountID),
     );
-    return Result.ok(lists.map((list) => list[1]));
+    return Result.ok(lists.map((list) => list));
   }
 
   async fetchListsByOwnerId(

--- a/pkg/timeline/adaptor/repository/dummyCache.ts
+++ b/pkg/timeline/adaptor/repository/dummyCache.ts
@@ -2,6 +2,7 @@ import { Result } from '@mikuroxina/mini-fn';
 
 import type { AccountID } from '../../../accounts/model/account.js';
 import type { Note, NoteID } from '../../../notes/model/note.js';
+import type { ListID } from '../../model/list.js';
 import type {
   CacheObjectKey,
   TimelineNotesCacheRepository,
@@ -20,15 +21,41 @@ export class InMemoryTimelineCacheRepository
     );
   }
 
-  private generateObjectKey(accountID: AccountID): CacheObjectKey {
-    return `timeline:home:${accountID}`;
+  private generateObjectKey(
+    id: AccountID | ListID,
+    timelineType: 'home' | 'list',
+  ): CacheObjectKey {
+    return `timeline:${timelineType}:${id}`;
   }
 
   async addNotesToHomeTimeline(
     accountID: AccountID,
     notes: Note[],
   ): Promise<Result.Result<Error, void>> {
-    const objectKey = this.generateObjectKey(accountID);
+    const objectKey = this.generateObjectKey(accountID, 'home');
+    if (!this.data.has(objectKey)) {
+      this.data.set(
+        objectKey,
+        notes.map((note) => note.getID()),
+      );
+      return Result.ok(undefined);
+    }
+    // biome-ignore lint/style/noNonNullAssertion: Use assertion to avoid compile errors because type inference has failed.
+    const fetched = this.data.get(objectKey)!;
+    // NOTE: replace by updated object
+    this.data.delete(objectKey);
+
+    fetched.push(...notes.map((note) => note.getID()));
+    this.data.set(objectKey, fetched);
+
+    return Result.ok(undefined);
+  }
+
+  async addNotesToList(
+    listID: ListID,
+    notes: readonly Note[],
+  ): Promise<Result.Result<Error, void>> {
+    const objectKey = this.generateObjectKey(listID, 'list');
     if (!this.data.has(objectKey)) {
       this.data.set(
         objectKey,
@@ -50,10 +77,24 @@ export class InMemoryTimelineCacheRepository
   async getHomeTimeline(
     accountID: AccountID,
   ): Promise<Result.Result<Error, NoteID[]>> {
-    const fetched = this.data.get(this.generateObjectKey(accountID));
+    const fetched = this.data.get(this.generateObjectKey(accountID, 'home'));
     if (!fetched) {
       return Result.err(new Error('Not found'));
     }
     return Result.ok(fetched.sort());
+  }
+
+  async getListTimeline(
+    listID: ListID,
+  ): Promise<Result.Result<Error, NoteID[]>> {
+    const fetched = this.data.get(this.generateObjectKey(listID, 'list'));
+    if (!fetched) {
+      return Result.err(new Error('Not found'));
+    }
+    return Result.ok(fetched.sort());
+  }
+
+  reset(): void {
+    this.data.clear();
   }
 }

--- a/pkg/timeline/adaptor/repository/dummyCache.ts
+++ b/pkg/timeline/adaptor/repository/dummyCache.ts
@@ -33,13 +33,13 @@ export class InMemoryTimelineCacheRepository
     notes: Note[],
   ): Promise<Result.Result<Error, void>> {
     const newNoteIDs = notes.map((note) => note.getID());
-    if (!this.data.has(this.generateObjectKey(accountID, 'home'))) {
-      this.data.set(this.generateObjectKey(accountID, 'home'), newNoteIDs);
+    const objectKey = this.generateObjectKey(accountID, 'home');
+
+    if (!this.data.has(objectKey)) {
+      this.data.set(objectKey, newNoteIDs);
       return Result.ok(undefined);
     }
-    this.data
-      .get(this.generateObjectKey(accountID, 'home'))
-      ?.push(...newNoteIDs);
+    this.data.get(objectKey)?.push(...newNoteIDs);
 
     return Result.ok(undefined);
   }
@@ -49,11 +49,13 @@ export class InMemoryTimelineCacheRepository
     notes: readonly Note[],
   ): Promise<Result.Result<Error, void>> {
     const newNoteIDs = notes.map((note) => note.getID());
-    if (!this.data.has(this.generateObjectKey(listID, 'list'))) {
-      this.data.set(this.generateObjectKey(listID, 'list'), newNoteIDs);
+    const objectKey = this.generateObjectKey(listID, 'list');
+
+    if (!this.data.has(objectKey)) {
+      this.data.set(objectKey, newNoteIDs);
       return Result.ok(undefined);
     }
-    this.data.get(this.generateObjectKey(listID, 'list'))?.push(...newNoteIDs);
+    this.data.get(objectKey)?.push(...newNoteIDs);
 
     return Result.ok(undefined);
   }

--- a/pkg/timeline/adaptor/repository/dummyCache.ts
+++ b/pkg/timeline/adaptor/repository/dummyCache.ts
@@ -32,21 +32,14 @@ export class InMemoryTimelineCacheRepository
     accountID: AccountID,
     notes: Note[],
   ): Promise<Result.Result<Error, void>> {
-    const objectKey = this.generateObjectKey(accountID, 'home');
-    if (!this.data.has(objectKey)) {
-      this.data.set(
-        objectKey,
-        notes.map((note) => note.getID()),
-      );
+    const newNoteIDs = notes.map((note) => note.getID());
+    if (!this.data.has(this.generateObjectKey(accountID, 'home'))) {
+      this.data.set(this.generateObjectKey(accountID, 'home'), newNoteIDs);
       return Result.ok(undefined);
     }
-    // biome-ignore lint/style/noNonNullAssertion: Use assertion to avoid compile errors because type inference has failed.
-    const fetched = this.data.get(objectKey)!;
-    // NOTE: replace by updated object
-    this.data.delete(objectKey);
-
-    fetched.push(...notes.map((note) => note.getID()));
-    this.data.set(objectKey, fetched);
+    this.data
+      .get(this.generateObjectKey(accountID, 'home'))
+      ?.push(...newNoteIDs);
 
     return Result.ok(undefined);
   }
@@ -55,21 +48,12 @@ export class InMemoryTimelineCacheRepository
     listID: ListID,
     notes: readonly Note[],
   ): Promise<Result.Result<Error, void>> {
-    const objectKey = this.generateObjectKey(listID, 'list');
-    if (!this.data.has(objectKey)) {
-      this.data.set(
-        objectKey,
-        notes.map((note) => note.getID()),
-      );
+    const newNoteIDs = notes.map((note) => note.getID());
+    if (!this.data.has(this.generateObjectKey(listID, 'list'))) {
+      this.data.set(this.generateObjectKey(listID, 'list'), newNoteIDs);
       return Result.ok(undefined);
     }
-    // biome-ignore lint/style/noNonNullAssertion: Use assertion to avoid compile errors because type inference has failed.
-    const fetched = this.data.get(objectKey)!;
-    // NOTE: replace by updated object
-    this.data.delete(objectKey);
-
-    fetched.push(...notes.map((note) => note.getID()));
-    this.data.set(objectKey, fetched);
+    this.data.get(this.generateObjectKey(listID, 'list'))?.push(...newNoteIDs);
 
     return Result.ok(undefined);
   }

--- a/pkg/timeline/adaptor/repository/valkeyCache.ts
+++ b/pkg/timeline/adaptor/repository/valkeyCache.ts
@@ -3,6 +3,7 @@ import type { Redis } from 'ioredis';
 
 import type { AccountID } from '../../../accounts/model/account.js';
 import type { Note, NoteID } from '../../../notes/model/note.js';
+import type { ListID } from '../../model/list.js';
 import type {
   CacheObjectKey,
   TimelineNotesCacheRepository,
@@ -13,8 +14,11 @@ export class ValkeyTimelineCacheRepository
 {
   constructor(private readonly redisClient: Redis) {}
 
-  private generateObjectKey(accountID: AccountID): CacheObjectKey {
-    return `timeline:home:${accountID}`;
+  private generateObjectKey(
+    id: AccountID | ListID,
+    timelineType: 'home' | 'list',
+  ): CacheObjectKey {
+    return `timeline:${timelineType}:${id}`;
   }
 
   async addNotesToHomeTimeline(
@@ -26,7 +30,27 @@ export class ValkeyTimelineCacheRepository
       await Promise.all(
         notes.map((v) =>
           this.redisClient.zadd(
-            this.generateObjectKey(accountID),
+            this.generateObjectKey(accountID, 'home'),
+            v.getCreatedAt().getTime(),
+            v.getID(),
+          ),
+        ),
+      );
+      return Result.ok(undefined);
+    } catch (e) {
+      return Result.err(e as Error);
+    }
+  }
+
+  async addNotesToList(
+    listID: ListID,
+    notes: readonly Note[],
+  ): Promise<Result.Result<Error, void>> {
+    try {
+      await Promise.all(
+        notes.map((v) =>
+          this.redisClient.zadd(
+            this.generateObjectKey(listID, 'list'),
             v.getCreatedAt().getTime(),
             v.getID(),
           ),
@@ -43,7 +67,22 @@ export class ValkeyTimelineCacheRepository
   ): Promise<Result.Result<Error, NoteID[]>> {
     try {
       const fetched = await this.redisClient.zrange(
-        this.generateObjectKey(accountID),
+        this.generateObjectKey(accountID, 'home'),
+        0,
+        -1,
+      );
+      return Result.ok(fetched as NoteID[]);
+    } catch (e) {
+      return Result.err(e as Error);
+    }
+  }
+
+  async getListTimeline(
+    listID: ListID,
+  ): Promise<Result.Result<Error, NoteID[]>> {
+    try {
+      const fetched = await this.redisClient.zrange(
+        this.generateObjectKey(listID, 'list'),
         0,
         -1,
       );

--- a/pkg/timeline/model/repository.ts
+++ b/pkg/timeline/model/repository.ts
@@ -47,12 +47,20 @@ export interface TimelineRepository {
 }
 export const timelineRepoSymbol = Ether.newEtherSymbol<TimelineRepository>();
 
-export type CacheObjectKey = `timeline:home:${AccountID}`;
+export type CacheObjectKey =
+  `timeline:${'home' | 'list'}:${AccountID | ListID}`;
 export interface TimelineNotesCacheRepository {
   addNotesToHomeTimeline(
     accountID: AccountID,
     notes: readonly Note[],
   ): Promise<Result.Result<Error, void>>;
+
+  addNotesToList(
+    listID: ListID,
+    notes: readonly Note[],
+  ): Promise<Result.Result<Error, void>>;
+
+  getListTimeline(listID: ListID): Promise<Result.Result<Error, NoteID[]>>;
 
   getHomeTimeline(
     accountID: AccountID,
@@ -68,5 +76,12 @@ export interface ListRepository {
     ownerId: AccountID,
   ): Promise<Result.Result<Error, List[]>>;
   fetchListMembers(listId: ListID): Promise<Result.Result<Error, AccountID[]>>;
+  /**
+   * @description Fetch lists by member account ID
+   * @param accountId ID of the account to which the list belongs
+   */
+  fetchListsByMemberAccountID(
+    accountID: AccountID,
+  ): Promise<Result.Result<Error, List[]>>;
   deleteById(listId: ListID): Promise<Result.Result<Error, void>>;
 }

--- a/pkg/timeline/service/fetchSubscribed.test.ts
+++ b/pkg/timeline/service/fetchSubscribed.test.ts
@@ -1,0 +1,26 @@
+import { Result } from '@mikuroxina/mini-fn';
+import { describe, expect, it } from 'vitest';
+import type { AccountID } from '../../accounts/model/account.js';
+import { InMemoryListRepository } from '../adaptor/repository/dummy.js';
+import { List, type ListID } from '../model/list.js';
+import { FetchSubscribedListService } from './fetchSubscribed.js';
+
+describe('FetchSubscribedListService', () => {
+  const dummyList = List.new({
+    id: '1' as ListID,
+    title: 'dummy',
+    memberIds: ['101' as AccountID],
+    publicity: 'PUBLIC',
+    ownerId: '100' as AccountID,
+    createdAt: new Date('2023-09-10T00:00:00.000Z'),
+  });
+  const listRepository = new InMemoryListRepository([dummyList]);
+  const fetchService = new FetchSubscribedListService(listRepository);
+
+  it('should fetch list by member account ID', async () => {
+    const res = await fetchService.handle('101' as AccountID);
+
+    expect(Result.isOk(res)).toBe(true);
+    expect(Result.unwrap(res)).toStrictEqual(['1' as AccountID]);
+  });
+});

--- a/pkg/timeline/service/fetchSubscribed.ts
+++ b/pkg/timeline/service/fetchSubscribed.ts
@@ -1,0 +1,23 @@
+import { Result } from '@mikuroxina/mini-fn';
+import type { AccountID } from '../../accounts/model/account.js';
+import type { ListID } from '../model/list.js';
+import type { ListRepository } from '../model/repository.js';
+
+export class FetchSubscribedListService {
+  constructor(private readonly listRepository: ListRepository) {}
+
+  /**
+   * @description Fetch list by member(assignee) account ID
+   * @param accountID
+   * @returns ListID[] which specified account is assigned
+   */
+  async handle(accountID: AccountID): Promise<Result.Result<Error, ListID[]>> {
+    const lists =
+      await this.listRepository.fetchListsByMemberAccountID(accountID);
+    if (Result.isErr(lists)) {
+      return lists;
+    }
+    const unwrapped = Result.unwrap(lists);
+    return Result.ok(unwrapped.map((list) => list.getId()));
+  }
+}

--- a/pkg/timeline/service/noteVisibility.test.ts
+++ b/pkg/timeline/service/noteVisibility.test.ts
@@ -159,4 +159,35 @@ describe('NoteVisibilityService', () => {
       }),
     ).toBe(false);
   });
+
+  it("listVisibilityCheck: return true if visibility is not 'PUBLIC' and 'HOME'", async () => {
+    vi.spyOn(dummyAccountModuleFacade, 'fetchFollowers').mockImplementation(
+      async () => Result.ok([partialAccount1]),
+    );
+
+    expect(
+      await visibilityService.isVisibleNoteInList({
+        accountID: '0' as AccountID,
+        note: dummyPublicNote,
+      }),
+    ).toBe(true);
+    expect(
+      await visibilityService.isVisibleNoteInList({
+        accountID: '0' as AccountID,
+        note: dummyHomeNote,
+      }),
+    ).toBe(true);
+    expect(
+      await visibilityService.isVisibleNoteInList({
+        accountID: '0' as AccountID,
+        note: dummyFollowersNote,
+      }),
+    ).toBe(false);
+    expect(
+      await visibilityService.isVisibleNoteInList({
+        accountID: '0' as AccountID,
+        note: dummyDirectNote,
+      }),
+    ).toBe(false);
+  });
 });

--- a/pkg/timeline/service/noteVisibility.ts
+++ b/pkg/timeline/service/noteVisibility.ts
@@ -48,6 +48,15 @@ export class NoteVisibilityService {
   ): Promise<boolean> {
     return args.note.getVisibility() !== 'DIRECT';
   }
+
+  public async isVisibleNoteInList(
+    args: NoteVisibilityCheckArgs,
+  ): Promise<boolean> {
+    return (
+      args.note.getVisibility() !== 'DIRECT' &&
+      args.note.getVisibility() !== 'FOLLOWERS'
+    );
+  }
 }
 export const noteVisibilitySymbol =
   Ether.newEtherSymbol<NoteVisibilityService>();

--- a/pkg/timeline/service/push.test.ts
+++ b/pkg/timeline/service/push.test.ts
@@ -1,20 +1,43 @@
 import { Result } from '@mikuroxina/mini-fn';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import type { AccountID } from '../../accounts/model/account.js';
 import { partialAccount1 } from '../../accounts/testData/testData.js';
 import { dummyAccountModuleFacade } from '../../intermodule/account.js';
+import type { NoteID } from '../../notes/model/note.js';
+import { InMemoryListRepository } from '../adaptor/repository/dummy.js';
 import { InMemoryTimelineCacheRepository } from '../adaptor/repository/dummyCache.js';
-import { dummyPublicNote } from '../testData/testData.js';
+import { List, type ListID } from '../model/list.js';
+import {
+  dummyDirectNote,
+  dummyFollowersNote,
+  dummyPublicNote,
+} from '../testData/testData.js';
+import { FetchSubscribedListService } from './fetchSubscribed.js';
 import { NoteVisibilityService } from './noteVisibility.js';
 import { PushTimelineService } from './push.js';
 
 describe('PushTimelineService', () => {
+  const dummyList = List.new({
+    id: '10' as ListID,
+    title: 'dummy',
+    memberIds: ['100' as AccountID],
+    publicity: 'PUBLIC',
+    ownerId: '101' as AccountID,
+    createdAt: new Date('2023-09-10T00:00:00.000Z'),
+  });
+
   const noteVisibility = new NoteVisibilityService(dummyAccountModuleFacade);
   const timelineCacheRepository = new InMemoryTimelineCacheRepository();
+  const listRepository = new InMemoryListRepository([dummyList]);
+  const fetchSubscribedListService = new FetchSubscribedListService(
+    listRepository,
+  );
   const pushTimelineService = new PushTimelineService(
     dummyAccountModuleFacade,
     noteVisibility,
     timelineCacheRepository,
+    fetchSubscribedListService,
   );
 
   beforeEach(() => {
@@ -23,11 +46,43 @@ describe('PushTimelineService', () => {
         return Result.ok([partialAccount1]);
       },
     );
+    timelineCacheRepository.reset();
   });
 
   it('push to home timeline', async () => {
     const res = await pushTimelineService.handle(dummyPublicNote);
 
     expect(Result.unwrap(res)).toBe(undefined);
+  });
+
+  it('push to list', async () => {
+    const res = await pushTimelineService.handle(dummyPublicNote);
+    const listTimeline = await timelineCacheRepository.getListTimeline(
+      '10' as ListID,
+    );
+
+    expect(Result.unwrap(res)).toBe(undefined);
+    expect(Result.isErr(listTimeline)).toBe(false);
+    expect(Result.unwrap(listTimeline)).toEqual(['1' as NoteID]);
+  });
+
+  it("if Note.visibility is DIRECT, don't push to List", async () => {
+    const res = await pushTimelineService.handle(dummyDirectNote);
+    const listTimeline = await timelineCacheRepository.getListTimeline(
+      '10' as ListID,
+    );
+
+    expect(Result.isErr(res)).toBe(true);
+    expect(Result.isErr(listTimeline)).toBe(true);
+  });
+
+  it("if Note.visibility is FOLLOWERS, don't push to List", async () => {
+    const res = await pushTimelineService.handle(dummyFollowersNote);
+    const listTimeline = await timelineCacheRepository.getListTimeline(
+      '10' as ListID,
+    );
+
+    expect(Result.isErr(res)).toBe(true);
+    expect(Result.isErr(listTimeline)).toBe(true);
   });
 });

--- a/pkg/timeline/service/push.ts
+++ b/pkg/timeline/service/push.ts
@@ -24,12 +24,7 @@ export class PushTimelineService {
       return home;
     }
 
-    const list = await this.pushToList(note);
-    if (Result.isErr(list)) {
-      return list;
-    }
-
-    return Result.ok(undefined);
+    return await this.pushToList(note);
   }
 
   private async pushToHomeTimeline(
@@ -70,7 +65,7 @@ export class PushTimelineService {
    * @description push note to List timeline
    * @param note
    */
-  private async pushToList(note: Note) {
+  private async pushToList(note: Note): Promise<Result.Result<Error, void>> {
     const lists = await this.fetchSubscribedListService.handle(
       note.getAuthorID(),
     );


### PR DESCRIPTION
## What does this PR do?
close #571
- ノートをリストに配信できるようにした
  - ホームタイムラインへの配信と同時にリストにも配信するようにしています

## Additional information
- テストケースの追加も行なっています
- ホームタイムラインへは配信できたが、リストには配信できなかったケースのハンドリングは実装していません
 - 呼び出し側で工夫するしかなさそう