### PR TITLE
feat: NoteのAttachmentを返すように

### DIFF
--- a/pkg/accounts/adaptor/controller/account.ts
+++ b/pkg/accounts/adaptor/controller/account.ts
@@ -219,7 +219,6 @@ export class AccountController {
     name: string,
     passphrase: string,
   ): Promise<Result.Result<Error, z.infer<typeof LoginResponseSchema>>> {
-    // ToDo: Check Captcha token
     const res = await this.authenticateService.handle(
       name as AccountName,
       passphrase,
@@ -258,7 +257,6 @@ export class AccountController {
     fromName: string,
     targetName: string,
   ): Promise<Result.Result<Error, void>> {
-    // ToDo: get following account's name from request
     const res = await this.followService.handle(
       fromName as AccountName,
       targetName as AccountName,

--- a/pkg/drive/testData/testData.ts
+++ b/pkg/drive/testData/testData.ts
@@ -1,0 +1,24 @@
+import type { AccountID } from '../../accounts/model/account.js';
+import { Medium, type MediumID } from '../model/medium.js';
+
+export const testMedium = Medium.new({
+  id: '300' as MediumID,
+  name: 'test.jpg',
+  mime: 'image/jpeg',
+  authorId: '101' as AccountID,
+  nsfw: false,
+  url: 'https://example.com/test.jpg',
+  thumbnailUrl: 'https://example.com/test_thumbnail.jpg',
+  hash: '40kdflnrh',
+});
+
+export const testNSFWMedium = Medium.new({
+  id: '301' as MediumID,
+  name: 'test.jpg',
+  mime: 'image/jpeg',
+  authorId: '101' as AccountID,
+  nsfw: true,
+  url: 'https://example.com/test.jpg',
+  thumbnailUrl: 'https://example.com/test_thumbnail.jpg',
+  hash: '40kdflnrh',
+});

--- a/pkg/notes/adaptor/controller/bookmark.ts
+++ b/pkg/notes/adaptor/controller/bookmark.ts
@@ -6,6 +6,7 @@ import type { Bookmark } from '../../model/bookmark.js';
 import type { NoteID } from '../../model/note.js';
 import type { CreateBookmarkService } from '../../service/createBookmark.js';
 import type { DeleteBookmarkService } from '../../service/deleteBookmark.js';
+import type { FetchService } from '../../service/fetch.js';
 import type { FetchBookmarkService } from '../../service/fetchBookmark.js';
 import type { CreateBookmarkResponseSchema } from '../validator/schema.js';
 
@@ -14,6 +15,7 @@ export class BookmarkController {
     private readonly createBookmarkService: CreateBookmarkService,
     private readonly fetchBookmarkService: FetchBookmarkService,
     private readonly deleteBookmarkService: DeleteBookmarkService,
+    private readonly fetchNoteService: FetchService,
   ) {}
 
   async createBookmark(
@@ -26,18 +28,38 @@ export class BookmarkController {
       noteID as NoteID,
       accountID as AccountID,
     );
-
     if (Result.isErr(res)) {
       return res;
     }
+    const unwrapped = Result.unwrap(res);
+
+    const attachmets = await this.fetchNoteService.fetchNoteAttachments(
+      unwrapped.getID(),
+    );
+    if (Result.isErr(attachmets)) {
+      return attachmets;
+    }
+    const unwrappedAttachments = Result.unwrap(attachmets);
 
     return Result.ok({
-      id: res[1].getID(),
-      content: res[1].getContent(),
-      visibility: res[1].getVisibility(),
-      contents_warning_comment: res[1].getCwComment(),
-      author_id: res[1].getAuthorID(),
-      created_at: res[1].getCreatedAt().toUTCString(),
+      id: unwrapped.getID(),
+      content: unwrapped.getContent(),
+      visibility: unwrapped.getVisibility(),
+      contents_warning_comment: unwrapped.getCwComment(),
+      author_id: unwrapped.getAuthorID(),
+      attachment_files: unwrappedAttachments.map((v) => {
+        return {
+          id: v.getId(),
+          name: v.getName(),
+          mime: v.getMime(),
+          url: v.getUrl(),
+          hash: v.getHash(),
+          author_id: v.getAuthorId(),
+          nsfw: v.isNsfw(),
+          thumbnail: v.getThumbnailUrl(),
+        };
+      }),
+      created_at: unwrapped.getCreatedAt().toUTCString(),
     });
   }
 

--- a/pkg/notes/adaptor/controller/bookmark.ts
+++ b/pkg/notes/adaptor/controller/bookmark.ts
@@ -24,30 +24,30 @@ export class BookmarkController {
   ): Promise<
     Result.Result<Error, z.infer<typeof CreateBookmarkResponseSchema>>
   > {
-    const res = await this.createBookmarkService.handle(
+    const bookmarkRes = await this.createBookmarkService.handle(
       noteID as NoteID,
       accountID as AccountID,
     );
-    if (Result.isErr(res)) {
-      return res;
+    if (Result.isErr(bookmarkRes)) {
+      return bookmarkRes;
     }
-    const unwrapped = Result.unwrap(res);
+    const bookmark = Result.unwrap(bookmarkRes);
 
-    const attachmets = await this.fetchNoteService.fetchNoteAttachments(
-      unwrapped.getID(),
+    const attachmetsRes = await this.fetchNoteService.fetchNoteAttachments(
+      bookmark.getID(),
     );
-    if (Result.isErr(attachmets)) {
-      return attachmets;
+    if (Result.isErr(attachmetsRes)) {
+      return attachmetsRes;
     }
-    const unwrappedAttachments = Result.unwrap(attachmets);
+    const attachments = Result.unwrap(attachmetsRes);
 
     return Result.ok({
-      id: unwrapped.getID(),
-      content: unwrapped.getContent(),
-      visibility: unwrapped.getVisibility(),
-      contents_warning_comment: unwrapped.getCwComment(),
-      author_id: unwrapped.getAuthorID(),
-      attachment_files: unwrappedAttachments.map((v) => {
+      id: bookmark.getID(),
+      content: bookmark.getContent(),
+      visibility: bookmark.getVisibility(),
+      contents_warning_comment: bookmark.getCwComment(),
+      author_id: bookmark.getAuthorID(),
+      attachment_files: attachments.map((v) => {
         return {
           id: v.getId(),
           name: v.getName(),
@@ -59,7 +59,7 @@ export class BookmarkController {
           thumbnail: v.getThumbnailUrl(),
         };
       }),
-      created_at: unwrapped.getCreatedAt().toUTCString(),
+      created_at: bookmark.getCreatedAt().toUTCString(),
     });
   }
 

--- a/pkg/notes/adaptor/controller/note.ts
+++ b/pkg/notes/adaptor/controller/note.ts
@@ -30,7 +30,7 @@ export class NoteController {
     attachmentFileID: string[];
     sendTo?: string;
   }): Promise<Result.Result<Error, z.infer<typeof CreateNoteResponseSchema>>> {
-    const res = await this.createService.handle(
+    const noteRes = await this.createService.handle(
       args.content,
       args.contentsWarningComment,
       !args.sendTo ? Option.none() : Option.some(args.sendTo as AccountID),
@@ -38,30 +38,30 @@ export class NoteController {
       args.attachmentFileID as MediumID[],
       args.visibility as NoteVisibility,
     );
-    if (Result.isErr(res)) {
-      return res;
+    if (Result.isErr(noteRes)) {
+      return noteRes;
     }
 
-    const unwrapped = Result.unwrap(res);
-    const attachments = await this.fetchService.fetchNoteAttachments(
-      unwrapped.getID(),
+    const note = Result.unwrap(noteRes);
+    const attachmentsRes = await this.fetchService.fetchNoteAttachments(
+      note.getID(),
     );
-    if (Result.isErr(attachments)) {
-      return attachments;
+    if (Result.isErr(attachmentsRes)) {
+      return attachmentsRes;
     }
-    const unwrappedAttachments = Result.unwrap(attachments);
+    const attachments = Result.unwrap(attachmentsRes);
 
     return Result.ok({
-      id: unwrapped.getID(),
-      content: unwrapped.getContent(),
-      visibility: unwrapped.getVisibility(),
-      contents_warning_comment: unwrapped.getCwComment(),
-      send_to: Option.isSome(unwrapped.getSendTo())
-        ? Option.unwrap(unwrapped.getSendTo())
+      id: note.getID(),
+      content: note.getContent(),
+      visibility: note.getVisibility(),
+      contents_warning_comment: note.getCwComment(),
+      send_to: Option.isSome(note.getSendTo())
+        ? Option.unwrap(note.getSendTo())
         : undefined,
-      author_id: unwrapped.getAuthorID(),
-      created_at: unwrapped.getCreatedAt().toUTCString(),
-      attachment_files: unwrappedAttachments.map((v) => {
+      author_id: note.getAuthorID(),
+      created_at: note.getCreatedAt().toUTCString(),
+      attachment_files: attachments.map((v) => {
         return {
           id: v.getId(),
           name: v.getName(),
@@ -79,38 +79,38 @@ export class NoteController {
   async getNoteByID(
     noteID: string,
   ): Promise<Result.Result<Error, z.infer<typeof GetNoteResponseSchema>>> {
-    const res = await this.fetchService.fetchNoteByID(noteID as NoteID);
-    if (Option.isNone(res)) {
+    const noteRes = await this.fetchService.fetchNoteByID(noteID as NoteID);
+    if (Option.isNone(noteRes)) {
       return Result.err(new Error('Note not found'));
     }
-    const unwrapped = Option.unwrap(res);
+    const note = Option.unwrap(noteRes);
 
-    const authorAccount = await this.accountModule.fetchAccount(
-      unwrapped.getAuthorID(),
+    const authorAccountRes = await this.accountModule.fetchAccount(
+      note.getAuthorID(),
     );
-    if (Result.isErr(authorAccount)) {
-      return authorAccount;
+    if (Result.isErr(authorAccountRes)) {
+      return authorAccountRes;
     }
-    const unwrappedAuthor = Result.unwrap(authorAccount);
+    const author = Result.unwrap(authorAccountRes);
 
-    const attachments = await this.fetchService.fetchNoteAttachments(
-      unwrapped.getID(),
+    const attachmentsRes = await this.fetchService.fetchNoteAttachments(
+      note.getID(),
     );
-    if (Result.isErr(attachments)) {
-      return attachments;
+    if (Result.isErr(attachmentsRes)) {
+      return attachmentsRes;
     }
-    const unwrappedAttachments = Result.unwrap(attachments);
+    const attachments = Result.unwrap(attachmentsRes);
 
     return Result.ok({
-      id: unwrapped.getID(),
-      content: unwrapped.getContent(),
-      contents_warning_comment: unwrapped.getCwComment(),
-      send_to: Option.isSome(unwrapped.getSendTo())
-        ? Option.unwrap(unwrapped.getSendTo())
+      id: note.getID(),
+      content: note.getContent(),
+      contents_warning_comment: note.getCwComment(),
+      send_to: Option.isSome(note.getSendTo())
+        ? Option.unwrap(note.getSendTo())
         : undefined,
-      visibility: unwrapped.getVisibility(),
-      created_at: unwrapped.getCreatedAt().toUTCString(),
-      attachment_files: unwrappedAttachments.map((v) => {
+      visibility: note.getVisibility(),
+      created_at: note.getCreatedAt().toUTCString(),
+      attachment_files: attachments.map((v) => {
         return {
           id: v.getId(),
           name: v.getName(),
@@ -123,10 +123,10 @@ export class NoteController {
         };
       }),
       author: {
-        id: unwrappedAuthor.getID(),
-        name: unwrappedAuthor.getName(),
-        display_name: unwrappedAuthor.getNickname(),
-        bio: unwrappedAuthor.getBio(),
+        id: author.getID(),
+        name: author.getName(),
+        display_name: author.getNickname(),
+        bio: author.getBio(),
         // ToDo: fill avatar, header
         avatar: '',
         header: '',
@@ -144,7 +144,7 @@ export class NoteController {
     contentsWarningComment: string;
     attachmentFileID: string[];
   }): Promise<Result.Result<Error, z.infer<typeof RenoteResponseSchema>>> {
-    const res = await this.renoteService.handle(
+    const renoteRes = await this.renoteService.handle(
       args.originalNoteID as NoteID,
       args.content,
       args.contentsWarningComment,
@@ -152,27 +152,27 @@ export class NoteController {
       args.attachmentFileID as MediumID[],
       args.visibility as NoteVisibility,
     );
-    if (Result.isErr(res)) {
-      return res;
+    if (Result.isErr(renoteRes)) {
+      return renoteRes;
     }
-    const unwrapped = Result.unwrap(res);
+    const renote = Result.unwrap(renoteRes);
 
-    const attachmets = await this.fetchService.fetchNoteAttachments(
-      unwrapped.getID(),
+    const attachmetsRes = await this.fetchService.fetchNoteAttachments(
+      renote.getID(),
     );
-    if (Result.isErr(attachmets)) {
-      return attachmets;
+    if (Result.isErr(attachmetsRes)) {
+      return attachmetsRes;
     }
-    const unwrappedAttachments = Result.unwrap(attachmets);
+    const attachments = Result.unwrap(attachmetsRes);
 
     return Result.ok({
-      id: unwrapped.getID(),
-      content: unwrapped.getContent(),
-      visibility: unwrapped.getVisibility(),
-      contents_warning_comment: unwrapped.getCwComment(),
-      original_note_id: Option.unwrap(unwrapped.getOriginalNoteID()),
-      author_id: unwrapped.getAuthorID(),
-      attachment_files: unwrappedAttachments.map((v) => {
+      id: renote.getID(),
+      content: renote.getContent(),
+      visibility: renote.getVisibility(),
+      contents_warning_comment: renote.getCwComment(),
+      original_note_id: Option.unwrap(renote.getOriginalNoteID()),
+      author_id: renote.getAuthorID(),
+      attachment_files: attachments.map((v) => {
         return {
           id: v.getId(),
           name: v.getName(),
@@ -184,7 +184,7 @@ export class NoteController {
           thumbnail: v.getThumbnailUrl(),
         };
       }),
-      created_at: unwrapped.getCreatedAt().toUTCString(),
+      created_at: renote.getCreatedAt().toUTCString(),
     });
   }
 }

--- a/pkg/notes/adaptor/controller/note.ts
+++ b/pkg/notes/adaptor/controller/note.ts
@@ -42,16 +42,37 @@ export class NoteController {
       return res;
     }
 
+    const unwrapped = Result.unwrap(res);
+    const attachments = await this.fetchService.fetchNoteAttachments(
+      unwrapped.getID(),
+    );
+    if (Result.isErr(attachments)) {
+      return attachments;
+    }
+    const unwrappedAttachments = Result.unwrap(attachments);
+
     return Result.ok({
-      id: res[1].getID(),
-      content: res[1].getContent(),
-      visibility: res[1].getVisibility(),
-      contents_warning_comment: res[1].getCwComment(),
-      send_to: Option.isSome(res[1].getSendTo())
-        ? Option.unwrap(res[1].getSendTo())
+      id: unwrapped.getID(),
+      content: unwrapped.getContent(),
+      visibility: unwrapped.getVisibility(),
+      contents_warning_comment: unwrapped.getCwComment(),
+      send_to: Option.isSome(unwrapped.getSendTo())
+        ? Option.unwrap(unwrapped.getSendTo())
         : undefined,
-      author_id: res[1].getAuthorID(),
-      created_at: res[1].getCreatedAt().toUTCString(),
+      author_id: unwrapped.getAuthorID(),
+      created_at: unwrapped.getCreatedAt().toUTCString(),
+      attachment_files: unwrappedAttachments.map((v) => {
+        return {
+          id: v.getId(),
+          name: v.getName(),
+          mime: v.getMime(),
+          url: v.getUrl(),
+          hash: v.getHash(),
+          author_id: v.getAuthorId(),
+          nsfw: v.isNsfw(),
+          thumbnail: v.getThumbnailUrl(),
+        };
+      }),
     });
   }
 
@@ -62,31 +83,51 @@ export class NoteController {
     if (Option.isNone(res)) {
       return Result.err(new Error('Note not found'));
     }
+    const unwrapped = Option.unwrap(res);
 
     const authorAccount = await this.accountModule.fetchAccount(
-      res[1].getAuthorID(),
+      unwrapped.getAuthorID(),
     );
-
     if (Result.isErr(authorAccount)) {
       return authorAccount;
     }
+    const unwrappedAuthor = Result.unwrap(authorAccount);
+
+    const attachments = await this.fetchService.fetchNoteAttachments(
+      unwrapped.getID(),
+    );
+    if (Result.isErr(attachments)) {
+      return attachments;
+    }
+    const unwrappedAttachments = Result.unwrap(attachments);
 
     return Result.ok({
-      id: res[1].getID(),
-      content: res[1].getContent(),
-      contents_warning_comment: res[1].getCwComment(),
-      send_to: Option.isSome(res[1].getSendTo())
-        ? Option.unwrap(res[1].getSendTo())
+      id: unwrapped.getID(),
+      content: unwrapped.getContent(),
+      contents_warning_comment: unwrapped.getCwComment(),
+      send_to: Option.isSome(unwrapped.getSendTo())
+        ? Option.unwrap(unwrapped.getSendTo())
         : undefined,
-      visibility: res[1].getVisibility(),
-      created_at: res[1].getCreatedAt().toUTCString(),
-      // ToDo: return AttachmentFile meta data
-      attachment_files: [],
+      visibility: unwrapped.getVisibility(),
+      created_at: unwrapped.getCreatedAt().toUTCString(),
+      attachment_files: unwrappedAttachments.map((v) => {
+        return {
+          id: v.getId(),
+          name: v.getName(),
+          mime: v.getMime(),
+          url: v.getUrl(),
+          hash: v.getHash(),
+          author_id: v.getAuthorId(),
+          nsfw: v.isNsfw(),
+          thumbnail: v.getThumbnailUrl(),
+        };
+      }),
       author: {
-        id: authorAccount[1].getID(),
-        name: authorAccount[1].getName(),
-        display_name: authorAccount[1].getNickname(),
-        bio: authorAccount[1].getBio(),
+        id: unwrappedAuthor.getID(),
+        name: unwrappedAuthor.getName(),
+        display_name: unwrappedAuthor.getNickname(),
+        bio: unwrappedAuthor.getBio(),
+        // ToDo: fill avatar, header
         avatar: '',
         header: '',
         followed_count: 0,
@@ -114,17 +155,36 @@ export class NoteController {
     if (Result.isErr(res)) {
       return res;
     }
+    const unwrapped = Result.unwrap(res);
+
+    const attachmets = await this.fetchService.fetchNoteAttachments(
+      unwrapped.getID(),
+    );
+    if (Result.isErr(attachmets)) {
+      return attachmets;
+    }
+    const unwrappedAttachments = Result.unwrap(attachmets);
 
     return Result.ok({
-      id: res[1].getID(),
-      content: res[1].getContent(),
-      visibility: res[1].getVisibility(),
-      contents_warning_comment: res[1].getCwComment(),
-      original_note_id: Option.unwrap(res[1].getOriginalNoteID()),
-      author_id: res[1].getAuthorID(),
-      // ToDo: return AttachmentFile meta data
-      attachment_files: [],
-      created_at: res[1].getCreatedAt().toUTCString(),
+      id: unwrapped.getID(),
+      content: unwrapped.getContent(),
+      visibility: unwrapped.getVisibility(),
+      contents_warning_comment: unwrapped.getCwComment(),
+      original_note_id: Option.unwrap(unwrapped.getOriginalNoteID()),
+      author_id: unwrapped.getAuthorID(),
+      attachment_files: unwrappedAttachments.map((v) => {
+        return {
+          id: v.getId(),
+          name: v.getName(),
+          mime: v.getMime(),
+          url: v.getUrl(),
+          hash: v.getHash(),
+          author_id: v.getAuthorId(),
+          nsfw: v.isNsfw(),
+          thumbnail: v.getThumbnailUrl(),
+        };
+      }),
+      created_at: unwrapped.getCreatedAt().toUTCString(),
     });
   }
 }

--- a/pkg/notes/adaptor/repository/dummy.ts
+++ b/pkg/notes/adaptor/repository/dummy.ts
@@ -134,7 +134,7 @@ export class InMemoryNoteAttachmentRepository
   private readonly medium: Map<MediumID, Medium>;
 
   constructor(medium: Medium[], attachments: [NoteID, MediumID[]][]) {
-    this.attachments = new Map(attachments.map((a) => a));
+    this.attachments = new Map(attachments);
     this.medium = new Map(medium.map((m) => [m.getId(), m]));
   }
 

--- a/pkg/notes/adaptor/repository/dummy.ts
+++ b/pkg/notes/adaptor/repository/dummy.ts
@@ -133,8 +133,8 @@ export class InMemoryNoteAttachmentRepository
   private readonly attachments: Map<NoteID, MediumID[]>;
   private readonly medium: Map<MediumID, Medium>;
 
-  constructor(medium: Medium[]) {
-    this.attachments = new Map();
+  constructor(medium: Medium[], attachments: [NoteID, MediumID[]][]) {
+    this.attachments = new Map(attachments.map((a) => a));
     this.medium = new Map(medium.map((m) => [m.getId(), m]));
   }
 

--- a/pkg/notes/adaptor/validator/schema.ts
+++ b/pkg/notes/adaptor/validator/schema.ts
@@ -9,6 +9,41 @@ export const CommonErrorSchema = z.object({
   }),
 });
 
+export const noteAttachmentSchema = z.object({
+  id: z.string().openapi({
+    example: '39783475',
+    description: 'attachment Medium id',
+  }),
+  name: z.string().openapi({
+    example: 'image.jpg',
+    description: 'attachment filename',
+  }),
+  author_id: z.string().openapi({
+    example: '309823457',
+    description: 'attachment author account id',
+  }),
+  hash: z.string().openapi({
+    example: 'e9f*5oin{dn',
+    description: 'attachment medium blurhash',
+  }),
+  mime: z.string().openapi({
+    example: 'image/jpeg',
+    description: 'attachment medium mime type',
+  }),
+  nsfw: z.boolean().openapi({
+    default: false,
+    description: 'if true, attachment is nsfw',
+  }),
+  url: z.string().url().openapi({
+    example: 'https://images.example.com/image.webp',
+    description: 'attachment medium url',
+  }),
+  thumbnail: z.string().openapi({
+    example: 'https://images.example.com/image_thumbnail.webp',
+    description: 'attachment thumbnail url',
+  }),
+});
+
 export const CreateNoteRequestSchema = z.object({
   content: z.string().max(3000).openapi({
     example: 'hello world!',
@@ -70,6 +105,9 @@ export const CreateNoteResponseSchema = z.object({
     example: '2021-01-01T00:00:00Z',
     description: 'Note created date',
   }),
+  attachment_files: z.array(noteAttachmentSchema).max(16).openapi({
+    description: 'Note Attachment Media',
+  }),
 });
 
 export const GetNoteResponseSchema = z.object({
@@ -108,14 +146,9 @@ export const GetNoteResponseSchema = z.object({
     following_count: z.number(),
   }),
   // ToDo: add reactions
-  attachment_files: z
-    .array(z.string())
-    .max(16)
-    .openapi({
-      example: ['38477395', '38477396'],
-      description: 'Attachment file IDs (max 16 files)',
-      default: [],
-    }),
+  attachment_files: z.array(noteAttachmentSchema).max(16).openapi({
+    description: 'Note Attachment Media',
+  }),
 });
 
 export const RenoteRequestSchema = z.object({
@@ -176,14 +209,9 @@ export const RenoteResponseSchema = z.object({
     example: '2021-01-01T00:00:00Z',
     description: 'Note created date',
   }),
-  attachment_files: z
-    .array(z.string())
-    .max(16)
-    .openapi({
-      example: ['38477395', '38477396'],
-      description: 'Attachment file IDs (max 16 files)',
-      default: [],
-    }),
+  attachment_files: z.array(noteAttachmentSchema).max(16).openapi({
+    description: 'Note Attachment Media',
+  }),
 });
 
 export const CreateBookmarkResponseSchema = z.object({
@@ -210,5 +238,8 @@ export const CreateBookmarkResponseSchema = z.object({
   created_at: z.string().openapi({
     example: '2021-01-01T00:00:00Z',
     description: 'Note created date',
+  }),
+  attachment_files: z.array(noteAttachmentSchema).max(16).openapi({
+    description: 'Note Attachment Media',
   }),
 });

--- a/pkg/notes/mod.ts
+++ b/pkg/notes/mod.ts
@@ -47,7 +47,7 @@ const bookmarkRepository = isProduction
   : new InMemoryBookmarkRepository();
 const attachmentRepository = isProduction
   ? new PrismaNoteAttachmentRepository(prismaClient)
-  : new InMemoryNoteAttachmentRepository([]);
+  : new InMemoryNoteAttachmentRepository([], []);
 const idGenerator = new SnowflakeIDGenerator(0, {
   now: () => BigInt(Date.now()),
 });
@@ -71,7 +71,11 @@ const createService = new CreateService(
   idGenerator,
   attachmentRepository,
 );
-const fetchService = new FetchService(noteRepository, accountModule);
+const fetchService = new FetchService(
+  noteRepository,
+  accountModule,
+  attachmentRepository,
+);
 const renoteService = new RenoteService(
   noteRepository,
   idGenerator,
@@ -95,6 +99,7 @@ const bookmarkController = new BookmarkController(
   createBookmarkService,
   fetchBookmarkService,
   deleteBookmarkService,
+  fetchService,
 );
 
 noteHandlers.openAPIRegistry.registerComponent('securitySchemes', 'Bearer', {

--- a/pkg/notes/service/create.test.ts
+++ b/pkg/notes/service/create.test.ts
@@ -24,6 +24,7 @@ const attachmentRepository = new InMemoryNoteAttachmentRepository(
       authorId: '1' as AccountID,
     });
   }),
+  [],
 );
 const createService = new CreateService(
   noteRepository,

--- a/pkg/notes/service/fetch.ts
+++ b/pkg/notes/service/fetch.ts
@@ -43,13 +43,6 @@ export class FetchService {
   async fetchNoteAttachments(
     noteID: NoteID,
   ): Promise<Result.Result<Error, Medium[]>> {
-    const attachments =
-      await this.noteAttachmentRepository.findByNoteID(noteID);
-
-    if (Result.isErr(attachments)) {
-      return attachments;
-    }
-
-    return Result.ok(attachments[1]);
+    return await this.noteAttachmentRepository.findByNoteID(noteID);
   }
 }

--- a/pkg/notes/service/fetch.ts
+++ b/pkg/notes/service/fetch.ts
@@ -1,13 +1,18 @@
 import { Option, Result } from '@mikuroxina/mini-fn';
 
+import type { Medium } from '../../drive/model/medium.js';
 import type { AccountModuleFacade } from '../../intermodule/account.js';
 import type { Note, NoteID } from '../model/note.js';
-import type { NoteRepository } from '../model/repository.js';
+import type {
+  NoteAttachmentRepository,
+  NoteRepository,
+} from '../model/repository.js';
 
 export class FetchService {
   constructor(
     private readonly noteRepository: NoteRepository,
     private readonly accountModule: AccountModuleFacade,
+    private readonly noteAttachmentRepository: NoteAttachmentRepository,
   ) {}
 
   async fetchNoteByID(noteID: NoteID): Promise<Option.Option<Note>> {
@@ -33,5 +38,18 @@ export class FetchService {
     }
 
     return note;
+  }
+
+  async fetchNoteAttachments(
+    noteID: NoteID,
+  ): Promise<Result.Result<Error, Medium[]>> {
+    const attachments =
+      await this.noteAttachmentRepository.findByNoteID(noteID);
+
+    if (Result.isErr(attachments)) {
+      return attachments;
+    }
+
+    return Result.ok(attachments[1]);
   }
 }

--- a/pkg/notes/service/renote.test.ts
+++ b/pkg/notes/service/renote.test.ts
@@ -36,6 +36,7 @@ const attachmentRepository = new InMemoryNoteAttachmentRepository(
       authorId: '1' as AccountID,
     });
   }),
+  [],
 );
 const service = new RenoteService(
   repository,

--- a/resources/schema.json
+++ b/resources/schema.json
@@ -1816,6 +1816,67 @@
                       "type": "string",
                       "description": "Note created date",
                       "example": "2021-01-01T00:00:00Z"
+                    },
+                    "attachment_files": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "description": "attachment Medium id",
+                            "example": "39783475"
+                          },
+                          "name": {
+                            "type": "string",
+                            "description": "attachment filename",
+                            "example": "image.jpg"
+                          },
+                          "author_id": {
+                            "type": "string",
+                            "description": "attachment author account id",
+                            "example": "309823457"
+                          },
+                          "hash": {
+                            "type": "string",
+                            "description": "attachment medium blurhash",
+                            "example": "e9f*5oin{dn"
+                          },
+                          "mime": {
+                            "type": "string",
+                            "description": "attachment medium mime type",
+                            "example": "image/jpeg"
+                          },
+                          "nsfw": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "if true, attachment is nsfw"
+                          },
+                          "url": {
+                            "type": "string",
+                            "format": "uri",
+                            "description": "attachment medium url",
+                            "example": "https://images.example.com/image.webp"
+                          },
+                          "thumbnail": {
+                            "type": "string",
+                            "description": "attachment thumbnail url",
+                            "example": "https://images.example.com/image_thumbnail.webp"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "name",
+                          "author_id",
+                          "hash",
+                          "mime",
+                          "nsfw",
+                          "url",
+                          "thumbnail"
+                        ]
+                      },
+                      "maxItems": 16,
+                      "description": "Note Attachment Media"
                     }
                   },
                   "required": [
@@ -1824,7 +1885,8 @@
                     "visibility",
                     "contents_warning_comment",
                     "author_id",
-                    "created_at"
+                    "created_at",
+                    "attachment_files"
                   ]
                 }
               }
@@ -1973,15 +2035,63 @@
                     "attachment_files": {
                       "type": "array",
                       "items": {
-                        "type": "string"
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "description": "attachment Medium id",
+                            "example": "39783475"
+                          },
+                          "name": {
+                            "type": "string",
+                            "description": "attachment filename",
+                            "example": "image.jpg"
+                          },
+                          "author_id": {
+                            "type": "string",
+                            "description": "attachment author account id",
+                            "example": "309823457"
+                          },
+                          "hash": {
+                            "type": "string",
+                            "description": "attachment medium blurhash",
+                            "example": "e9f*5oin{dn"
+                          },
+                          "mime": {
+                            "type": "string",
+                            "description": "attachment medium mime type",
+                            "example": "image/jpeg"
+                          },
+                          "nsfw": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "if true, attachment is nsfw"
+                          },
+                          "url": {
+                            "type": "string",
+                            "format": "uri",
+                            "description": "attachment medium url",
+                            "example": "https://images.example.com/image.webp"
+                          },
+                          "thumbnail": {
+                            "type": "string",
+                            "description": "attachment thumbnail url",
+                            "example": "https://images.example.com/image_thumbnail.webp"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "name",
+                          "author_id",
+                          "hash",
+                          "mime",
+                          "nsfw",
+                          "url",
+                          "thumbnail"
+                        ]
                       },
                       "maxItems": 16,
-                      "default": [],
-                      "description": "Attachment file IDs (max 16 files)",
-                      "example": [
-                        "38477395",
-                        "38477396"
-                      ]
+                      "description": "Note Attachment Media"
                     }
                   },
                   "required": [
@@ -2158,15 +2268,63 @@
                     "attachment_files": {
                       "type": "array",
                       "items": {
-                        "type": "string"
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "description": "attachment Medium id",
+                            "example": "39783475"
+                          },
+                          "name": {
+                            "type": "string",
+                            "description": "attachment filename",
+                            "example": "image.jpg"
+                          },
+                          "author_id": {
+                            "type": "string",
+                            "description": "attachment author account id",
+                            "example": "309823457"
+                          },
+                          "hash": {
+                            "type": "string",
+                            "description": "attachment medium blurhash",
+                            "example": "e9f*5oin{dn"
+                          },
+                          "mime": {
+                            "type": "string",
+                            "description": "attachment medium mime type",
+                            "example": "image/jpeg"
+                          },
+                          "nsfw": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "if true, attachment is nsfw"
+                          },
+                          "url": {
+                            "type": "string",
+                            "format": "uri",
+                            "description": "attachment medium url",
+                            "example": "https://images.example.com/image.webp"
+                          },
+                          "thumbnail": {
+                            "type": "string",
+                            "description": "attachment thumbnail url",
+                            "example": "https://images.example.com/image_thumbnail.webp"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "name",
+                          "author_id",
+                          "hash",
+                          "mime",
+                          "nsfw",
+                          "url",
+                          "thumbnail"
+                        ]
                       },
                       "maxItems": 16,
-                      "default": [],
-                      "description": "Attachment file IDs (max 16 files)",
-                      "example": [
-                        "38477395",
-                        "38477396"
-                      ]
+                      "description": "Note Attachment Media"
                     }
                   },
                   "required": [
@@ -2308,6 +2466,67 @@
                       "type": "string",
                       "description": "Note created date",
                       "example": "2021-01-01T00:00:00Z"
+                    },
+                    "attachment_files": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "description": "attachment Medium id",
+                            "example": "39783475"
+                          },
+                          "name": {
+                            "type": "string",
+                            "description": "attachment filename",
+                            "example": "image.jpg"
+                          },
+                          "author_id": {
+                            "type": "string",
+                            "description": "attachment author account id",
+                            "example": "309823457"
+                          },
+                          "hash": {
+                            "type": "string",
+                            "description": "attachment medium blurhash",
+                            "example": "e9f*5oin{dn"
+                          },
+                          "mime": {
+                            "type": "string",
+                            "description": "attachment medium mime type",
+                            "example": "image/jpeg"
+                          },
+                          "nsfw": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "if true, attachment is nsfw"
+                          },
+                          "url": {
+                            "type": "string",
+                            "format": "uri",
+                            "description": "attachment medium url",
+                            "example": "https://images.example.com/image.webp"
+                          },
+                          "thumbnail": {
+                            "type": "string",
+                            "description": "attachment thumbnail url",
+                            "example": "https://images.example.com/image_thumbnail.webp"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "name",
+                          "author_id",
+                          "hash",
+                          "mime",
+                          "nsfw",
+                          "url",
+                          "thumbnail"
+                        ]
+                      },
+                      "maxItems": 16,
+                      "description": "Note Attachment Media"
                     }
                   },
                   "required": [
@@ -2316,7 +2535,8 @@
                     "visibility",
                     "contents_warning_comment",
                     "author_id",
-                    "created_at"
+                    "created_at",
+                    "attachment_files"
                   ]
                 }
               }


### PR DESCRIPTION
## What does this PR do?
related #604 
related pulsate-dev/specification#9
- Note APIで、Attachmentの情報を返すようにしました
- API Docを更新

## Additional information
- Note APIのみ変更しています
  - Timelineモジュール用にAttachmentを取得する処理はNoteモジュール用と事情(最大取得ノート数)が違うためです
    - Timeline: 最大20ノート / Note: 1ノート