### PR TITLE
feat: アカウントロールなどによるアクセス制御の実装

### DIFF
--- a/pkg/accounts/adaptor/controller/account.ts
+++ b/pkg/accounts/adaptor/controller/account.ts
@@ -98,6 +98,7 @@ export class AccountController {
       bio: string;
     },
     etag: string,
+    actorName: string,
   ): Promise<
     Result.Result<Error, z.infer<typeof UpdateAccountResponseSchema>>
   > {
@@ -106,6 +107,7 @@ export class AccountController {
         etag,
         name as AccountName,
         args.nickname,
+        actorName as AccountName,
       );
       if (Result.isErr(res)) {
         return res;
@@ -116,6 +118,7 @@ export class AccountController {
         etag,
         name as AccountName,
         args.passphrase,
+        actorName as AccountName,
       );
       if (Result.isErr(res)) {
         return res;
@@ -126,6 +129,7 @@ export class AccountController {
         etag,
         name as AccountName,
         args.email,
+        actorName as AccountName,
       );
       if (Result.isErr(res)) {
         return res;
@@ -136,6 +140,7 @@ export class AccountController {
       etag,
       name as AccountName,
       args.bio,
+      actorName as AccountName,
     );
     if (Result.isErr(editedBioResp)) {
       return Result.err(editedBioResp[1]);

--- a/pkg/accounts/adaptor/controller/account.ts
+++ b/pkg/accounts/adaptor/controller/account.ts
@@ -90,7 +90,7 @@ export class AccountController {
   }
 
   async updateAccount(
-    name: string,
+    target: string,
     args: {
       nickname?: string;
       email?: string;
@@ -105,7 +105,7 @@ export class AccountController {
     if (args.nickname) {
       const res = await this.editService.editNickname(
         etag,
-        name as AccountName,
+        target as AccountName,
         args.nickname,
         actorName as AccountName,
       );
@@ -116,7 +116,7 @@ export class AccountController {
     if (args.passphrase) {
       const res = await this.editService.editPassphrase(
         etag,
-        name as AccountName,
+        target as AccountName,
         args.passphrase,
         actorName as AccountName,
       );
@@ -127,7 +127,7 @@ export class AccountController {
     if (args.email) {
       const res = await this.editService.editEmail(
         etag,
-        name as AccountName,
+        target as AccountName,
         args.email,
         actorName as AccountName,
       );
@@ -138,7 +138,7 @@ export class AccountController {
 
     const editedBioResp = await this.editService.editBio(
       etag,
-      name as AccountName,
+      target as AccountName,
       args.bio,
       actorName as AccountName,
     );
@@ -146,7 +146,7 @@ export class AccountController {
       return Result.err(editedBioResp[1]);
     }
 
-    const res = await this.fetchService.fetchAccount(name as AccountName);
+    const res = await this.fetchService.fetchAccount(target as AccountName);
     if (Result.isErr(res)) {
       return res;
     }

--- a/pkg/accounts/service/edit.test.ts
+++ b/pkg/accounts/service/edit.test.ts
@@ -290,4 +290,159 @@ describe('EditService', () => {
       },
     );
   });
+
+  describe('access controll', async () => {
+    const testNormalAccount = Account.reconstruct({
+      id: '2' as AccountID,
+      name: '@alice@example.com',
+      mail: 'alice@example.com',
+      nickname: 'Alice',
+      passphraseHash: 'hash',
+      bio: '',
+      role: 'normal',
+      frozen: 'normal',
+      silenced: 'normal',
+      status: 'active',
+      createdAt: new Date(),
+    });
+    const testFrozenAccount = Account.reconstruct({
+      id: '3' as AccountID,
+      name: '@bob@example.com',
+      mail: 'bob@example.com',
+      nickname: 'Bob',
+      passphraseHash: 'hash',
+      bio: '',
+      role: 'normal',
+      frozen: 'frozen',
+      silenced: 'normal',
+      status: 'active',
+      createdAt: new Date(),
+    });
+    const testNotAcvivatedAccount = Account.reconstruct({
+      id: '4' as AccountID,
+      name: '@carol@example.com',
+      mail: 'carol@example.com',
+      nickname: 'Carol',
+      passphraseHash: 'hash',
+      bio: '',
+      role: 'normal',
+      frozen: 'normal',
+      silenced: 'normal',
+      status: 'notActivated',
+      createdAt: new Date(),
+    });
+    beforeEach(async () => {
+      repository.create(testNormalAccount);
+      repository.create(testFrozenAccount);
+      repository.create(testNotAcvivatedAccount);
+    });
+
+    it("can't edit other account data", async () => {
+      const nickname = await editService.editNickname(
+        etag,
+        account.getName(),
+        'new nickname',
+        testNormalAccount.getName(),
+      );
+      const passphrase = await editService.editPassphrase(
+        etag,
+        account.getName(),
+        'new password',
+        testNormalAccount.getName(),
+      );
+      const email = await editService.editEmail(
+        etag,
+        account.getName(),
+        'test@example.com',
+        testNormalAccount.getName(),
+      );
+      const bio = await editService.editBio(
+        etag,
+        account.getName(),
+        'new bio',
+        testNormalAccount.getName(),
+      );
+
+      expect(Result.isOk(nickname)).toBe(false);
+      expect(passphrase[1]).toStrictEqual(new Error('not allowed'));
+
+      expect(Result.isOk(email)).toBe(false);
+      expect(email[1]).toStrictEqual(new Error('not allowed'));
+
+      expect(Result.isOk(bio)).toBe(false);
+      expect(bio[1]).toStrictEqual(new Error('not allowed'));
+    });
+
+    it("can't edit account data if actor frozen", async () => {
+      const nickname = await editService.editNickname(
+        etag,
+        testFrozenAccount.getName(),
+        'new nickname',
+        testFrozenAccount.getName(),
+      );
+      const passphrase = await editService.editPassphrase(
+        etag,
+        testFrozenAccount.getName(),
+        'new password',
+        testFrozenAccount.getName(),
+      );
+      const email = await editService.editEmail(
+        etag,
+        testFrozenAccount.getName(),
+        'test@example.com',
+        testFrozenAccount.getName(),
+      );
+      const bio = await editService.editBio(
+        etag,
+        testFrozenAccount.getName(),
+        'new bio',
+        testFrozenAccount.getName(),
+      );
+
+      expect(Result.isOk(nickname)).toBe(false);
+      expect(passphrase[1]).toStrictEqual(new Error('not allowed'));
+
+      expect(Result.isOk(email)).toBe(false);
+      expect(email[1]).toStrictEqual(new Error('not allowed'));
+
+      expect(Result.isOk(bio)).toBe(false);
+      expect(bio[1]).toStrictEqual(new Error('not allowed'));
+    });
+
+    it("can't edit account data if actor not activated", async () => {
+      const nickname = await editService.editNickname(
+        etag,
+        testNotAcvivatedAccount.getName(),
+        'new nickname',
+        testNotAcvivatedAccount.getName(),
+      );
+      const passphrase = await editService.editPassphrase(
+        etag,
+        testNotAcvivatedAccount.getName(),
+        'new password',
+        testNotAcvivatedAccount.getName(),
+      );
+      const email = await editService.editEmail(
+        etag,
+        testNotAcvivatedAccount.getName(),
+        'test@example.com',
+        testNotAcvivatedAccount.getName(),
+      );
+      const bio = await editService.editBio(
+        etag,
+        testNotAcvivatedAccount.getName(),
+        'new bio',
+        testNotAcvivatedAccount.getName(),
+      );
+
+      expect(Result.isOk(nickname)).toBe(false);
+      expect(passphrase[1]).toStrictEqual(new Error('not allowed'));
+
+      expect(Result.isOk(email)).toBe(false);
+      expect(email[1]).toStrictEqual(new Error('not allowed'));
+
+      expect(Result.isOk(bio)).toBe(false);
+      expect(bio[1]).toStrictEqual(new Error('not allowed'));
+    });
+  });
 });

--- a/pkg/accounts/service/edit.test.ts
+++ b/pkg/accounts/service/edit.test.ts
@@ -18,7 +18,7 @@ describe('EditService', () => {
 
   beforeEach(async () => {
     await repository.create(
-      Account.new({
+      Account.reconstruct({
         id: '1' as AccountID,
         name: '@john@example.com',
         mail: 'johndoe@example.com',
@@ -28,7 +28,7 @@ describe('EditService', () => {
         role: 'normal',
         frozen: 'normal',
         silenced: 'normal',
-        status: 'notActivated',
+        status: 'active',
         createdAt: new Date(),
       }),
     );
@@ -61,6 +61,7 @@ describe('EditService', () => {
           etag,
           '@john@example.com',
           nickname,
+          '@john@example.com',
         );
         expect(Result.isOk(updateRes)).toBe(true);
 
@@ -97,6 +98,7 @@ describe('EditService', () => {
           invalid ?? etag,
           name ?? '@john@example.com',
           nickname,
+          name ?? '@john@example.com',
         );
         expect(Result.isErr(updateRes)).toBe(true);
       },
@@ -124,6 +126,7 @@ describe('EditService', () => {
           etag,
           '@john@example.com',
           passphrase,
+          '@john@example.com',
         );
         expect(Result.isOk(updateRes)).toBe(true);
 
@@ -165,6 +168,7 @@ describe('EditService', () => {
           invalid ?? etag,
           name ?? '@john@example.com',
           passphrase,
+          name ?? '@john@example.com',
         );
 
         expect(Result.isErr(updateRes)).toBe(true);
@@ -197,6 +201,7 @@ describe('EditService', () => {
           etag,
           '@john@example.com',
           email,
+          '@john@example.com',
         );
         expect(Result.isOk(updateRes)).toBe(true);
 
@@ -229,6 +234,7 @@ describe('EditService', () => {
           invalid ?? etag,
           name ?? '@john@example.com',
           email,
+          name ?? '@john@example.com',
         );
         expect(Result.isErr(updateRes)).toBe(true);
       },
@@ -247,6 +253,7 @@ describe('EditService', () => {
           etag,
           '@john@example.com',
           bio,
+          '@john@example.com',
         );
 
         expect(Result.isOk(updateRes)).toBe(true);
@@ -276,6 +283,7 @@ describe('EditService', () => {
           invalid ?? etag,
           name ?? '@john@example.com',
           bio,
+          name ?? '@john@example.com',
         );
 
         expect(Result.isErr(updateRes)).toBe(true);

--- a/pkg/accounts/service/edit.ts
+++ b/pkg/accounts/service/edit.ts
@@ -45,6 +45,9 @@ export class EditService {
     }
     const account = Option.unwrap(res);
     const actorRes = await this.accountRepository.findByName(actorName);
+    if (Option.isNone(actorRes)) {
+      return Result.err(new Error('actor not found'));
+    }
     const actor = Option.unwrap(actorRes);
 
     if (!this.isAllowed('edit', actor, account)) {
@@ -89,6 +92,9 @@ export class EditService {
     }
     const account = Option.unwrap(res);
     const actorRes = await this.accountRepository.findByName(actorName);
+    if (Option.isNone(actorRes)) {
+      return Result.err(new Error('actor not found'));
+    }
     const actor = Option.unwrap(actorRes);
 
     if (!this.isAllowed('edit', actor, account)) {
@@ -135,6 +141,9 @@ export class EditService {
     }
     const account = Option.unwrap(res);
     const actorRes = await this.accountRepository.findByName(actorName);
+    if (Option.isNone(actorRes)) {
+      return Result.err(new Error('actor not found'));
+    }
     const actor = Option.unwrap(actorRes);
 
     if (!this.isAllowed('edit', actor, account)) {
@@ -181,6 +190,9 @@ export class EditService {
     }
     const account = Option.unwrap(res);
     const actorRes = await this.accountRepository.findByName(actorName);
+    if (Option.isNone(actorRes)) {
+      return Result.err(new Error('actor not found'));
+    }
     const actor = Option.unwrap(actorRes);
 
     if (!this.isAllowed('edit', actor, account)) {

--- a/pkg/accounts/service/edit.ts
+++ b/pkg/accounts/service/edit.ts
@@ -35,11 +35,11 @@ export class EditService {
 
   async editNickname(
     etag: string,
-    name: AccountName,
+    target: AccountName,
     nickname: string,
     actorName: AccountName,
   ): Promise<Result.Result<Error, boolean>> {
-    const res = await this.accountRepository.findByName(name);
+    const res = await this.accountRepository.findByName(target);
     if (Option.isNone(res)) {
       return Result.err(new Error('account not found'));
     }
@@ -82,11 +82,11 @@ export class EditService {
 
   async editPassphrase(
     etag: string,
-    name: AccountName,
+    target: AccountName,
     newPassphrase: string,
     actorName: AccountName,
   ): Promise<Result.Result<Error, boolean>> {
-    const res = await this.accountRepository.findByName(name);
+    const res = await this.accountRepository.findByName(target);
     if (Option.isNone(res)) {
       return Result.err(new Error('account not found'));
     }
@@ -131,11 +131,11 @@ export class EditService {
 
   async editEmail(
     etag: string,
-    name: AccountName,
+    target: AccountName,
     newEmail: string,
     actorName: AccountName,
   ): Promise<Result.Result<Error, boolean>> {
-    const res = await this.accountRepository.findByName(name);
+    const res = await this.accountRepository.findByName(target);
     if (Option.isNone(res)) {
       return Result.err(new Error('account not found'));
     }
@@ -180,11 +180,11 @@ export class EditService {
 
   async editBio(
     etag: string,
-    name: AccountName,
+    target: AccountName,
     bio: string,
     actorName: AccountName,
   ): Promise<Result.Result<Error, boolean>> {
-    const res = await this.accountRepository.findByName(name);
+    const res = await this.accountRepository.findByName(target);
     if (Option.isNone(res)) {
       return Result.err(new Error('account not found'));
     }


### PR DESCRIPTION
## What does this PR do?
related #608 
- `AccountModule::EditService#isAllowed`を追加
  - 操作者(`Actor`)と操作する対象を受け取り、操作が可能かどうかを判定
- 必要なテストを追加
## Additional information
