### PR TITLE
fix: 不必要な再圧縮を削除

### DIFF
--- a/pkg/drive/service/upload.test.ts
+++ b/pkg/drive/service/upload.test.ts
@@ -29,7 +29,7 @@ describe('upload', () => {
     });
     const unwrapped = Result.unwrap(res);
     expect(unwrapped.getHash()).toStrictEqual(
-      'U6IX{S^znNM}01xv?bM{IU%MWBxu~WRiRk%L',
+      'U6IX{S^gnNNH0Kxv?bM{IU%MWBxu~WRiRk%L',
     );
     expect(unwrapped.getAuthorId()).toStrictEqual('1');
     expect(unwrapped.getName()).toStrictEqual('flower.jpg');

--- a/pkg/drive/service/upload.ts
+++ b/pkg/drive/service/upload.ts
@@ -109,8 +109,7 @@ export class UploadMediaService {
   > {
     // ToDo: separate cases when images are animated
 
-    const webp = await sharp(file).webp().toBuffer();
-    const resized = await sharp(webp).toBuffer();
+    const resized = await sharp(file).webp().toBuffer();
     const thumbnail = await sharp(resized).resize(200, 200).toBuffer();
 
     const { data, info } = await sharp(thumbnail)


### PR DESCRIPTION
## What does this PR do?

`UploadMediaService` で `sharp` による不必要な再圧縮がかかっていたのでこれを削除した.
これに伴い `blurhash` のハッシュ値が変化したため, 該当するテストも合わせて修正した.

## Additional information

ImageMagick を使用し再圧縮前後で画像データの比較を目視と数値比較により行ったが, そもそも画像は WebP Lossy なこともあり, 再圧縮前後で意図しない有意な差は発見されなかった. 以下に再圧縮前後の画像データを `identify` に通した結果の diff を残しておく (ハイライトするために `<details>` で綴じなかった. 長いのはご容赦).

```diff
2c2
<   Filename: /tmp/before.webp
---
>   Filename: /tmp/after.webp
24c24
<       mean: 132.16 (0.518273)
---
>       mean: 132.107 (0.518069)
26,29c26,29
<       standard deviation: 87.7134 (0.343974)
<       kurtosis: -1.53583
<       skewness: -0.213171
<       entropy: 0.96809
---
>       standard deviation: 87.6616 (0.343771)
>       kurtosis: -1.53664
>       skewness: -0.212579
>       entropy: 0.968413
33c33
<       mean: 129.538 (0.507991)
---
>       mean: 129.671 (0.508515)
35,38c35,38
<       standard deviation: 82.7031 (0.324326)
<       kurtosis: -1.51058
<       skewness: -0.0742505
<       entropy: 0.983255
---
>       standard deviation: 82.6731 (0.324208)
>       kurtosis: -1.51157
>       skewness: -0.0740327
>       entropy: 0.982934
42c42
<       mean: 103.322 (0.405185)
---
>       mean: 103.378 (0.405405)
44,47c44,47
<       standard deviation: 93.7492 (0.367644)
<       kurtosis: -1.60294
<       skewness: 0.257491
<       entropy: 0.902559
---
>       standard deviation: 93.3163 (0.365946)
>       kurtosis: -1.60082
>       skewness: 0.258776
>       entropy: 0.910305
52c52
<       mean: 121.673 (0.477149)
---
>       mean: 121.719 (0.47733)
54,57c54,57
<       standard deviation: 88.0552 (0.345315)
<       kurtosis: -1.54978
<       skewness: -0.00997685
<       entropy: 0.951301
---
>       standard deviation: 87.8837 (0.344642)
>       kurtosis: -1.54968
>       skewness: -0.00927858
>       entropy: 0.953884
78,81c78,81
<     date:create: 2024-08-18T06:36:57+00:00
<     date:modify: 2024-08-18T06:36:57+00:00
<     date:timestamp: 2024-08-18T06:39:13+00:00
<     signature: c4ce570cea015c90642adeee26a4492238fa81fb5d3b4ae2ce5c8ef664c84dec
---
>     date:create: 2024-08-18T06:36:58+00:00
>     date:modify: 2024-08-18T06:36:58+00:00
>     date:timestamp: 2024-08-18T06:39:31+00:00
>     signature: ed6385d48e2fa7b9c447e17f12dc8383c9fdd4ecac177106a80726e71b028407
85c85
<   Filesize: 1.59943MiB
---
>   Filesize: 1.564MiB
88,90c88,90
<   Pixels per second: 63.1205MP
<   User time: 0.140u
<   Elapsed time: 0:01.144
---
>   Pixels per second: 66.6539MP
>   User time: 0.130u
>   Elapsed time: 0:01.137
```