### PR TITLE
feat: ノートがリノート可能であるかをチェックするように

### DIFF
--- a/pkg/accounts/testData/testData.ts
+++ b/pkg/accounts/testData/testData.ts
@@ -1,59 +1,109 @@
 import type { PartialAccount } from '../../intermodule/account.js';
-import { Account, type AccountID } from '../model/account.js';
+import {
+  Account,
+  type AccountFrozen,
+  type AccountID,
+  type AccountName,
+  type AccountRole,
+  type AccountSilenced,
+  type AccountStatus,
+} from '../model/account.js';
 import { AccountFollow } from '../model/follow.js';
 
-export const dummyAccount1 = Account.new({
+/**
+ * @description generate dummy account (factory function)
+ * @param args dummy accont's data
+ * @returns {@link Account}
+ */
+export const generateDummyAccount = (args: {
+  id: AccountID;
+  name: AccountName;
+  role: AccountRole;
+  silenced: AccountSilenced;
+  status: AccountStatus;
+  frozen: AccountFrozen;
+  createdAt: Date;
+}): Account => {
+  return Account.reconstruct({
+    id: args.id,
+    bio: 'this is test user',
+    mail: 'testuser@example.com',
+    name: args.name,
+    nickname: `test user ${args.id}`,
+    passphraseHash: '029833kjnert945@@sfne',
+    role: args.role,
+    silenced: args.silenced,
+    status: args.status,
+    frozen: args.frozen,
+    createdAt: args.createdAt,
+  });
+};
+
+export const dummyNormalAccount1 = generateDummyAccount({
   id: '101' as AccountID,
-  bio: 'this is test user',
-  mail: 'john@example.com',
   name: '@john@example.com',
-  nickname: 'John Doe',
-  passphraseHash: '',
   role: 'normal',
   silenced: 'normal',
   status: 'active',
   frozen: 'normal',
   createdAt: new Date('2023-09-10T00:00:00Z'),
 });
-export const dummyAccount2 = Account.new({
+export const dummyNormalAccount2 = generateDummyAccount({
   id: '102' as AccountID,
-  bio: 'Hello world ✨',
-  mail: 'john@example.com',
   name: '@johndoe@example.com',
-  nickname: '🌤 John',
-  passphraseHash: '',
   role: 'normal',
   silenced: 'normal',
   status: 'active',
   frozen: 'normal',
   createdAt: new Date('2023-09-11T00:00:00Z'),
 });
-export const dummyAccount3 = Account.new({
+export const dummyNormalAccount3 = generateDummyAccount({
   id: '103' as AccountID,
-  bio: 'テストのアカウントです',
-  mail: 'alice@example.com',
   name: '@alice@example.com',
-  nickname: 'Alice',
-  passphraseHash: '',
   role: 'normal',
   silenced: 'normal',
   status: 'active',
   frozen: 'normal',
   createdAt: new Date('2023-09-12T00:00:00Z'),
 });
-export const dummyAccounts = [dummyAccount1, dummyAccount2, dummyAccount3];
+export const dummyFrozenAccount = generateDummyAccount({
+  id: '104' as AccountID,
+  name: '@frozen@example.com',
+  role: 'normal',
+  silenced: 'normal',
+  status: 'active',
+  frozen: 'frozen',
+  createdAt: new Date('2023-09-13T00:00:00Z'),
+});
+export const dummySilencedAccount = generateDummyAccount({
+  id: '105' as AccountID,
+  name: '@silenced@example.com',
+  role: 'normal',
+  silenced: 'silenced',
+  status: 'active',
+  frozen: 'normal',
+  createdAt: new Date('2023-09-14T00:00:00Z'),
+});
+
+export const dummyAccounts = [
+  dummyNormalAccount1,
+  dummyNormalAccount2,
+  dummyNormalAccount3,
+  dummyFrozenAccount,
+  dummySilencedAccount,
+];
 
 export const partialAccount1: PartialAccount = {
-  id: dummyAccount1.getID(),
-  name: dummyAccount1.getName(),
-  nickname: dummyAccount1.getNickname(),
-  bio: dummyAccount1.getBio(),
+  id: dummyNormalAccount1.getID(),
+  name: dummyNormalAccount1.getName(),
+  nickname: dummyNormalAccount1.getNickname(),
+  bio: dummyNormalAccount1.getBio(),
 };
 export const partialAccount2: PartialAccount = {
-  id: dummyAccount2.getID(),
-  name: dummyAccount2.getName(),
-  nickname: dummyAccount2.getNickname(),
-  bio: dummyAccount2.getBio(),
+  id: dummyNormalAccount2.getID(),
+  name: dummyNormalAccount2.getName(),
+  nickname: dummyNormalAccount2.getNickname(),
+  bio: dummyNormalAccount2.getBio(),
 };
 export const partialAccounts = [partialAccount1, partialAccount2];
 

--- a/pkg/notes/mod.ts
+++ b/pkg/notes/mod.ts
@@ -8,7 +8,10 @@ import {
 } from '../adaptors/authenticateMiddleware.js';
 import { prismaClient } from '../adaptors/prisma.js';
 import { SnowflakeIDGenerator } from '../id/mod.js';
-import { accountModule } from '../intermodule/account.js';
+import {
+  accountModule,
+  dummyAccountModuleFacade,
+} from '../intermodule/account.js';
 import {
   dummyTimelineModuleFacade,
   timelineModuleFacade,
@@ -91,6 +94,7 @@ const renoteService = new RenoteService(
   noteRepository,
   idGenerator,
   attachmentRepository,
+  isProduction ? accountModule : dummyAccountModuleFacade,
 );
 const controller = new NoteController(
   createService,

--- a/pkg/notes/service/renote.ts
+++ b/pkg/notes/service/renote.ts
@@ -43,7 +43,6 @@ export class RenoteService {
     // NOTE: PUBLIC, HOME note can be renote
     switch (visibility) {
       case 'PUBLIC':
-        break;
       case 'HOME':
         break;
       default:
@@ -61,6 +60,9 @@ export class RenoteService {
     const originalNote = Option.unwrap(originalNoteRes);
 
     switch (originalNote.getVisibility()) {
+      case 'PUBLIC':
+      case 'HOME':
+        break;
       case 'FOLLOWERS':
         // NOTE: FOLLOWERS note can renote only author
         if (originalNote.getAuthorID() !== authorID) {

--- a/pkg/notes/service/renote.ts
+++ b/pkg/notes/service/renote.ts
@@ -61,11 +61,6 @@ export class RenoteService {
     const originalNote = Option.unwrap(originalNoteRes);
 
     switch (originalNote.getVisibility()) {
-      case 'PUBLIC':
-        break;
-      case 'HOME':
-        break;
-
       case 'FOLLOWERS':
         // NOTE: FOLLOWERS note can renote only author
         if (originalNote.getAuthorID() !== authorID) {
@@ -115,16 +110,14 @@ export class RenoteService {
 
   private isAllowed(actor: Account, visibility: NoteVisibility): boolean {
     // NOTE: actor must be active, not frozen
-    if (!(actor.getStatus() === 'active' || actor.getFrozen() === 'normal')) {
+    if (actor.getStatus() !== 'active') {
       return false;
     }
 
-    if (actor.getStatus() === 'notActivated') {
+    if (actor.getFrozen() !== 'normal') {
       return false;
     }
-    if (actor.getFrozen() === 'frozen') {
-      return false;
-    }
+
     if (actor.getSilenced() === 'silenced') {
       // NOTE: silenced account can not set note visibility to PUBLIC
       if (visibility === 'PUBLIC') {


### PR DESCRIPTION
## What does this PR do?
close #606 
- ノートがリノートできるかどうかをチェックするように
- 元ノートより公開範囲を広く設定した場合にエラーになるように
  - テストの追加
- アカウントの権限チェック
- テストデータの追加と、ファクトリ関数の実装

## Additional information
アカウントの権限チェック(サイレンスされている時はPUBLICを選択できないようにする など)をCreateNoteServiceにも実装する必要がありそう