### PR TITLE
feat: return reactions GET /notes/:id ,fix broken serializer

### DIFF
--- a/pkg/notes/adaptor/controller/note.ts
+++ b/pkg/notes/adaptor/controller/note.ts
@@ -101,6 +101,14 @@ export class NoteController {
     }
     const attachments = Result.unwrap(attachmentsRes);
 
+    const reactionsRes = await this.fetchService.fetchNoteReactions(
+      note.getID(),
+    );
+    if (Result.isErr(reactionsRes)) {
+      return reactionsRes;
+    }
+    const reactions = Result.unwrap(reactionsRes);
+
     return Result.ok({
       id: note.getID(),
       content: note.getContent(),
@@ -120,6 +128,12 @@ export class NoteController {
           author_id: v.getAuthorId(),
           nsfw: v.isNsfw(),
           thumbnail: v.getThumbnailUrl(),
+        };
+      }),
+      reactions: reactions.map((v) => {
+        return {
+          emoji: v.getEmoji(),
+          reacted_by: v.getAccountID(),
         };
       }),
       author: {
@@ -157,13 +171,13 @@ export class NoteController {
     }
     const renote = Result.unwrap(renoteRes);
 
-    const attachmetsRes = await this.fetchService.fetchNoteAttachments(
+    const attachmentsRes = await this.fetchService.fetchNoteAttachments(
       renote.getID(),
     );
-    if (Result.isErr(attachmetsRes)) {
-      return attachmetsRes;
+    if (Result.isErr(attachmentsRes)) {
+      return attachmentsRes;
     }
-    const attachments = Result.unwrap(attachmetsRes);
+    const attachments = Result.unwrap(attachmentsRes);
 
     return Result.ok({
       id: renote.getID(),

--- a/pkg/notes/adaptor/repository/dummy.ts
+++ b/pkg/notes/adaptor/repository/dummy.ts
@@ -242,6 +242,12 @@ export class InMemoryReactionRepository implements ReactionRepository {
 
     return Result.ok(reactions);
   }
+  async findByNoteID(id: NoteID): Promise<Result.Result<Error, Reaction[]>> {
+    const reactions = [...this.reactions.entries()]
+      .filter((v) => this.disassembleID(v[0]).noteID === id)
+      .map((v) => v[1]);
+    return Result.ok(reactions);
+  }
   async deleteByID(id: { accountID: AccountID; noteID: NoteID }): Promise<
     Result.Result<Error, void>
   > {

--- a/pkg/notes/adaptor/repository/prisma.ts
+++ b/pkg/notes/adaptor/repository/prisma.ts
@@ -255,7 +255,7 @@ export class PrismaNoteAttachmentRepository
   constructor(private readonly client: PrismaClient) {}
 
   private deserialize(data: DeserializeNoteAttachmentArgs): Medium[] {
-    data.map((v) => {
+    return data.map((v) => {
       const medium = v.medium;
       return Medium.reconstruct({
         authorId: medium.authorId as AccountID,
@@ -268,8 +268,6 @@ export class PrismaNoteAttachmentRepository
         url: medium.url,
       });
     });
-
-    return [];
   }
 
   async create(
@@ -376,6 +374,21 @@ export class PrismaReactionRepository implements ReactionRepository {
       const res = await this.client.reaction.findMany({
         where: {
           reactedById: id,
+          deletedAt: undefined,
+        },
+      });
+
+      return Result.ok(res.map((v) => this.deserialize(v)));
+    } catch (e) {
+      return Result.err(e as Error);
+    }
+  }
+
+  async findByNoteID(id: NoteID): Promise<Result.Result<Error, Reaction[]>> {
+    try {
+      const res = await this.client.reaction.findMany({
+        where: {
+          reactedToId: id,
           deletedAt: undefined,
         },
       });

--- a/pkg/notes/adaptor/validator/schema.ts
+++ b/pkg/notes/adaptor/validator/schema.ts
@@ -1,4 +1,5 @@
 import { z } from '@hono/zod-openapi';
+import { EmojiSchema } from '../../model/reaction.js';
 
 export const CommonErrorSchema = z.object({
   // ToDo: define error code list (oneOf)
@@ -41,6 +42,17 @@ export const noteAttachmentSchema = z.object({
   thumbnail: z.string().openapi({
     example: 'https://images.example.com/image_thumbnail.webp',
     description: 'attachment thumbnail url',
+  }),
+});
+
+export const reactionSchema = z.object({
+  emoji: EmojiSchema.openapi({
+    description: 'Reaction Emoji (Unicode or Custom Emoji)',
+    examples: ['🎉', '<:custom_emoji:123456789>'],
+  }),
+  reacted_by: z.string().openapi({
+    example: '38477395',
+    description: 'Reacted account ID',
   }),
 });
 
@@ -145,7 +157,9 @@ export const GetNoteResponseSchema = z.object({
     followed_count: z.number(),
     following_count: z.number(),
   }),
-  // ToDo: add reactions
+  reactions: z.array(reactionSchema).openapi({
+    description: 'Reactions',
+  }),
   attachment_files: z.array(noteAttachmentSchema).max(16).openapi({
     description: 'Note Attachment Media',
   }),

--- a/pkg/notes/mod.ts
+++ b/pkg/notes/mod.ts
@@ -30,6 +30,7 @@ import {
   PrismaBookmarkRepository,
   PrismaNoteAttachmentRepository,
   PrismaNoteRepository,
+  PrismaReactionRepository,
 } from './adaptor/repository/prisma.js';
 import {
   CreateBookmarkRoute,
@@ -57,7 +58,9 @@ const noteRepository = isProduction
 const bookmarkRepository = isProduction
   ? new PrismaBookmarkRepository(prismaClient)
   : new InMemoryBookmarkRepository();
-const reactionRepository = new InMemoryReactionRepository();
+const reactionRepository = isProduction
+  ? new PrismaReactionRepository(prismaClient)
+  : new InMemoryReactionRepository();
 const attachmentRepository = isProduction
   ? new PrismaNoteAttachmentRepository(prismaClient)
   : new InMemoryNoteAttachmentRepository([], []);
@@ -89,6 +92,7 @@ const fetchService = new FetchService(
   noteRepository,
   accountModule,
   attachmentRepository,
+  reactionRepository,
 );
 const renoteService = new RenoteService(
   noteRepository,

--- a/pkg/notes/model/reaction.ts
+++ b/pkg/notes/model/reaction.ts
@@ -2,15 +2,15 @@ import { z } from '@hono/zod-openapi';
 import type { AccountID } from '../../accounts/model/account.js';
 import type { NoteID } from './note.js';
 
-const UnicodeEmojiSchema = z
+export const UnicodeEmojiSchema = z
   .string()
   .regex(
     /[\u2700-\u27BF]|[\uE000-\uF8FF]|\uD83C[\uDC00-\uDFFF]|\uD83D[\uDC00-\uDFFF]|[\u2011-\u26FF]|\uD83E[\uDD10-\uDDFF]/,
   );
 
-const CustomEmojiSchema = z.string().regex(/<:(\w+):(\d+)>/);
+export const CustomEmojiSchema = z.string().regex(/<:(\w+):(\d+)>/);
 
-const EmojiSchema = z.union([UnicodeEmojiSchema, CustomEmojiSchema]);
+export const EmojiSchema = z.union([UnicodeEmojiSchema, CustomEmojiSchema]);
 
 type Emoji = z.infer<typeof EmojiSchema>;
 

--- a/pkg/notes/model/repository.ts
+++ b/pkg/notes/model/repository.ts
@@ -53,6 +53,7 @@ export interface ReactionRepository {
     accountID: AccountID;
   }): Promise<Option.Option<Reaction>>;
   reactionsByAccount(id: AccountID): Promise<Result.Result<Error, Reaction[]>>;
+  findByNoteID(id: NoteID): Promise<Result.Result<Error, Reaction[]>>;
   deleteByID(id: {
     noteID: NoteID;
     accountID: AccountID;

--- a/pkg/notes/service/fetch.test.ts
+++ b/pkg/notes/service/fetch.test.ts
@@ -9,6 +9,7 @@ import { dummyAccountModuleFacade } from '../../intermodule/account.js';
 import {
   InMemoryNoteAttachmentRepository,
   InMemoryNoteRepository,
+  InMemoryReactionRepository,
 } from '../adaptor/repository/dummy.js';
 import { Note, type NoteID } from '../model/note.js';
 import { FetchService } from './fetch.js';
@@ -94,11 +95,13 @@ const noteAttachmentRepository = new InMemoryNoteAttachmentRepository(
   [testMedium, testNSFWMedium],
   [['1' as NoteID, ['300' as MediumID, '301' as MediumID]]],
 );
+const reactionRepository = new InMemoryReactionRepository();
 
 const service = new FetchService(
   repository,
   dummyAccountModuleFacade,
   noteAttachmentRepository,
+  reactionRepository,
 );
 
 describe('FetchService', () => {

--- a/pkg/notes/service/fetch.ts
+++ b/pkg/notes/service/fetch.ts
@@ -3,9 +3,11 @@ import { Option, Result } from '@mikuroxina/mini-fn';
 import type { Medium } from '../../drive/model/medium.js';
 import type { AccountModuleFacade } from '../../intermodule/account.js';
 import type { Note, NoteID } from '../model/note.js';
+import type { Reaction } from '../model/reaction.js';
 import type {
   NoteAttachmentRepository,
   NoteRepository,
+  ReactionRepository,
 } from '../model/repository.js';
 
 export class FetchService {
@@ -13,6 +15,7 @@ export class FetchService {
     private readonly noteRepository: NoteRepository,
     private readonly accountModule: AccountModuleFacade,
     private readonly noteAttachmentRepository: NoteAttachmentRepository,
+    private readonly reactionRepository: ReactionRepository,
   ) {}
 
   async fetchNoteByID(noteID: NoteID): Promise<Option.Option<Note>> {
@@ -44,5 +47,11 @@ export class FetchService {
     noteID: NoteID,
   ): Promise<Result.Result<Error, Medium[]>> {
     return await this.noteAttachmentRepository.findByNoteID(noteID);
+  }
+
+  async fetchNoteReactions(
+    noteID: NoteID,
+  ): Promise<Result.Result<Error, Reaction[]>> {
+    return await this.reactionRepository.findByNoteID(noteID);
   }
 }

--- a/resources/schema.json
+++ b/resources/schema.json
@@ -2072,6 +2072,41 @@
                         "following_count"
                       ]
                     },
+                    "reactions": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "emoji": {
+                            "anyOf": [
+                              {
+                                "type": "string",
+                                "pattern": "[\\u2700-\\u27BF]|[\\uE000-\\uF8FF]|\\uD83C[\\uDC00-\\uDFFF]|\\uD83D[\\uDC00-\\uDFFF]|[\\u2011-\\u26FF]|\\uD83E[\\uDD10-\\uDDFF]"
+                              },
+                              {
+                                "type": "string",
+                                "pattern": "<:(\\w+):(\\d+)>"
+                              }
+                            ],
+                            "description": "Reaction Emoji (Unicode or Custom Emoji)",
+                            "examples": [
+                              "🎉",
+                              "<:custom_emoji:123456789>"
+                            ]
+                          },
+                          "reacted_by": {
+                            "type": "string",
+                            "description": "Reacted account ID",
+                            "example": "38477395"
+                          }
+                        },
+                        "required": [
+                          "emoji",
+                          "reacted_by"
+                        ]
+                      },
+                      "description": "Reactions"
+                    },
                     "attachment_files": {
                       "type": "array",
                       "items": {
@@ -2141,6 +2176,7 @@
                     "visibility",
                     "created_at",
                     "author",
+                    "reactions",
                     "attachment_files"
                   ]
                 }


### PR DESCRIPTION
## What does this PR do?
close #701 
- APIエンドポイントの修正
  - ノート取得時にリアクションを取得できるように
  - APIスキーマ定義の更新
- AttachmentのPrismaRepositoryで、シリアライズが壊れていたのを修正

## Additional information
なし