### PR TITLE
feat: Accountモジュールのエラー型を定義してそれを使うように

### DIFF
--- a/pkg/accounts/adaptor/captcha/turnstile.ts
+++ b/pkg/accounts/adaptor/captcha/turnstile.ts
@@ -23,9 +23,10 @@ export class TurnstileCaptchaValidator implements Captcha {
     );
     const response = await res.json();
     if (!response.success) {
+      const errorResponse = (({ success, ...rest }) => rest)(response);
       return Option.some(
         new AccountCaptchaTokenInvalidError('failed to verify captcha token', {
-          cause: new Error(response['error-codes'][0]),
+          cause: errorResponse,
         }),
       );
     }

--- a/pkg/accounts/adaptor/captcha/turnstile.ts
+++ b/pkg/accounts/adaptor/captcha/turnstile.ts
@@ -25,7 +25,7 @@ export class TurnstileCaptchaValidator implements Captcha {
     if (!response.success) {
       return Option.some(
         new AccountCaptchaTokenInvalidError('failed to verify captcha token', {
-          cause: null,
+          cause: new Error(response['error-codes'][0]),
         }),
       );
     }

--- a/pkg/accounts/adaptor/captcha/turnstile.ts
+++ b/pkg/accounts/adaptor/captcha/turnstile.ts
@@ -23,10 +23,10 @@ export class TurnstileCaptchaValidator implements Captcha {
     );
     const response = await res.json();
     if (!response.success) {
-      const errorResponse = (({ success, ...rest }) => rest)(response);
+      const { success, ...rest } = response;
       return Option.some(
         new AccountCaptchaTokenInvalidError('failed to verify captcha token', {
-          cause: errorResponse,
+          cause: rest,
         }),
       );
     }

--- a/pkg/accounts/adaptor/captcha/turnstile.ts
+++ b/pkg/accounts/adaptor/captcha/turnstile.ts
@@ -1,6 +1,7 @@
 import { Ether, Option } from '@mikuroxina/mini-fn';
 
 import { type Captcha, captchaSymbol } from '../../model/captcha.js';
+import { AccountCaptchaTokenInvalidError } from '../../model/errors.js';
 
 export class TurnstileCaptchaValidator implements Captcha {
   constructor(private readonly secret: string) {}
@@ -22,7 +23,11 @@ export class TurnstileCaptchaValidator implements Captcha {
     );
     const response = await res.json();
     if (!response.success) {
-      return Option.some(new Error('failed to verify captcha token'));
+      return Option.some(
+        new AccountCaptchaTokenInvalidError('failed to verify captcha token', {
+          cause: null,
+        }),
+      );
     }
 
     return Option.none();

--- a/pkg/accounts/adaptor/presenter/errors.ts
+++ b/pkg/accounts/adaptor/presenter/errors.ts
@@ -1,0 +1,71 @@
+import { z } from '@hono/zod-openapi';
+
+export const InternalError = z.literal('INTERNAL_ERROR').openapi({
+  description: 'Internal server error.',
+});
+
+export const InvalidAccountName = z.literal('INVALID_ACCOUNT_NAME').openapi({
+  description: 'Account name is invalid.',
+});
+export const TooLongAccountName = z.literal('TOO_LONG_ACCOUNT_NAME').openapi({
+  description: 'Account name is too long.',
+});
+export const EMailInUse = z.literal('EMAIL_IN_USE').openapi({
+  description: 'Account email is already in use.',
+});
+export const YouAreBot = z.literal('YOU_ARE_BOT').openapi({
+  description: 'CAPTCHA verification failed.',
+});
+export const AccountNameInUse = z.literal('ACCOUNT_NAME_IN_USE').openapi({
+  description: 'Account name is already in use.',
+});
+export const InvalidSequence = z.literal('INVALID_SEQUENCE').openapi({
+  description: 'Contains unusable character types in parameters.',
+});
+export const VulnerablePassphrase = z.literal('VULNERABLE_PASSPHRASE').openapi({
+  description: 'Passphrase is too weak.',
+});
+export const AccountNotFound = z.literal('ACCOUNT_NOT_FOUND').openapi({
+  description: 'Account not found.',
+});
+export const InvalidETag = z.literal('INVALID_ETAG').openapi({
+  description: 'ETag is invalid.',
+});
+export const AlreadyFrozen = z.literal('ALREADY_FROZEN').openapi({
+  description: 'Account is already frozen.',
+});
+export const NoPermission = z.literal('NO_PERMISSION').openapi({
+  description: "You can't do this action.",
+});
+export const AccountAlreadyVerified = z
+  .literal('ACCOUNT_ALREADY_VERIFIED')
+  .openapi({
+    description: 'Account email address is already verified.',
+  });
+export const InvalidAccessToken = z.literal('INVALID_TOKEN').openapi({
+  description: 'Access token is invalid.',
+});
+export const FailedToLogin = z.literal('FAILED_TO_LOGIN').openapi({
+  description: 'Failed to login. Passphrase or Account Name is invalid.',
+});
+export const YouAreFrozen = z.literal('YOU_ARE_FROZEN').openapi({
+  description: "Your account is frozen, you can't login.",
+});
+export const InvalidRefreshToken = z.literal('INVALID_TOKEN').openapi({
+  description: 'Refresh token is invalid.',
+});
+export const InvalidEMailVerifyToken = z.literal('INVALID_TOKEN').openapi({
+  description: 'EMail verification token is invalid.',
+});
+export const ExpiredToken = z.literal('EXPIRED_TOKEN').openapi({
+  description: 'Refresh or Access token is expired. Please re-login.',
+});
+export const AlreadyFollowing = z.literal('ALREADY_FOLLOWING').openapi({
+  description: 'You are already following this account.',
+});
+export const YouAreBlocked = z.literal('YOU_ARE_BLOCKED').openapi({
+  description: 'You are blocked by this account.',
+});
+export const YouAreNotFollowing = z.literal('YOU_ARE_NOT_FOLLOWING').openapi({
+  description: 'You are not following this account.',
+});

--- a/pkg/accounts/adaptor/repository/dummy.ts
+++ b/pkg/accounts/adaptor/repository/dummy.ts
@@ -1,6 +1,7 @@
 import { Ether, Option, Result } from '@mikuroxina/mini-fn';
 
 import type { Account, AccountID } from '../../model/account.js';
+import { AccountNotFoundError } from '../../model/errors.js';
 import type { AccountFollow } from '../../model/follow.js';
 import type { InactiveAccount } from '../../model/inactiveAccount.js';
 import {
@@ -153,7 +154,7 @@ export class InMemoryAccountFollowRepository
       (f) => f.getFromID() === accountID && f.getTargetID() === targetID,
     );
     if (!follow) {
-      return Result.err(new Error('Not found'));
+      return Result.err(new AccountNotFoundError('not found', { cause: null }));
     }
 
     this.data.delete(follow);

--- a/pkg/accounts/mod.ts
+++ b/pkg/accounts/mod.ts
@@ -383,6 +383,9 @@ accounts.openapi(LoginRoute, async (c) => {
     if (error instanceof AccountAuthenticationFailedError) {
       return c.json({ error: 'FAILED_TO_LOGIN' as const }, 400);
     }
+    if (error instanceof AccountNotFoundError) {
+      return c.json({ error: 'FAILED_TO_LOGIN' as const }, 400);
+    }
     if (error instanceof AccountLoginRejectedError) {
       return c.json({ error: 'YOU_ARE_FROZEN' as const }, 403);
     }

--- a/pkg/accounts/mod.ts
+++ b/pkg/accounts/mod.ts
@@ -22,6 +22,25 @@ import {
   prismaVerifyTokenRepo,
 } from './adaptor/repository/prisma.js';
 import type { AccountName } from './model/account.js';
+import {
+  AccountAlreadyFollowingError,
+  AccountAlreadyFrozenError,
+  AccountAuthenticationFailedError,
+  AccountCaptchaTokenInvalidError,
+  AccountFollowingBlockedError,
+  AccountInsufficientPermissionError,
+  AccountLoginRejectedError,
+  AccountMailAddressAlreadyInUseError,
+  AccountMailAddressAlreadyVerifiedError,
+  AccountMailAddressLengthError,
+  AccountMailAddressVerificationTokenInvalidError,
+  AccountNameAlreadyInUseError,
+  AccountNameInvalidUsageError,
+  AccountNameTooLongError,
+  AccountNotFollowingError,
+  AccountNotFoundError,
+  AccountPassphraseRequirementsNotMetError,
+} from './model/errors.js';
 import { accountRepoSymbol } from './model/repository.js';
 import {
   CreateAccountRoute,
@@ -182,7 +201,23 @@ accounts.openapi(CreateAccountRoute, async (c) => {
 
   const res = await controller.createAccount(name, email, passphrase);
   if (Result.isErr(res)) {
-    return c.json({ error: res[1].message }, 400);
+    const error = Result.unwrapErr(res);
+    if (error instanceof AccountNameInvalidUsageError) {
+      return c.json({ error: 'INVALID_ACCOUNT_NAME' as const }, 400);
+    }
+    if (error instanceof AccountNameTooLongError) {
+      return c.json({ error: 'TOO_LONG_ACCOUNT_NAME' as const }, 400);
+    }
+    if (error instanceof AccountCaptchaTokenInvalidError) {
+      return c.json({ error: 'YOU_ARE_BOT' as const }, 400);
+    }
+    if (error instanceof AccountMailAddressAlreadyInUseError) {
+      return c.json({ error: 'EMAIL_IN_USE' as const }, 409);
+    }
+    if (error instanceof AccountNameAlreadyInUseError) {
+      return c.json({ error: 'ACCOUNT_NAME_IN_USE' as const }, 409);
+    }
+    return c.json({ error: 'INTERNAL_ERROR' as const }, 500);
   }
 
   return c.json(res[1], 200);
@@ -199,7 +234,7 @@ accounts.openapi(UpdateAccountRoute, async (c) => {
   const eTag = c.req.header('If-Match');
 
   if (!eTag) {
-    return c.json({ error: 'INVALID_ETAG' }, 412);
+    return c.json({ error: 'INVALID_ETAG' as const }, 412);
   }
 
   const res = await controller.updateAccount(
@@ -214,7 +249,18 @@ accounts.openapi(UpdateAccountRoute, async (c) => {
     actorName,
   );
   if (Result.isErr(res)) {
-    return c.json({ error: res[1].message }, 400);
+    const error = Result.unwrapErr(res);
+
+    if (error instanceof AccountMailAddressLengthError) {
+      return c.json({ error: 'INVALID_SEQUENCE' as const }, 400);
+    }
+    if (error instanceof AccountPassphraseRequirementsNotMetError) {
+      return c.json({ error: 'VULNERABLE_PASSPHRASE' as const }, 400);
+    }
+    if (error instanceof AccountNotFoundError) {
+      return c.json({ error: 'ACCOUNT_NOT_FOUND' as const }, 404);
+    }
+    return c.json({ error: 'INTERNAL_ERROR' as const }, 500);
   }
 
   return c.json(res[1], 200);
@@ -230,7 +276,19 @@ accounts.openapi(FreezeAccountRoute, async (c) => {
 
   const res = await controller.freezeAccount(targetName, actor);
   if (Result.isErr(res)) {
-    return c.json({ error: res[1].message }, 400);
+    const error = Result.unwrapErr(res);
+
+    if (error instanceof AccountNotFoundError) {
+      return c.json({ error: 'ACCOUNT_NOT_FOUND' as const }, 404);
+    }
+    if (error instanceof AccountAlreadyFrozenError) {
+      return c.json({ error: 'ALREADY_FROZEN' as const }, 400);
+    }
+    if (error instanceof AccountInsufficientPermissionError) {
+      return c.json({ error: 'NO_PERMISSION' as const }, 403);
+    }
+
+    return c.json({ error: 'INTERNAL_ERROR' as const }, 500);
   }
 
   return new Response(null, { status: 204 });
@@ -246,7 +304,16 @@ accounts.openapi(UnFreezeAccountRoute, async (c) => {
 
   const res = await controller.unFreezeAccount(targetName, actor);
   if (Result.isErr(res)) {
-    return c.json({ error: res[1].message }, 400);
+    const error = Result.unwrapErr(res);
+
+    if (error instanceof AccountNotFoundError) {
+      return c.json({ error: 'ACCOUNT_NOT_FOUND' as const }, 404);
+    }
+    if (error instanceof AccountInsufficientPermissionError) {
+      return c.json({ error: 'NO_PERMISSION' as const }, 403);
+    }
+
+    return c.json({ error: 'INTERNAL_ERROR' as const }, 500);
   }
 
   return new Response(null, { status: 204 });
@@ -258,7 +325,16 @@ accounts.openapi(VerifyEmailRoute, async (c) => {
 
   const res = await controller.verifyEmail(name, token);
   if (Result.isErr(res)) {
-    return c.json({ error: res[1].message }, 400);
+    const error = Result.unwrapErr(res);
+
+    if (error instanceof AccountNotFoundError) {
+      return c.json({ error: 'ACCOUNT_NOT_FOUND' as const }, 404);
+    }
+    if (error instanceof AccountMailAddressVerificationTokenInvalidError) {
+      return c.json({ error: 'INVALID_TOKEN' as const }, 400);
+    }
+
+    return c.json({ error: 'INTERNAL_ERROR' as const }, 500);
   }
 
   return new Response(null, { status: 204 });
@@ -273,7 +349,12 @@ accounts.openapi(GetAccountRoute, async (c) => {
 
   const res = await controller.getAccount(id);
   if (Result.isErr(res)) {
-    return c.json({ error: res[1].message }, 404);
+    const error = Result.unwrapErr(res);
+
+    if (error instanceof AccountNotFoundError) {
+      return c.json({ error: 'ACCOUNT_NOT_FOUND' as const }, 404);
+    }
+    return c.json({ error: 'INTERNAL_ERROR' as const }, 500);
   }
 
   return c.json(
@@ -297,7 +378,16 @@ accounts.openapi(LoginRoute, async (c) => {
 
   const res = await controller.login(name as AccountName, passphrase);
   if (Result.isErr(res)) {
-    return c.json({ error: res[1].message }, 400);
+    const error = Result.unwrapErr(res);
+
+    if (error instanceof AccountAuthenticationFailedError) {
+      return c.json({ error: 'FAILED_TO_LOGIN' as const }, 400);
+    }
+    if (error instanceof AccountLoginRejectedError) {
+      return c.json({ error: 'YOU_ARE_FROZEN' as const }, 403);
+    }
+
+    return c.json({ error: 'INTERNAL_ERROR' as const }, 500);
   }
 
   return c.json(res[1], 200);
@@ -316,7 +406,17 @@ accounts.openapi(SilenceAccountRoute, async (c) => {
   const name = c.req.param('name');
   const res = await controller.silenceAccount(name, actor);
   if (Result.isErr(res)) {
-    return c.json({ error: res[1].message }, { status: 400 });
+    const error = Result.unwrapErr(res);
+
+    if (error instanceof AccountInsufficientPermissionError) {
+      return c.json({ error: 'NO_PERMISSION' as const }, 403);
+    }
+
+    if (error instanceof AccountNotFoundError) {
+      return c.json({ error: 'ACCOUNT_NOT_FOUND' as const }, 404);
+    }
+
+    return c.json({ error: 'INTERNAL_ERROR' }, 500);
   }
 
   return new Response(null, { status: 204 });
@@ -331,7 +431,16 @@ accounts.openapi(UnSilenceAccountRoute, async (c) => {
   const name = c.req.param('name');
   const res = await controller.unSilenceAccount(name, actor);
   if (Result.isErr(res)) {
-    return c.json({ error: res[1].message }, 400);
+    const error = Result.unwrapErr(res);
+
+    if (error instanceof AccountInsufficientPermissionError) {
+      return c.json({ error: 'NO_PERMISSION' as const }, 403);
+    }
+    if (error instanceof AccountNotFoundError) {
+      return c.json({ error: 'ACCOUNT_NOT_FOUND' as const }, 404);
+    }
+
+    return c.json({ error: 'INTERNAL_ERROR' }, 500);
   }
 
   return new Response(null, { status: 204 });
@@ -347,7 +456,20 @@ accounts.openapi(FollowAccountRoute, async (c) => {
 
   const res = await controller.followAccount(fromName, targetName);
   if (Result.isErr(res)) {
-    return c.json({ error: res[1].message }, 403);
+    const error = Result.unwrapErr(res);
+
+    if (error instanceof AccountAlreadyFollowingError) {
+      return c.json({ error: 'ALREADY_FOLLOWING' as const }, 403);
+    }
+    if (error instanceof AccountFollowingBlockedError) {
+      return c.json({ error: 'YOU_ARE_BLOCKED' as const }, 403);
+    }
+
+    if (error instanceof AccountNotFoundError) {
+      return c.json({ error: 'ACCOUNT_NOT_FOUND' as const }, 404);
+    }
+
+    return c.json({ error: 'INTERNAL_ERROR' }, 500);
   }
 
   return c.json({}, 201);
@@ -363,7 +485,16 @@ accounts.openapi(UnFollowAccountRoute, async (c) => {
 
   const res = await controller.unFollowAccount(fromName, targetName);
   if (Result.isErr(res)) {
-    return c.json({ error: res[1].message }, 400);
+    const error = Result.unwrapErr(res);
+
+    if (error instanceof AccountNotFoundError) {
+      return c.json({ error: 'ACCOUNT_NOT_FOUND' as const }, 404);
+    }
+    if (error instanceof AccountNotFollowingError) {
+      return c.json({ error: 'YOU_ARE_NOT_FOLLOW_ACCOUNT' as const }, 403);
+    }
+
+    return c.json({ error: 'INTERNAL_ERROR' }, 500);
   }
 
   return new Response(null, { status: 204 });
@@ -374,7 +505,16 @@ accounts.openapi(ResendVerificationEmailRoute, async (c) => {
 
   const res = await controller.resendVerificationEmail(name);
   if (Result.isErr(res)) {
-    return c.json({ error: res[1].message }, 400);
+    const error = Result.unwrapErr(res);
+
+    if (error instanceof AccountNotFoundError) {
+      return c.json({ error: 'ACCOUNT_NOT_FOUND' as const }, 404);
+    }
+    if (error instanceof AccountMailAddressAlreadyVerifiedError) {
+      return c.json({ error: 'ACCOUNT_ALREADY_VERIFIED' as const }, 400);
+    }
+
+    return c.json({ error: 'INTERNAL_ERROR' as const }, 500);
   }
 
   return new Response(null, { status: 204 });
@@ -384,7 +524,13 @@ accounts.openapi(GetAccountFollowingRoute, async (c) => {
   const id = c.req.param('id');
   const res = await controller.fetchFollowing(id);
   if (Result.isErr(res)) {
-    return c.json({ error: res[1].message }, 404);
+    const error = Result.unwrapErr(res);
+
+    if (error instanceof AccountNotFoundError) {
+      return c.json({ error: 'ACCOUNT_NOT_FOUND' as const }, 404);
+    }
+
+    return c.json({ error: 'INTERNAL_ERROR' as const }, 500);
   }
   const unwrap = Result.unwrap(res);
   return c.json(
@@ -408,7 +554,13 @@ accounts.openapi(GetAccountFollowerRoute, async (c) => {
   const id = c.req.param('id');
   const res = await controller.fetchFollower(id);
   if (Result.isErr(res)) {
-    return c.json({ error: res[1].message }, 404);
+    const error = Result.unwrapErr(res);
+
+    if (error instanceof AccountNotFoundError) {
+      return c.json({ error: 'ACCOUNT_NOT_FOUND' as const }, 404);
+    }
+
+    return c.json({ error: 'INTERNAL_ERROR' as const }, 500);
   }
   const unwrap = Result.unwrap(res);
   return c.json(

--- a/pkg/accounts/model/errors.ts
+++ b/pkg/accounts/model/errors.ts
@@ -1,0 +1,260 @@
+/*
+Error naming convention:
+(Model or Service Name) +
+((adverb or prototype of verb) or 3rd-person-singular-present-tense or past participle) +
+noun phrase +
+Error
+*/
+
+/**
+ * Internal Error
+ */
+export class AccountInternalError extends Error {
+  constructor(message: string, options: { cause: unknown }) {
+    super(message);
+    this.name = 'AccountInternalError';
+    this.cause = options.cause;
+  }
+}
+
+/**
+ * Account don't have permission to do this action
+ */
+export class AccountInsufficientPermissionError extends Error {
+  constructor(message: string, options: { cause: unknown }) {
+    super(message);
+    this.name = 'AccountInsufficientPermissionError';
+    this.cause = options.cause;
+  }
+}
+
+/**
+ * Account is frozen.
+ */
+export class AccountLoginRejectedError extends Error {
+  constructor(message: string, options: { cause: unknown }) {
+    super(message);
+    this.name = 'AccountLoginRejectedError';
+    this.cause = options.cause;
+  }
+}
+
+/**
+ * Account not found
+ */
+export class AccountNotFoundError extends Error {
+  constructor(message: string, options: { cause: unknown }) {
+    super(message);
+    this.name = 'AccountNotFoundError';
+    this.cause = options.cause;
+  }
+}
+
+/**
+ * Account mail address is already in use
+ */
+export class AccountMailAddressAlreadyInUseError extends Error {
+  constructor(message: string, options: { cause: unknown }) {
+    super(message);
+    this.name = 'AccountMailAddressAlreadyInUseError';
+    this.cause = options.cause;
+  }
+}
+
+/**
+ * Account name is already in use
+ */
+export class AccountNameAlreadyInUseError extends Error {
+  constructor(message: string, options: { cause: unknown }) {
+    super(message);
+    this.name = '';
+    this.cause = options.cause;
+  }
+}
+
+/**
+ * Account name is too long
+ */
+export class AccountNameTooLongError extends Error {
+  constructor(message: string, options: { cause: unknown }) {
+    super(message);
+    this.name = '';
+    this.cause = options.cause;
+  }
+}
+
+/**
+ * Account Nickname is too short
+ */
+export class AccountNicknameTooShortError extends Error {
+  constructor(message: string, options: { cause: unknown }) {
+    super(message);
+    this.name = 'AccountNicknameTooShortError';
+    this.cause = options.cause;
+  }
+}
+
+/**
+ * Account nickname is too long
+ */
+export class AccountNicknameTooLongError extends Error {
+  constructor(message: string, options: { cause: unknown }) {
+    super(message);
+    this.name = 'AccountNicknameTooLongError';
+    this.cause = options.cause;
+  }
+}
+
+/**
+ * Account mail address length out of range
+ */
+export class AccountMailAddressLengthError extends Error {
+  constructor(message: string, options: { cause: unknown }) {
+    super(message);
+    this.name = 'AccountMailAddressLengthError';
+    this.cause = options.cause;
+  }
+}
+
+/**
+ * Account name's character sequence is invalid
+ */
+export class AccountNameInvalidUsageError extends Error {
+  constructor(message: string, options: { cause: unknown }) {
+    super(message);
+    this.name = '';
+    this.cause = options.cause;
+  }
+}
+
+/**
+ * CAPTCHA verification failed
+ */
+export class AccountCaptchaTokenInvalidError extends Error {
+  constructor(message: string, options: { cause: unknown }) {
+    super(message);
+    this.name = '';
+    this.cause = options.cause;
+  }
+}
+
+/**
+ * Account passphrase is too weak
+ */
+export class AccountPassphraseRequirementsNotMetError extends Error {
+  constructor(message: string, options: { cause: unknown }) {
+    super(message);
+    this.name = '';
+    this.cause = options.cause;
+  }
+}
+
+/**
+ * Failed to log in
+ */
+export class AccountAuthenticationFailedError extends Error {
+  constructor(message: string, options: { cause: unknown }) {
+    super(message);
+    this.name = '';
+    this.cause = options.cause;
+  }
+}
+
+/**
+ * Account mail address is already verified
+ */
+export class AccountMailAddressAlreadyVerifiedError extends Error {
+  constructor(message: string, options: { cause: unknown }) {
+    super(message);
+    this.name = '';
+    this.cause = options.cause;
+  }
+}
+
+/**
+ * Account mail address verification token is invalid
+ */
+export class AccountMailAddressVerificationTokenInvalidError extends Error {
+  constructor(message: string, options: { cause: unknown }) {
+    super(message);
+    this.name = '';
+    this.cause = options.cause;
+  }
+}
+
+/**
+ * Refresh token is invalid
+ */
+export class AccountRefreshTokenInvalidError extends Error {
+  constructor(message: string, options: { cause: unknown }) {
+    super(message);
+    this.name = '';
+    this.cause = options.cause;
+  }
+}
+
+/**
+ * Refresh token is expired
+ */
+export class AccountRefreshTokenExpiredError extends Error {
+  constructor(message: string, options: { cause: unknown }) {
+    super(message);
+    this.name = '';
+    this.cause = options.cause;
+  }
+}
+
+/**
+ * Specified account is already frozen
+ */
+export class AccountAlreadyFrozenError extends Error {
+  constructor(message: string, options: { cause: unknown }) {
+    super(message);
+    this.name = '';
+    this.cause = options.cause;
+  }
+}
+
+/**
+ * Account info updating ETag is invalid
+ */
+export class AccountUpdateETagInvalidError extends Error {
+  constructor(message: string, options: { cause: unknown }) {
+    super(message);
+    this.name = '';
+    this.cause = options.cause;
+  }
+}
+
+/**
+ * Blocked by the account try to follow
+ */
+export class AccountFollowingBlockedError extends Error {
+  constructor(message: string, options: { cause: unknown }) {
+    super(message);
+    this.name = 'AccountFollowingBlockedError';
+    this.cause = options.cause;
+  }
+}
+
+/**
+ * Account is already following
+ */
+export class AccountAlreadyFollowingError extends Error {
+  constructor(message: string, options: { cause: unknown }) {
+    super(message);
+    this.name = 'AccountAlreadyFollowingError';
+    this.cause = options.cause;
+  }
+}
+
+/**
+ * Account is not following
+ */
+export class AccountNotFollowingError extends Error {
+  constructor(message: string, options: { cause: unknown }) {
+    super(message);
+    this.name = 'AccountNotFollowingError';
+    this.cause = options.cause;
+  }
+}

--- a/pkg/accounts/service/edit.ts
+++ b/pkg/accounts/service/edit.ts
@@ -6,6 +6,15 @@ import {
 } from '../../password/mod.js';
 import type { Account, AccountName } from '../model/account.js';
 import {
+  AccountInternalError,
+  AccountMailAddressLengthError,
+  AccountNicknameTooLongError,
+  AccountNicknameTooShortError,
+  AccountNotFoundError,
+  AccountPassphraseRequirementsNotMetError,
+  AccountUpdateETagInvalidError,
+} from '../model/errors.js';
+import {
   type AccountRepository,
   accountRepoSymbol,
 } from '../model/repository.js';
@@ -41,12 +50,16 @@ export class EditService {
   ): Promise<Result.Result<Error, boolean>> {
     const res = await this.accountRepository.findByName(target);
     if (Option.isNone(res)) {
-      return Result.err(new Error('account not found'));
+      return Result.err(
+        new AccountNotFoundError('account not found', { cause: null }),
+      );
     }
     const account = Option.unwrap(res);
     const actorRes = await this.accountRepository.findByName(actorName);
     if (Option.isNone(actorRes)) {
-      return Result.err(new Error('actor not found'));
+      return Result.err(
+        new AccountNotFoundError('actor not found', { cause: null }),
+      );
     }
     const actor = Option.unwrap(actorRes);
 
@@ -57,14 +70,20 @@ export class EditService {
     const match = await this.etagService.verify(account, etag);
     if (!match) {
       // TODO: add a new error type for etag not match
-      return Result.err(new Error('etag not match'));
+      return Result.err(
+        new AccountUpdateETagInvalidError('etag not match', { cause: null }),
+      );
     }
 
     if (nickname.length < this.nicknameShortest) {
-      return Result.err(new Error('nickname too short'));
+      return Result.err(
+        new AccountNicknameTooShortError('nickname too short', { cause: null }),
+      );
     }
     if (nickname.length > this.nicknameLongest) {
-      return Result.err(new Error('nickname too long'));
+      return Result.err(
+        new AccountNicknameTooLongError('nickname too long', { cause: null }),
+      );
     }
 
     try {
@@ -76,7 +95,9 @@ export class EditService {
 
       return Result.ok(true);
     } catch (e) {
-      return Result.err(e as unknown as Error);
+      return Result.err(
+        new AccountInternalError('failed to update account', { cause: e }),
+      );
     }
   }
 
@@ -88,12 +109,16 @@ export class EditService {
   ): Promise<Result.Result<Error, boolean>> {
     const res = await this.accountRepository.findByName(target);
     if (Option.isNone(res)) {
-      return Result.err(new Error('account not found'));
+      return Result.err(
+        new AccountNotFoundError('account not found', { cause: null }),
+      );
     }
     const account = Option.unwrap(res);
     const actorRes = await this.accountRepository.findByName(actorName);
     if (Option.isNone(actorRes)) {
-      return Result.err(new Error('actor not found'));
+      return Result.err(
+        new AccountNotFoundError('actor not found', { cause: null }),
+      );
     }
     const actor = Option.unwrap(actorRes);
 
@@ -103,14 +128,24 @@ export class EditService {
 
     const match = await this.etagService.verify(account, etag);
     if (!match) {
-      return Result.err(new Error('etag not match'));
+      return Result.err(
+        new AccountUpdateETagInvalidError('etag not match', { cause: null }),
+      );
     }
 
     if (newPassphrase.length < this.passphraseShortest) {
-      return Result.err(new Error('passphrase too short'));
+      return Result.err(
+        new AccountPassphraseRequirementsNotMetError('passphrase too short', {
+          cause: null,
+        }),
+      );
     }
     if (newPassphrase.length > this.passphraseLongest) {
-      return Result.err(new Error('passphrase too long'));
+      return Result.err(
+        new AccountPassphraseRequirementsNotMetError('passphrase too long', {
+          cause: null,
+        }),
+      );
     }
 
     try {
@@ -125,7 +160,9 @@ export class EditService {
 
       return Result.ok(true);
     } catch (e) {
-      return Result.err(e as unknown as Error);
+      return Result.err(
+        new AccountInternalError('failed to update account', { cause: e }),
+      );
     }
   }
 
@@ -137,12 +174,16 @@ export class EditService {
   ): Promise<Result.Result<Error, boolean>> {
     const res = await this.accountRepository.findByName(target);
     if (Option.isNone(res)) {
-      return Result.err(new Error('account not found'));
+      return Result.err(
+        new AccountNotFoundError('account not found', { cause: null }),
+      );
     }
     const account = Option.unwrap(res);
     const actorRes = await this.accountRepository.findByName(actorName);
     if (Option.isNone(actorRes)) {
-      return Result.err(new Error('actor not found'));
+      return Result.err(
+        new AccountNotFoundError('actor not found', { cause: null }),
+      );
     }
     const actor = Option.unwrap(actorRes);
 
@@ -152,14 +193,20 @@ export class EditService {
 
     const match = await this.etagService.verify(account, etag);
     if (!match) {
-      return Result.err(new Error('etag not match'));
+      return Result.err(
+        new AccountUpdateETagInvalidError('etag not match', { cause: null }),
+      );
     }
 
     if (newEmail.length < this.emailShortest) {
-      return Result.err(new Error('email too short'));
+      return Result.err(
+        new AccountMailAddressLengthError('email too short', { cause: null }),
+      );
     }
     if (newEmail.length > this.emailLongest) {
-      return Result.err(new Error('email too long'));
+      return Result.err(
+        new AccountMailAddressLengthError('email too long', { cause: null }),
+      );
     }
 
     // TODO: add a process to check the email is active
@@ -174,7 +221,9 @@ export class EditService {
 
       return Result.ok(true);
     } catch (e) {
-      return Result.err(e as unknown as Error);
+      return Result.err(
+        new AccountInternalError('failed to update account', { cause: e }),
+      );
     }
   }
 
@@ -186,12 +235,16 @@ export class EditService {
   ): Promise<Result.Result<Error, boolean>> {
     const res = await this.accountRepository.findByName(target);
     if (Option.isNone(res)) {
-      return Result.err(new Error('account not found'));
+      return Result.err(
+        new AccountNotFoundError('account not found', { cause: null }),
+      );
     }
     const account = Option.unwrap(res);
     const actorRes = await this.accountRepository.findByName(actorName);
     if (Option.isNone(actorRes)) {
-      return Result.err(new Error('actor not found'));
+      return Result.err(
+        new AccountNotFoundError('actor not found', { cause: null }),
+      );
     }
     const actor = Option.unwrap(actorRes);
 
@@ -201,7 +254,9 @@ export class EditService {
 
     const match = await this.etagService.verify(account, etag);
     if (!match) {
-      return Result.err(new Error('etag not match'));
+      return Result.err(
+        new AccountUpdateETagInvalidError('etag not match', { cause: null }),
+      );
     }
 
     // ToDo(laminne): bio length check
@@ -216,7 +271,9 @@ export class EditService {
 
       return Result.ok(true);
     } catch (e) {
-      return Result.err(e as unknown as Error);
+      return Result.err(
+        new AccountInternalError('failed to update account', { cause: e }),
+      );
     }
   }
 

--- a/pkg/accounts/service/fetch.ts
+++ b/pkg/accounts/service/fetch.ts
@@ -1,6 +1,7 @@
 import { Ether, Option, Result } from '@mikuroxina/mini-fn';
 
 import type { Account, AccountID } from '../model/account.js';
+import { AccountNotFoundError } from '../model/errors.js';
 import {
   type AccountRepository,
   accountRepoSymbol,
@@ -16,7 +17,9 @@ export class FetchService {
   async fetchAccount(name: string): Promise<Result.Result<Error, Account>> {
     const res = await this.accountRepository.findByName(name);
     if (Option.isNone(res)) {
-      return Result.err(new Error('AccountNotFoundError'));
+      return Result.err(
+        new AccountNotFoundError('account not found', { cause: null }),
+      );
     }
 
     try {
@@ -31,7 +34,9 @@ export class FetchService {
     id: AccountID,
   ): Promise<Result.Result<Error, Account>> {
     const res = await this.accountRepository.findByID(id);
-    return Option.okOr(new Error('AccountNotFoundError'))(res);
+    return Option.okOr(
+      new AccountNotFoundError('account not found', { cause: null }),
+    )(res);
   }
 
   async fetchManyAccountsByID(

--- a/pkg/accounts/service/fetchFollow.ts
+++ b/pkg/accounts/service/fetchFollow.ts
@@ -1,6 +1,7 @@
 import { Cat, Ether, Option, Result } from '@mikuroxina/mini-fn';
 
 import type { AccountID, AccountName } from '../model/account.js';
+import { AccountNotFoundError } from '../model/errors.js';
 import type { AccountFollow } from '../model/follow.js';
 import {
   type AccountFollowRepository,
@@ -25,7 +26,11 @@ export class FetchFollowService {
     name: AccountName,
   ): Promise<Result.Result<Error, AccountFollow[]>> {
     const resId = Cat.cat(await this.accountRepository.findByName(name))
-      .feed(Option.okOr(new Error('ACCOUNT_NOT_FOUND')))
+      .feed(
+        Option.okOr(
+          new AccountNotFoundError('account not found', { cause: null }),
+        ),
+      )
       .feed(Result.map((a) => a.getID())).value;
 
     if (Result.isErr(resId)) {
@@ -45,7 +50,11 @@ export class FetchFollowService {
     name: AccountName,
   ): Promise<Result.Result<Error, AccountFollow[]>> {
     const resId = Cat.cat(await this.accountRepository.findByName(name))
-      .feed(Option.okOr(new Error('ACCOUNT_NOT_FOUND')))
+      .feed(
+        Option.okOr(
+          new AccountNotFoundError('account not found', { cause: null }),
+        ),
+      )
       .feed(Result.map((a) => a.getID())).value;
 
     if (Result.isErr(resId)) {

--- a/pkg/accounts/service/follow.ts
+++ b/pkg/accounts/service/follow.ts
@@ -1,6 +1,7 @@
 import { Ether, Option, Result } from '@mikuroxina/mini-fn';
 
 import type { AccountName } from '../model/account.js';
+import { AccountNotFoundError } from '../model/errors.js';
 import { AccountFollow } from '../model/follow.js';
 import {
   type AccountFollowRepository,
@@ -21,11 +22,15 @@ export class FollowService {
   ): Promise<Result.Result<Error, AccountFollow>> {
     const fromAccount = await this.accountRepository.findByName(from);
     if (Option.isNone(fromAccount)) {
-      return Result.err(new Error('from account not found'));
+      return Result.err(
+        new AccountNotFoundError('account not found', { cause: null }),
+      );
     }
     const targetAccount = await this.accountRepository.findByName(target);
     if (Option.isNone(targetAccount)) {
-      return Result.err(new Error('target account not found'));
+      return Result.err(
+        new AccountNotFoundError('account not found', { cause: null }),
+      );
     }
 
     const follow = AccountFollow.new({

--- a/pkg/accounts/service/freeze.ts
+++ b/pkg/accounts/service/freeze.ts
@@ -1,6 +1,7 @@
 import { Ether, Option, Result } from '@mikuroxina/mini-fn';
 
 import type { Account, AccountName } from '../model/account.js';
+import { AccountNotFoundError } from '../model/errors.js';
 import {
   type AccountRepository,
   accountRepoSymbol,
@@ -15,12 +16,16 @@ export class FreezeService {
   ): Promise<Result.Result<Error, boolean>> {
     const accountRes = await this.accountRepository.findByName(targetName);
     if (Option.isNone(accountRes)) {
-      return Result.err(new Error('account not found'));
+      return Result.err(
+        new AccountNotFoundError('account not found', { cause: null }),
+      );
     }
     const account = Option.unwrap(accountRes);
     const actorRes = await this.accountRepository.findByName(actorName);
     if (Option.isNone(actorRes)) {
-      return Result.err(new Error('actor not found'));
+      return Result.err(
+        new AccountNotFoundError('actor not found', { cause: null }),
+      );
     }
     const actor = Option.unwrap(actorRes);
 
@@ -42,12 +47,16 @@ export class FreezeService {
   ): Promise<Result.Result<Error, boolean>> {
     const accountRes = await this.accountRepository.findByName(targetName);
     if (Option.isNone(accountRes)) {
-      return Result.err(new Error('account not found'));
+      return Result.err(
+        new AccountNotFoundError('account not found', { cause: null }),
+      );
     }
     const account = Option.unwrap(accountRes);
     const actorRes = await this.accountRepository.findByName(actorName);
     if (Option.isNone(actorRes)) {
-      return Result.err(new Error('actor not found'));
+      return Result.err(
+        new AccountNotFoundError('actor not found', { cause: null }),
+      );
     }
     const actor = Option.unwrap(actorRes);
 

--- a/pkg/accounts/service/resendToken.test.ts
+++ b/pkg/accounts/service/resendToken.test.ts
@@ -7,6 +7,7 @@ import {
   InMemoryAccountVerifyTokenRepository,
 } from '../adaptor/repository/dummy.js';
 import { Account, type AccountID } from '../model/account.js';
+import { AccountNotFoundError } from '../model/errors.js';
 import { ResendVerifyTokenService } from './resendToken.js';
 import { DummySendNotificationService } from './sendNotification.js';
 import { VerifyAccountTokenService } from './verifyToken.js';
@@ -78,6 +79,8 @@ describe('ResendVerifyTokenService', () => {
 
     expect(Option.isSome(actual)).toBe(true);
     if (Option.isNone(actual)) return;
-    expect(actual[1]).toStrictEqual(new Error('AccountNotFoundError'));
+    expect(actual[1]).toStrictEqual(
+      new AccountNotFoundError('account not found', { cause: null }),
+    );
   });
 });

--- a/pkg/accounts/service/resendToken.ts
+++ b/pkg/accounts/service/resendToken.ts
@@ -2,6 +2,10 @@ import { Ether, Option, Result } from '@mikuroxina/mini-fn';
 
 import type { AccountName } from '../model/account.js';
 import {
+  AccountMailAddressAlreadyVerifiedError,
+  AccountNotFoundError,
+} from '../model/errors.js';
+import {
   type AccountRepository,
   accountRepoSymbol,
 } from '../model/repository.js';
@@ -32,11 +36,17 @@ export class ResendVerifyTokenService {
   async handle(name: AccountName): Promise<Option.Option<Error>> {
     const account = await this.accountRepository.findByName(name);
     if (Option.isNone(account)) {
-      return Option.some(new Error('AccountNotFoundError'));
+      return Option.some(
+        new AccountNotFoundError('account not found', { cause: null }),
+      );
     }
 
     if (account[1].getStatus() !== 'notActivated') {
-      return Option.some(new Error('AccountAlreadyVerifiedError'));
+      return Option.some(
+        new AccountMailAddressAlreadyVerifiedError('account already verified', {
+          cause: null,
+        }),
+      );
     }
 
     const token = await this.verifyAccountTokenService.generate(

--- a/pkg/accounts/service/silence.ts
+++ b/pkg/accounts/service/silence.ts
@@ -1,6 +1,7 @@
 import { Ether, Option, Result } from '@mikuroxina/mini-fn';
 
 import type { Account, AccountName } from '../model/account.js';
+import { AccountNotFoundError } from '../model/errors.js';
 import {
   type AccountRepository,
   accountRepoSymbol,
@@ -19,13 +20,17 @@ export class SilenceService {
   ): Promise<Result.Result<Error, boolean>> {
     const accountRes = await this.accountRepository.findByName(targetName);
     if (Option.isNone(accountRes)) {
-      return Result.err(new Error('account not found'));
+      return Result.err(
+        new AccountNotFoundError('account not found', { cause: null }),
+      );
     }
     const account = Option.unwrap(accountRes);
 
     const actorRes = await this.accountRepository.findByName(actorName);
     if (Option.isNone(actorRes)) {
-      return Result.err(new Error('actor not found'));
+      return Result.err(
+        new AccountNotFoundError('actor not found', { cause: null }),
+      );
     }
     const actor = Option.unwrap(actorRes);
 
@@ -47,13 +52,17 @@ export class SilenceService {
   ): Promise<Result.Result<Error, boolean>> {
     const accountRes = await this.accountRepository.findByName(targetName);
     if (Option.isNone(accountRes)) {
-      return Result.err(new Error('account not found'));
+      return Result.err(
+        new AccountNotFoundError('account not found', { cause: null }),
+      );
     }
     const account = Option.unwrap(accountRes);
 
     const actorRes = await this.accountRepository.findByName(actorName);
     if (Option.isNone(actorRes)) {
-      return Result.err(new Error('actor not found'));
+      return Result.err(
+        new AccountNotFoundError('actor not found', { cause: null }),
+      );
     }
     const actor = Option.unwrap(actorRes);
 

--- a/pkg/accounts/service/unfollow.ts
+++ b/pkg/accounts/service/unfollow.ts
@@ -1,6 +1,7 @@
 import { Ether, Option, Result } from '@mikuroxina/mini-fn';
 
 import type { AccountName } from '../model/account.js';
+import { AccountNotFoundError } from '../model/errors.js';
 import {
   type AccountFollowRepository,
   type AccountRepository,
@@ -20,11 +21,15 @@ export class UnfollowService {
   ): Promise<Option.Option<Error>> {
     const fromAccount = await this.accountRepository.findByName(from);
     if (Option.isNone(fromAccount)) {
-      return Option.some(new Error('from account not found'));
+      return Option.some(
+        new AccountNotFoundError('from account not found', { cause: null }),
+      );
     }
     const targetAccount = await this.accountRepository.findByName(target);
     if (Option.isNone(targetAccount)) {
-      return Option.some(new Error('target account not found'));
+      return Option.some(
+        new AccountNotFoundError('target account not found', { cause: null }),
+      );
     }
 
     const res = await this.followRepository.unfollow(

--- a/pkg/accounts/service/verifyToken.ts
+++ b/pkg/accounts/service/verifyToken.ts
@@ -3,6 +3,10 @@ import { Ether, Option, Result } from '@mikuroxina/mini-fn';
 import { type Clock, clockSymbol } from '../../id/mod.js';
 import type { AccountName } from '../model/account.js';
 import {
+  AccountMailAddressVerificationTokenInvalidError,
+  AccountNotFoundError,
+} from '../model/errors.js';
+import {
   type AccountRepository,
   type AccountVerifyTokenRepository,
   accountRepoSymbol,
@@ -35,7 +39,9 @@ export class VerifyAccountTokenService {
 
     const account = await this.accountRepository.findByName(accountName);
     if (Option.isNone(account)) {
-      return Result.err(new Error('Account not found'));
+      return Result.err(
+        new AccountNotFoundError('account not found', { cause: null }),
+      );
     }
 
     const res = await this.repository.create(
@@ -62,21 +68,33 @@ export class VerifyAccountTokenService {
   ): Promise<Result.Result<Error, void>> {
     const account = await this.accountRepository.findByName(accountName);
     if (Option.isNone(account)) {
-      return Result.err(new Error('Account not found'));
+      return Result.err(
+        new AccountNotFoundError('account not found', { cause: null }),
+      );
     }
 
     const res = await this.repository.findByID(account[1].getID());
     if (Option.isNone(res)) {
       // ToDo(laminne): Consider whether to create an error type (e.g. AccountNotFoundError)
-      return Result.err(new Error('Account not found'));
+      return Result.err(
+        new AccountNotFoundError('account not found', { cause: null }),
+      );
     }
 
     if (res[1].expire < new Date()) {
-      return Result.err(new Error('Token expired'));
+      return Result.err(
+        new AccountMailAddressVerificationTokenInvalidError('Token expired', {
+          cause: null,
+        }),
+      );
     }
 
     if (res[1].token !== token) {
-      return Result.err(new Error('Token not match'));
+      return Result.err(
+        new AccountMailAddressVerificationTokenInvalidError('Token not match', {
+          cause: null,
+        }),
+      );
     }
 
     return Result.ok(undefined);

--- a/resources/schema.json
+++ b/resources/schema.json
@@ -45,6 +45,21 @@
           "email"
         ]
       },
+      "InternalErrorResponse": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "type": "string",
+            "enum": [
+              "INTERNAL_ERROR"
+            ],
+            "description": "Internal server error."
+          }
+        },
+        "required": [
+          "error"
+        ]
+      },
       "CreateAccountRequest": {
         "type": "object",
         "properties": {
@@ -443,6 +458,188 @@
       "Account ID": {
         "type": "string"
       },
+      "GetListTimelineResponse": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "Note ID",
+              "example": "38477395"
+            },
+            "content": {
+              "type": "string",
+              "description": "Note content",
+              "example": "hello world!"
+            },
+            "contents_warning_comment": {
+              "type": "string",
+              "description": "Contents warning comment",
+              "example": "(if length not 0) This note contains sensitive content"
+            },
+            "visibility": {
+              "type": "string",
+              "description": "Note visibility (PUBLIC/HOME/FOLLOWERS/DIRECT)",
+              "example": "PUBLIC"
+            },
+            "created_at": {
+              "type": "string",
+              "format": "date-time",
+              "description": "Note created date",
+              "example": "2021-01-01T00:00:00Z"
+            },
+            "author": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "display_name": {
+                  "type": "string"
+                },
+                "bio": {
+                  "type": "string"
+                },
+                "avatar": {
+                  "type": "string"
+                },
+                "header": {
+                  "type": "string"
+                },
+                "followed_count": {
+                  "type": "number"
+                },
+                "following_count": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "id",
+                "name",
+                "display_name",
+                "bio",
+                "avatar",
+                "header",
+                "followed_count",
+                "following_count"
+              ]
+            },
+            "reactions": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "emoji": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "pattern": "[\\u2700-\\u27BF]|[\\uE000-\\uF8FF]|\\uD83C[\\uDC00-\\uDFFF]|\\uD83D[\\uDC00-\\uDFFF]|[\\u2011-\\u26FF]|\\uD83E[\\uDD10-\\uDDFF]"
+                      },
+                      {
+                        "type": "string",
+                        "pattern": "<:(\\w+):(\\d+)>"
+                      }
+                    ],
+                    "description": "Reaction Emoji (Unicode or Custom Emoji)",
+                    "examples": [
+                      "🎉",
+                      "<:custom_emoji:123456789>"
+                    ]
+                  },
+                  "reacted_by": {
+                    "type": "string",
+                    "description": "Reacted account ID",
+                    "example": "38477395"
+                  }
+                },
+                "required": [
+                  "emoji",
+                  "reacted_by"
+                ]
+              },
+              "description": "Reactions"
+            },
+            "attachment_files": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "description": "attachment Medium id",
+                    "example": "39783475"
+                  },
+                  "name": {
+                    "type": "string",
+                    "description": "attachment filename",
+                    "example": "image.jpg"
+                  },
+                  "author_id": {
+                    "type": "string",
+                    "description": "attachment author account id",
+                    "example": "309823457"
+                  },
+                  "hash": {
+                    "type": "string",
+                    "description": "attachment medium blurhash",
+                    "example": "e9f*5oin{dn"
+                  },
+                  "mime": {
+                    "type": "string",
+                    "description": "attachment medium mime type",
+                    "example": "image/jpeg"
+                  },
+                  "nsfw": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "if true, attachment is nsfw"
+                  },
+                  "url": {
+                    "type": "string",
+                    "format": "uri",
+                    "description": "attachment medium url",
+                    "example": "https://images.example.com/image.webp"
+                  },
+                  "thumbnail": {
+                    "type": "string",
+                    "description": "attachment thumbnail url",
+                    "example": "https://images.example.com/image_thumbnail.webp"
+                  }
+                },
+                "required": [
+                  "id",
+                  "name",
+                  "author_id",
+                  "hash",
+                  "mime",
+                  "nsfw",
+                  "url",
+                  "thumbnail"
+                ]
+              },
+              "maxItems": 16,
+              "description": "Note Attachment Media"
+            }
+          },
+          "required": [
+            "id",
+            "content",
+            "contents_warning_comment",
+            "visibility",
+            "created_at",
+            "author",
+            "reactions",
+            "attachment_files"
+          ]
+        }
+      },
+      "List ID": {
+        "type": "string"
+      },
       "CreateListResponse": {
         "type": "object",
         "properties": {
@@ -511,9 +708,6 @@
           "title",
           "public"
         ]
-      },
-      "List ID": {
-        "type": "string"
       },
       "EditListRequest": {
         "type": "object",
@@ -635,10 +829,31 @@
                   "type": "object",
                   "properties": {
                     "error": {
-                      "type": "string",
-                      "default": "",
-                      "description": "Error code",
-                      "example": "TEST_ERROR_CODE"
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "enum": [
+                            "INVALID_ACCOUNT_NAME"
+                          ],
+                          "description": "Account name is invalid."
+                        },
+                        {
+                          "type": "string",
+                          "enum": [
+                            "TOO_LONG_ACCOUNT_NAME"
+                          ],
+                          "description": "Account name is too long."
+                        },
+                        {
+                          "type": "string",
+                          "enum": [
+                            "YOU_ARE_BOT"
+                          ],
+                          "description": "CAPTCHA verification failed."
+                        }
+                      ],
+                      "description": "Error codes",
+                      "example": "INVALID_ACCOUNT_NAME"
                     }
                   },
                   "required": [
@@ -656,15 +871,39 @@
                   "type": "object",
                   "properties": {
                     "error": {
-                      "type": "string",
-                      "default": "",
-                      "description": "Error code",
-                      "example": "TEST_ERROR_CODE"
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "enum": [
+                            "EMAIL_IN_USE"
+                          ],
+                          "description": "Account email is already in use."
+                        },
+                        {
+                          "type": "string",
+                          "enum": [
+                            "ACCOUNT_NAME_IN_USE"
+                          ],
+                          "description": "Account name is already in use."
+                        }
+                      ],
+                      "description": "Error codes",
+                      "example": "ACCOUNT_NAME_IN_USE"
                     }
                   },
                   "required": [
                     "error"
                   ]
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalErrorResponse"
                 }
               }
             }
@@ -734,10 +973,23 @@
                   "type": "object",
                   "properties": {
                     "error": {
-                      "type": "string",
-                      "default": "",
-                      "description": "Error code",
-                      "example": "TEST_ERROR_CODE"
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "enum": [
+                            "INVALID_SEQUENCE"
+                          ],
+                          "description": "Contains unusable character types in parameters."
+                        },
+                        {
+                          "type": "string",
+                          "enum": [
+                            "VULNERABLE_PASSPHRASE"
+                          ],
+                          "description": "Passphrase is too weak."
+                        }
+                      ],
+                      "description": "error codes"
                     }
                   },
                   "required": [
@@ -756,14 +1008,16 @@
                   "properties": {
                     "error": {
                       "type": "string",
-                      "default": "",
-                      "description": "Error code",
-                      "example": "TEST_ERROR_CODE"
+                      "enum": [
+                        "ACCOUNT_NOT_FOUND"
+                      ],
+                      "description": "Account not found."
                     }
                   },
                   "required": [
                     "error"
-                  ]
+                  ],
+                  "description": "account not found"
                 }
               }
             }
@@ -777,14 +1031,26 @@
                   "properties": {
                     "error": {
                       "type": "string",
-                      "default": "",
-                      "description": "Error code",
-                      "example": "TEST_ERROR_CODE"
+                      "enum": [
+                        "INVALID_ETAG"
+                      ],
+                      "description": "ETag is invalid."
                     }
                   },
                   "required": [
                     "error"
-                  ]
+                  ],
+                  "description": "etag is invalid"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalErrorResponse"
                 }
               }
             }
@@ -829,14 +1095,16 @@
                   "properties": {
                     "error": {
                       "type": "string",
-                      "default": "",
-                      "description": "Error code",
-                      "example": "TEST_ERROR_CODE"
+                      "enum": [
+                        "ALREADY_FROZEN"
+                      ],
+                      "description": "Account is already frozen."
                     }
                   },
                   "required": [
                     "error"
-                  ]
+                  ],
+                  "description": "account already frozen"
                 }
               }
             }
@@ -850,14 +1118,16 @@
                   "properties": {
                     "error": {
                       "type": "string",
-                      "default": "",
-                      "description": "Error code",
-                      "example": "TEST_ERROR_CODE"
+                      "enum": [
+                        "NO_PERMISSION"
+                      ],
+                      "description": "You can't do this action."
                     }
                   },
                   "required": [
                     "error"
-                  ]
+                  ],
+                  "description": "You can not do this action."
                 }
               }
             }
@@ -871,14 +1141,26 @@
                   "properties": {
                     "error": {
                       "type": "string",
-                      "default": "",
-                      "description": "Error code",
-                      "example": "TEST_ERROR_CODE"
+                      "enum": [
+                        "ACCOUNT_NOT_FOUND"
+                      ],
+                      "description": "Account not found."
                     }
                   },
                   "required": [
                     "error"
-                  ]
+                  ],
+                  "description": "account not found"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalErrorResponse"
                 }
               }
             }
@@ -912,27 +1194,6 @@
           "204": {
             "description": "No Content"
           },
-          "400": {
-            "description": "Bad Request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string",
-                      "default": "",
-                      "description": "Error code",
-                      "example": "TEST_ERROR_CODE"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
           "403": {
             "description": "Forbidden",
             "content": {
@@ -942,14 +1203,16 @@
                   "properties": {
                     "error": {
                       "type": "string",
-                      "default": "",
-                      "description": "Error code",
-                      "example": "TEST_ERROR_CODE"
+                      "enum": [
+                        "NO_PERMISSION"
+                      ],
+                      "description": "You can't do this action."
                     }
                   },
                   "required": [
                     "error"
-                  ]
+                  ],
+                  "description": "You can not do this action."
                 }
               }
             }
@@ -963,14 +1226,26 @@
                   "properties": {
                     "error": {
                       "type": "string",
-                      "default": "",
-                      "description": "Error code",
-                      "example": "TEST_ERROR_CODE"
+                      "enum": [
+                        "ACCOUNT_NOT_FOUND"
+                      ],
+                      "description": "Account not found."
                     }
                   },
                   "required": [
                     "error"
-                  ]
+                  ],
+                  "description": "account not found"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalErrorResponse"
                 }
               }
             }
@@ -1019,14 +1294,16 @@
                   "properties": {
                     "error": {
                       "type": "string",
-                      "default": "",
-                      "description": "Error code",
-                      "example": "TEST_ERROR_CODE"
+                      "enum": [
+                        "INVALID_TOKEN"
+                      ],
+                      "description": "EMail verification token is invalid."
                     }
                   },
                   "required": [
                     "error"
-                  ]
+                  ],
+                  "description": "email address token is invalid"
                 }
               }
             }
@@ -1040,14 +1317,26 @@
                   "properties": {
                     "error": {
                       "type": "string",
-                      "default": "",
-                      "description": "Error code",
-                      "example": "TEST_ERROR_CODE"
+                      "enum": [
+                        "ACCOUNT_NOT_FOUND"
+                      ],
+                      "description": "Account not found."
                     }
                   },
                   "required": [
                     "error"
-                  ]
+                  ],
+                  "description": "account not found"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalErrorResponse"
                 }
               }
             }
@@ -1092,14 +1381,26 @@
                   "properties": {
                     "error": {
                       "type": "string",
-                      "default": "",
-                      "description": "Error code",
-                      "example": "TEST_ERROR_CODE"
+                      "enum": [
+                        "ACCOUNT_NOT_FOUND"
+                      ],
+                      "description": "Account not found."
                     }
                   },
                   "required": [
                     "error"
-                  ]
+                  ],
+                  "description": "account not found"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalErrorResponse"
                 }
               }
             }
@@ -1141,14 +1442,16 @@
                   "properties": {
                     "error": {
                       "type": "string",
-                      "default": "",
-                      "description": "Error code",
-                      "example": "TEST_ERROR_CODE"
+                      "enum": [
+                        "FAILED_TO_LOGIN"
+                      ],
+                      "description": "Failed to login. Passphrase or Account Name is invalid."
                     }
                   },
                   "required": [
                     "error"
-                  ]
+                  ],
+                  "description": "failed to login."
                 }
               }
             }
@@ -1162,14 +1465,26 @@
                   "properties": {
                     "error": {
                       "type": "string",
-                      "default": "",
-                      "description": "Error code",
-                      "example": "TEST_ERROR_CODE"
+                      "enum": [
+                        "YOU_ARE_FROZEN"
+                      ],
+                      "description": "Your account is frozen, you can't login."
                     }
                   },
                   "required": [
                     "error"
-                  ]
+                  ],
+                  "description": "You can not login."
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalErrorResponse"
                 }
               }
             }
@@ -1210,15 +1525,39 @@
                   "type": "object",
                   "properties": {
                     "error": {
-                      "type": "string",
-                      "default": "",
-                      "description": "Error code",
-                      "example": "TEST_ERROR_CODE"
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "enum": [
+                            "INVALID_TOKEN"
+                          ],
+                          "description": "Refresh token is invalid."
+                        },
+                        {
+                          "type": "string",
+                          "enum": [
+                            "EXPIRED_TOKEN"
+                          ],
+                          "description": "Refresh or Access token is expired. Please re-login."
+                        }
+                      ],
+                      "description": "error codes",
+                      "example": "INVALID_TOKEN"
                     }
                   },
                   "required": [
                     "error"
                   ]
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalErrorResponse"
                 }
               }
             }
@@ -1270,14 +1609,16 @@
                   "properties": {
                     "error": {
                       "type": "string",
-                      "default": "",
-                      "description": "Error code",
-                      "example": "TEST_ERROR_CODE"
+                      "enum": [
+                        "NO_PERMISSION"
+                      ],
+                      "description": "You can't do this action."
                     }
                   },
                   "required": [
                     "error"
-                  ]
+                  ],
+                  "description": "You can not do this action."
                 }
               }
             }
@@ -1291,14 +1632,26 @@
                   "properties": {
                     "error": {
                       "type": "string",
-                      "default": "",
-                      "description": "Error code",
-                      "example": "TEST_ERROR_CODE"
+                      "enum": [
+                        "ACCOUNT_NOT_FOUND"
+                      ],
+                      "description": "Account not found."
                     }
                   },
                   "required": [
                     "error"
-                  ]
+                  ],
+                  "description": "account not found"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalErrorResponse"
                 }
               }
             }
@@ -1348,14 +1701,16 @@
                   "properties": {
                     "error": {
                       "type": "string",
-                      "default": "",
-                      "description": "Error code",
-                      "example": "TEST_ERROR_CODE"
+                      "enum": [
+                        "NO_PERMISSION"
+                      ],
+                      "description": "You can't do this action."
                     }
                   },
                   "required": [
                     "error"
-                  ]
+                  ],
+                  "description": "You can not do this action."
                 }
               }
             }
@@ -1369,14 +1724,26 @@
                   "properties": {
                     "error": {
                       "type": "string",
-                      "default": "",
-                      "description": "Error code",
-                      "example": "TEST_ERROR_CODE"
+                      "enum": [
+                        "ACCOUNT_NOT_FOUND"
+                      ],
+                      "description": "Account not found."
                     }
                   },
                   "required": [
                     "error"
-                  ]
+                  ],
+                  "description": "account not found"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalErrorResponse"
                 }
               }
             }
@@ -1427,15 +1794,28 @@
                   "type": "object",
                   "properties": {
                     "error": {
-                      "type": "string",
-                      "default": "",
-                      "description": "Error code",
-                      "example": "TEST_ERROR_CODE"
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "enum": [
+                            "ALREADY_FOLLOWING"
+                          ],
+                          "description": "You are already following this account."
+                        },
+                        {
+                          "type": "string",
+                          "enum": [
+                            "YOU_ARE_BLOCKED"
+                          ],
+                          "description": "You are blocked by this account."
+                        }
+                      ]
                     }
                   },
                   "required": [
                     "error"
-                  ]
+                  ],
+                  "description": "You can not do this action."
                 }
               }
             }
@@ -1449,14 +1829,26 @@
                   "properties": {
                     "error": {
                       "type": "string",
-                      "default": "",
-                      "description": "Error code",
-                      "example": "TEST_ERROR_CODE"
+                      "enum": [
+                        "ACCOUNT_NOT_FOUND"
+                      ],
+                      "description": "Account not found."
                     }
                   },
                   "required": [
                     "error"
-                  ]
+                  ],
+                  "description": "account not found"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalErrorResponse"
                 }
               }
             }
@@ -1498,7 +1890,7 @@
             "description": "No Content"
           },
           "400": {
-            "description": "Forbidden",
+            "description": "Bad request",
             "content": {
               "application/json": {
                 "schema": {
@@ -1506,14 +1898,16 @@
                   "properties": {
                     "error": {
                       "type": "string",
-                      "default": "",
-                      "description": "Error code",
-                      "example": "TEST_ERROR_CODE"
+                      "enum": [
+                        "YOU_ARE_NOT_FOLLOWING"
+                      ],
+                      "description": "You are not following this account."
                     }
                   },
                   "required": [
                     "error"
-                  ]
+                  ],
+                  "description": "You are not following specified account."
                 }
               }
             }
@@ -1527,14 +1921,26 @@
                   "properties": {
                     "error": {
                       "type": "string",
-                      "default": "",
-                      "description": "Error code",
-                      "example": "TEST_ERROR_CODE"
+                      "enum": [
+                        "ACCOUNT_NOT_FOUND"
+                      ],
+                      "description": "Account not found."
                     }
                   },
                   "required": [
                     "error"
-                  ]
+                  ],
+                  "description": "account not found"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalErrorResponse"
                 }
               }
             }
@@ -1583,14 +1989,16 @@
                   "properties": {
                     "error": {
                       "type": "string",
-                      "default": "",
-                      "description": "Error code",
-                      "example": "TEST_ERROR_CODE"
+                      "enum": [
+                        "ACCOUNT_ALREADY_VERIFIED"
+                      ],
+                      "description": "Account email address is already verified."
                     }
                   },
                   "required": [
                     "error"
-                  ]
+                  ],
+                  "description": "account email is already verified."
                 }
               }
             }
@@ -1604,14 +2012,16 @@
                   "properties": {
                     "error": {
                       "type": "string",
-                      "default": "",
-                      "description": "Error code",
-                      "example": "TEST_ERROR_CODE"
+                      "enum": [
+                        "NO_PERMISSION"
+                      ],
+                      "description": "You can't do this action."
                     }
                   },
                   "required": [
                     "error"
-                  ]
+                  ],
+                  "description": "You can not do this action."
                 }
               }
             }
@@ -1625,14 +2035,26 @@
                   "properties": {
                     "error": {
                       "type": "string",
-                      "default": "",
-                      "description": "Error code",
-                      "example": "TEST_ERROR_CODE"
+                      "enum": [
+                        "ACCOUNT_NOT_FOUND"
+                      ],
+                      "description": "Account not found."
                     }
                   },
                   "required": [
                     "error"
-                  ]
+                  ],
+                  "description": "account not found"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalErrorResponse"
                 }
               }
             }
@@ -1679,14 +2101,26 @@
                   "properties": {
                     "error": {
                       "type": "string",
-                      "default": "",
-                      "description": "Error code",
-                      "example": "TEST_ERROR_CODE"
+                      "enum": [
+                        "ACCOUNT_NOT_FOUND"
+                      ],
+                      "description": "Account not found."
                     }
                   },
                   "required": [
                     "error"
-                  ]
+                  ],
+                  "description": "account not found"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalErrorResponse"
                 }
               }
             }
@@ -1733,14 +2167,26 @@
                   "properties": {
                     "error": {
                       "type": "string",
-                      "default": "",
-                      "description": "Error code",
-                      "example": "TEST_ERROR_CODE"
+                      "enum": [
+                        "ACCOUNT_NOT_FOUND"
+                      ],
+                      "description": "Account not found."
                     }
                   },
                   "required": [
                     "error"
-                  ]
+                  ],
+                  "description": "account not found"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalErrorResponse"
                 }
               }
             }
@@ -3049,6 +3495,83 @@
           },
           "404": {
             "description": "Account not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "default": "",
+                      "description": "Error code",
+                      "example": "TEST_ERROR_CODE"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/lists/:id/notes": {
+      "get": {
+        "tags": [
+          "timeline"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "$ref": "#/components/schemas/List ID"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "boolean",
+              "description": "If true, only return notes with attachment"
+            },
+            "required": false,
+            "name": "has_attachment",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "boolean",
+              "description": "If true, only return notes without sensitive content"
+            },
+            "required": false,
+            "name": "no_nsfw",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Return notes before this note ID. specified note ID is not included"
+            },
+            "required": false,
+            "name": "before_id",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetListTimelineResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "List not found",
             "content": {
               "application/json": {
                 "schema": {


### PR DESCRIPTION
## What does this PR do?
close #696 
- Accountモジュール内で必要なエラー型を定義
- Prismaのエラーは一部のみパースするように
- APIエンドポイントが返すエラーコードを定義してスキーマを更新
  - ほぼ全てのエンドポイントが(specificationで定義されている)エラーコードを適切に返すようになりました

## Additional information
Prismaのエラーは完全に内部表現にできなかったので、別Issueで対応した方が良いかもしれません(自分では判断できず)
