### PR TITLE
feat: home timeline controller/handler implementations

### DIFF
--- a/pkg/adaptors/valkey.ts
+++ b/pkg/adaptors/valkey.ts
@@ -1,0 +1,3 @@
+import { Redis } from 'ioredis';
+
+export const valkeyClient = new Redis('localhost:6379');

--- a/pkg/intermodule/timeline.ts
+++ b/pkg/intermodule/timeline.ts
@@ -1,8 +1,12 @@
 import { Result } from '@mikuroxina/mini-fn';
 import type { Note } from '../notes/model/note.js';
 
+import { prismaClient } from '../adaptors/prisma.js';
+import { valkeyClient } from '../adaptors/valkey.js';
 import { InMemoryListRepository } from '../timeline/adaptor/repository/dummy.js';
 import { InMemoryTimelineCacheRepository } from '../timeline/adaptor/repository/dummyCache.js';
+import { PrismaListRepository } from '../timeline/adaptor/repository/prisma.js';
+import { ValkeyTimelineCacheRepository } from '../timeline/adaptor/repository/valkeyCache.js';
 import { FetchSubscribedListService } from '../timeline/service/fetchSubscribed.js';
 import { NoteVisibilityService } from '../timeline/service/noteVisibility.js';
 import { PushTimelineService } from '../timeline/service/push.js';
@@ -30,9 +34,9 @@ export const timelineModuleFacade = new TimelineModuleFacade(
     accountModule,
     new NoteVisibilityService(accountModule),
     // ToDo: Use valkey here
-    new InMemoryTimelineCacheRepository(),
+    new ValkeyTimelineCacheRepository(valkeyClient),
     // ToDo: Implement PrismaListRepository
-    new FetchSubscribedListService(new InMemoryListRepository()),
+    new FetchSubscribedListService(new PrismaListRepository(prismaClient)),
   ),
 );
 

--- a/pkg/timeline/adaptor/repository/dummy.test.ts
+++ b/pkg/timeline/adaptor/repository/dummy.test.ts
@@ -82,13 +82,12 @@ describe('InMemoryTimelineRepository', () => {
     ).toBe(false);
   });
   it('Home Timeline only returns PUBLIC/HOME/FOLLOWERS notes', async () => {
-    const actual = await repository.getHomeTimeline(
-      ['1' as NoteID, '2' as NoteID, '3' as NoteID, '4' as NoteID],
-      {
-        hasAttachment: true,
-        noNsfw: false,
-      },
-    );
+    const actual = await repository.getHomeTimeline([
+      '1' as NoteID,
+      '2' as NoteID,
+      '3' as NoteID,
+      '4' as NoteID,
+    ]);
     expect(Result.isOk(actual)).toBe(true);
     expect(Result.unwrap(actual).length).toBe(3);
     expect(

--- a/pkg/timeline/adaptor/repository/dummy.ts
+++ b/pkg/timeline/adaptor/repository/dummy.ts
@@ -6,7 +6,6 @@ import { ListInternalError, ListNotFoundError } from '../../model/errors.js';
 import type { List, ListID } from '../../model/list.js';
 import type {
   FetchAccountTimelineFilter,
-  FetchHomeTimelineFilter,
   ListRepository,
   TimelineRepository,
 } from '../../model/repository.js';
@@ -44,7 +43,6 @@ export class InMemoryTimelineRepository implements TimelineRepository {
 
   async getHomeTimeline(
     noteIDs: NoteID[],
-    filter: FetchHomeTimelineFilter,
   ): Promise<Result.Result<Error, Note[]>> {
     const notes: Note[] = [];
     for (const noteID of noteIDs) {
@@ -62,11 +60,8 @@ export class InMemoryTimelineRepository implements TimelineRepository {
     filtered.sort(
       (a, b) => b.getCreatedAt().getTime() - a.getCreatedAt().getTime(),
     );
-    const beforeIndex = filter.beforeId
-      ? filtered.findIndex((note) => note.getID() === filter.beforeId)
-      : filtered.length;
 
-    return Result.ok(filtered.slice(0, beforeIndex));
+    return Result.ok(filtered);
   }
 
   async fetchListTimeline(

--- a/pkg/timeline/adaptor/repository/prisma.ts
+++ b/pkg/timeline/adaptor/repository/prisma.ts
@@ -81,7 +81,6 @@ export class PrismaTimelineRepository implements TimelineRepository {
 
   async getHomeTimeline(
     noteIDs: NoteID[],
-    filter: FetchAccountTimelineFilter,
   ): Promise<Result.Result<Error, Note[]>> {
     const homeNotes = await this.prisma.note.findMany({
       where: {
@@ -91,9 +90,6 @@ export class PrismaTimelineRepository implements TimelineRepository {
       },
       orderBy: {
         createdAt: 'desc',
-      },
-      cursor: {
-        id: filter.beforeId ?? '',
       },
       take: this.TIMELINE_NOTE_LIMIT,
     });

--- a/pkg/timeline/adaptor/validator/timeline.ts
+++ b/pkg/timeline/adaptor/validator/timeline.ts
@@ -4,42 +4,44 @@ import {
   reactionSchema,
 } from '../../../notes/adaptor/validator/schema.js';
 
+const TimelineNoteBaseSchema = z.object({
+  id: z.string().openapi({
+    example: '38477395',
+    description: 'Note ID',
+  }),
+  content: z.string().openapi({
+    example: 'hello world!',
+    description: 'Note content',
+  }),
+  contents_warning_comment: z.string().openapi({
+    example: '(if length not 0) This note contains sensitive content',
+    description: 'Contents warning comment',
+  }),
+  visibility: z.string().openapi({
+    example: 'PUBLIC',
+    description: 'Note visibility (PUBLIC/HOME/FOLLOWERS/DIRECT)',
+  }),
+  created_at: z.string().datetime().openapi({
+    example: '2021-01-01T00:00:00Z',
+    description: 'Note created date',
+  }),
+  author: z.object({
+    id: z.string(),
+    name: z.string(),
+    display_name: z.string(),
+    bio: z.string(),
+    avatar: z.string(),
+    header: z.string(),
+    followed_count: z.number(),
+    following_count: z.number(),
+  }),
+});
+
 export const GetAccountTimelineResponseSchema = z
-  .array(
-    z.object({
-      id: z.string().openapi({
-        example: '38477395',
-        description: 'Note ID',
-      }),
-      content: z.string().openapi({
-        example: 'hello world!',
-        description: 'Note content',
-      }),
-      contents_warning_comment: z.string().openapi({
-        example: '(if length not 0) This note contains sensitive content',
-        description: 'Contents warning comment',
-      }),
-      visibility: z.string().openapi({
-        example: 'PUBLIC',
-        description: 'Note visibility (PUBLIC/HOME/FOLLOWERS/DIRECT)',
-      }),
-      created_at: z.string().datetime().openapi({
-        example: '2021-01-01T00:00:00Z',
-        description: 'Note created date',
-      }),
-      author: z.object({
-        id: z.string(),
-        name: z.string(),
-        display_name: z.string(),
-        bio: z.string(),
-        avatar: z.string(),
-        header: z.string(),
-        followed_count: z.number(),
-        following_count: z.number(),
-      }),
-    }),
-  )
+  .array(TimelineNoteBaseSchema)
   .openapi('GetAccountTimelineResponse');
+
+export const GetHomeTimelineResponseSchema = z.array(TimelineNoteBaseSchema);
 
 export const GetListTimelineResponseSchema = z
   .array(

--- a/pkg/timeline/mod.ts
+++ b/pkg/timeline/mod.ts
@@ -1,9 +1,14 @@
 import { OpenAPIHono } from '@hono/zod-openapi';
-import { Option, Result } from '@mikuroxina/mini-fn';
+import { Cat, Ether, Option, Promise, Result } from '@mikuroxina/mini-fn';
 
 import { AccountNotFoundError } from '../accounts/model/errors.js';
-import type { AuthMiddlewareVariable } from '../adaptors/authenticateMiddleware.js';
+import { authenticateToken } from '../accounts/service/authenticationTokenService.js';
+import {
+  type AuthMiddlewareVariable,
+  authenticateMiddleware,
+} from '../adaptors/authenticateMiddleware.js';
 import { prismaClient } from '../adaptors/prisma.js';
+import { valkeyClient } from '../adaptors/valkey.js';
 import { SnowflakeIDGenerator } from '../id/mod.js';
 import {
   accountModule,
@@ -20,6 +25,7 @@ import {
   PrismaListRepository,
   PrismaTimelineRepository,
 } from './adaptor/repository/prisma.js';
+import { ValkeyTimelineCacheRepository } from './adaptor/repository/valkeyCache.js';
 import {
   ListNotFoundError,
   ListTitleTooLongError,
@@ -32,6 +38,7 @@ import {
   EditListRoute,
   FetchListRoute,
   GetAccountTimelineRoute,
+  GetHomeTimelineRoute,
   GetListMemberRoute,
   GetListTimelineRoute,
 } from './router.js';
@@ -41,6 +48,7 @@ import { DeleteListService } from './service/deleteList.js';
 import { EditListService } from './service/editList.js';
 import { FetchListService } from './service/fetchList.js';
 import { FetchListMemberService } from './service/fetchMember.js';
+import { HomeTimelineService } from './service/home.js';
 import { ListTimelineService } from './service/list.js';
 import { NoteVisibilityService } from './service/noteVisibility.js';
 
@@ -59,7 +67,9 @@ const noteVisibilityService = new NoteVisibilityService(
   isProduction ? accountModule : dummyAccountModuleFacade,
 );
 // ToDo: export redis client instances at adaptors package
-const timelineCacheRepository = new InMemoryTimelineCacheRepository();
+const timelineCacheRepository = isProduction
+  ? new ValkeyTimelineCacheRepository(valkeyClient)
+  : new InMemoryTimelineCacheRepository();
 
 const controller = new TimelineController({
   accountTimelineService: new AccountTimelineService({
@@ -77,7 +87,23 @@ const controller = new TimelineController({
     timelineRepository,
   ),
   noteModule: noteModule,
+  homeTimeline: new HomeTimelineService(
+    timelineCacheRepository,
+    timelineRepository,
+  ),
 });
+const liftOverPromise = <const D extends Record<string, symbol>, T>(
+  ether: Ether.Ether<D, T>,
+): Ether.EtherT<D, Promise.PromiseHkt, T> => ({
+  ...ether,
+  handler: (resolved) => Promise.pure(ether.handler(resolved)),
+});
+const composer = Ether.composeT(Promise.monad);
+const AuthMiddleware = await Ether.runEtherT(
+  Cat.cat(liftOverPromise(authenticateMiddleware)).feed(
+    composer(authenticateToken),
+  ).value,
+);
 
 export const timeline = new OpenAPIHono<{
   Variables: AuthMiddlewareVariable;
@@ -93,14 +119,44 @@ timeline.openAPIRegistry.registerComponent('securitySchemes', 'Bearer', {
   scheme: 'bearer',
 });
 
+timeline[GetHomeTimelineRoute.method](
+  GetHomeTimelineRoute.path,
+  AuthMiddleware.handle({ forceAuthorized: true }),
+);
+timeline.openapi(GetHomeTimelineRoute, async (c) => {
+  const actorID = Option.unwrap(c.get('accountID'));
+  const { has_attachment, no_nsfw, before_id } = c.req.valid('query');
+  const res = await controller.getHomeTimeline(
+    actorID,
+    has_attachment,
+    no_nsfw,
+    before_id,
+  );
+  if (Result.isErr(res)) {
+    const error = Result.unwrapErr(res);
+
+    if (error instanceof TimelineNoMoreNotesError) {
+      return c.json({ error: 'NOTHING_LEFT' as const }, 404);
+    }
+
+    return c.json({ error: 'INTERNAL_ERROR' as const }, 500);
+  }
+
+  return c.json(Result.unwrap(res), 200);
+});
+
+timeline[GetAccountTimelineRoute.method](
+  GetAccountTimelineRoute.path,
+  AuthMiddleware.handle({ forceAuthorized: false }),
+);
 timeline.openapi(GetAccountTimelineRoute, async (c) => {
-  // ToDo: get account id who is trying to see the timeline
+  const actorID = Option.unwrap(c.get('accountID'));
   const { id } = c.req.param();
   const { has_attachment, no_nsfw, before_id } = c.req.valid('query');
 
   const res = await controller.getAccountTimeline(
     id,
-    '',
+    actorID,
     has_attachment,
     no_nsfw,
     before_id,
@@ -126,6 +182,10 @@ timeline.openapi(GetAccountTimelineRoute, async (c) => {
   return c.json(res[1], 200);
 });
 
+timeline[GetListTimelineRoute.method](
+  GetListTimelineRoute.path,
+  AuthMiddleware.handle({ forceAuthorized: true }),
+);
 timeline.openapi(GetListTimelineRoute, async (c) => {
   const { id } = c.req.param();
 
@@ -147,7 +207,10 @@ timeline.openapi(GetListTimelineRoute, async (c) => {
   return c.json(res[1], 200);
 });
 
-// ToDo: add account authorization
+timeline[CreateListRoute.method](
+  CreateListRoute.path,
+  AuthMiddleware.handle({ forceAuthorized: true }),
+);
 timeline.openapi(CreateListRoute, async (c) => {
   // NOTE: `public` is a reserved keyword
   const req = c.req.valid('json');
@@ -167,6 +230,10 @@ timeline.openapi(CreateListRoute, async (c) => {
   return c.json(res[1], 200);
 });
 
+timeline[EditListRoute.method](
+  EditListRoute.path,
+  AuthMiddleware.handle({ forceAuthorized: true }),
+);
 timeline.openapi(EditListRoute, async (c) => {
   const { id } = c.req.valid('param');
   const req = c.req.valid('json');
@@ -192,7 +259,10 @@ timeline.openapi(EditListRoute, async (c) => {
   return c.json(list, 200);
 });
 
-// ToDo: add account authorization
+timeline[FetchListRoute.method](
+  FetchListRoute.path,
+  AuthMiddleware.handle({ forceAuthorized: true }),
+);
 timeline.openapi(FetchListRoute, async (c) => {
   const { id } = c.req.valid('param');
   const res = await controller.fetchList(id);
@@ -208,7 +278,10 @@ timeline.openapi(FetchListRoute, async (c) => {
   return c.json(Result.unwrap(res), 200);
 });
 
-// ToDo: add account authorization
+timeline[DeleteListRoute.method](
+  DeleteListRoute.path,
+  AuthMiddleware.handle({ forceAuthorized: true }),
+);
 timeline.openapi(DeleteListRoute, async (c) => {
   const { id } = c.req.valid('param');
 
@@ -225,7 +298,10 @@ timeline.openapi(DeleteListRoute, async (c) => {
   return new Response(undefined, { status: 204 });
 });
 
-// ToDo: add account authorization
+timeline[GetListMemberRoute.method](
+  GetListMemberRoute.path,
+  AuthMiddleware.handle({ forceAuthorized: true }),
+);
 timeline.openapi(GetListMemberRoute, async (c) => {
   const { id } = c.req.param();
 

--- a/pkg/timeline/mod.ts
+++ b/pkg/timeline/mod.ts
@@ -92,12 +92,7 @@ const controller = new TimelineController({
     timelineRepository,
   ),
 });
-const liftOverPromise = <const D extends Record<string, symbol>, T>(
-  ether: Ether.Ether<D, T>,
-): Ether.EtherT<D, Promise.PromiseHkt, T> => ({
-  ...ether,
-  handler: (resolved) => Promise.pure(ether.handler(resolved)),
-});
+const liftOverPromise = Ether.liftEther(Promise.monad);
 const composer = Ether.composeT(Promise.monad);
 const AuthMiddleware = await Ether.runEtherT(
   Cat.cat(liftOverPromise(authenticateMiddleware)).feed(

--- a/pkg/timeline/model/repository.ts
+++ b/pkg/timeline/model/repository.ts
@@ -30,11 +30,10 @@ export interface TimelineRepository {
   /**
    * @description Fetch home timeline
    * @param noteIDs IDs of the notes to be fetched
-   * @param filter Filter for fetching notes
+   * ToDo: Add filter (noNSFW/hasAttachment)
    * */
   getHomeTimeline(
     noteIDs: readonly NoteID[],
-    filter: FetchAccountTimelineFilter,
   ): Promise<Result.Result<Error, Note[]>>;
 
   /**

--- a/pkg/timeline/service/home.ts
+++ b/pkg/timeline/service/home.ts
@@ -19,15 +19,18 @@ export class HomeTimelineService {
     filter: FetchHomeTimelineFilter,
   ): Promise<Result.Result<Error, Note[]>> {
     // ToDo: get note IDs from cache repository
-    const noteIDs =
+    const noteIDsRes =
       await this.timelineCacheRepository.getHomeTimeline(accountID);
-    if (Result.isErr(noteIDs)) {
-      return noteIDs;
+    if (Result.isErr(noteIDsRes)) {
+      return noteIDsRes;
     }
+    const noteIDs = Result.unwrap(noteIDsRes);
+    const beforeIndex = filter.beforeId
+      ? noteIDs.findIndex((note) => note === filter.beforeId)
+      : noteIDs.length;
 
-    return await this.timelineRepository.getHomeTimeline(noteIDs[1], {
-      id: accountID,
-      ...filter,
-    });
+    return await this.timelineRepository.getHomeTimeline(
+      noteIDs.slice(0, beforeIndex),
+    );
   }
 }


### PR DESCRIPTION
## What does this PR do?
- ホームタイムラインのcontroller/handler実装をした
- PrismaRepository使用時に取得が壊れる問題を修正
- いくつかのRoute/Schema定義を分離して共通化した

## Additional information
PrismaTimelineRepository.getHomeTimelineからfilterを消しました  
理由:
- noNSFW/hasAttachmentの項目は未実装(後回し)
- beforeIDはIDを投入する前(≒ ServiceやValkeyCache)で決定して投入すべきなため
  - HomeTimelineServiceの実装を改善して正しくbeforeIDが動作するようにしました
