### PR TITLE
feat: リアクションを解除できるように

### DIFF
--- a/pkg/notes/adaptor/controller/reaction.ts
+++ b/pkg/notes/adaptor/controller/reaction.ts
@@ -3,6 +3,7 @@ import { Result } from '@mikuroxina/mini-fn';
 import type { AccountID } from '../../../accounts/model/account.js';
 import type { NoteID } from '../../model/note.js';
 import type { CreateReactionService } from '../../service/createReaction.js';
+import type { DeleteReactionService } from '../../service/deleteReaction.js';
 import type { FetchService } from '../../service/fetch.js';
 import type { CreateReactionResponseSchema } from '../validator/schema.js';
 
@@ -10,6 +11,7 @@ export class ReactionController {
   constructor(
     private readonly createReactionService: CreateReactionService,
     private readonly fetchNoteService: FetchService,
+    private readonly deleteReactionService: DeleteReactionService,
   ) {}
 
   async create(
@@ -58,5 +60,15 @@ export class ReactionController {
       })),
       created_at: note.getCreatedAt().toUTCString(),
     });
+  }
+
+  async delete(
+    noteID: string,
+    accountID: string,
+  ): Promise<Result.Result<Error, void>> {
+    return this.deleteReactionService.handle(
+      noteID as NoteID,
+      accountID as AccountID,
+    );
   }
 }

--- a/pkg/notes/adaptor/repository/dummy.ts
+++ b/pkg/notes/adaptor/repository/dummy.ts
@@ -3,6 +3,7 @@ import { Option, Result } from '@mikuroxina/mini-fn';
 import type { AccountID } from '../../../accounts/model/account.js';
 import type { Medium, MediumID } from '../../../drive/model/medium.js';
 import { Bookmark } from '../../model/bookmark.js';
+import { NoteNotFoundError } from '../../model/errors.js';
 import type { Note, NoteID } from '../../model/note.js';
 import { Reaction } from '../../model/reaction.js';
 import type {
@@ -264,6 +265,11 @@ export class InMemoryReactionRepository implements ReactionRepository {
   async deleteByID(id: { accountID: AccountID; noteID: NoteID }): Promise<
     Result.Result<Error, void>
   > {
+    if (!this.reactions.has(this.compositeID(id)))
+      return Result.err(
+        new NoteNotFoundError('reaction not found', { cause: null }),
+      );
+
     this.reactions.delete(this.compositeID(id));
 
     return Result.ok(undefined);

--- a/pkg/notes/adaptor/repository/dummy.ts
+++ b/pkg/notes/adaptor/repository/dummy.ts
@@ -3,7 +3,7 @@ import { Option, Result } from '@mikuroxina/mini-fn';
 import type { AccountID } from '../../../accounts/model/account.js';
 import type { Medium, MediumID } from '../../../drive/model/medium.js';
 import { Bookmark } from '../../model/bookmark.js';
-import { NoteNotFoundError } from '../../model/errors.js';
+import { NoteNotReactedYetError } from '../../model/errors.js';
 import type { Note, NoteID } from '../../model/note.js';
 import { Reaction } from '../../model/reaction.js';
 import type {
@@ -267,7 +267,7 @@ export class InMemoryReactionRepository implements ReactionRepository {
   > {
     if (!this.reactions.has(this.compositeID(id)))
       return Result.err(
-        new NoteNotFoundError('reaction not found', { cause: null }),
+        new NoteNotReactedYetError('reaction not found', { cause: null }),
       );
 
     this.reactions.delete(this.compositeID(id));

--- a/pkg/notes/adaptor/repository/prisma.ts
+++ b/pkg/notes/adaptor/repository/prisma.ts
@@ -408,7 +408,7 @@ export class PrismaReactionRepository implements ReactionRepository {
       const res = await this.client.reaction.findMany({
         where: {
           reactedToId: id,
-          deletedAt: undefined,
+          deletedAt: null,
         },
       });
 
@@ -422,15 +422,12 @@ export class PrismaReactionRepository implements ReactionRepository {
     Result.Result<Error, void>
   > {
     try {
-      await this.client.reaction.update({
+      await this.client.reaction.delete({
         where: {
           reactedById_reactedToId: {
             reactedById: id.accountID,
             reactedToId: id.noteID,
           },
-        },
-        data: {
-          deletedAt: new Date(),
         },
       });
       return Result.ok(undefined);

--- a/pkg/notes/mod.ts
+++ b/pkg/notes/mod.ts
@@ -39,6 +39,7 @@ import {
   NoteEmojiNotFoundError,
   NoteNoDestinationError,
   NoteNotFoundError,
+  NoteNotReactedYetError,
   NoteTooLongContentsError,
   NoteTooManyAttachmentsError,
   NoteVisibilityInvalidError,
@@ -312,8 +313,8 @@ noteHandlers.openapi(DeleteReactionRoute, async (c) => {
 
   if (Result.isErr(res)) {
     const error = Result.unwrapErr(res);
-    if (error instanceof NoteNotFoundError) {
-      return c.json({ error: 'NOTE_NOT_FOUND' as const }, 404);
+    if (error instanceof NoteNotReactedYetError) {
+      return c.json({ error: 'NOT_REACTED' as const }, 404);
     }
     return c.json({ error: 'INTERNAL_ERROR' as const }, 500);
   }

--- a/pkg/notes/router.ts
+++ b/pkg/notes/router.ts
@@ -7,6 +7,7 @@ import {
   EmojiNotFound,
   InvalidVisibility,
   NoDestination,
+  NotReacted,
   NoteInternal,
   NoteNotFound,
   TooManyAttachments,
@@ -363,7 +364,7 @@ export const DeleteReactionRoute = createRoute({
       content: {
         'application/json': {
           schema: z.object({
-            error: NoteNotFound,
+            error: NotReacted,
           }),
         },
       },

--- a/pkg/notes/router.ts
+++ b/pkg/notes/router.ts
@@ -337,6 +337,54 @@ export const CreateReactionRoute = createRoute({
   },
 });
 
+export const DeleteReactionRoute = createRoute({
+  method: 'delete',
+  tags: ['reaction'],
+  path: '/notes/:id/reaction',
+  security: [
+    {
+      bearer: [],
+    },
+  ],
+  request: {
+    params: z.object({
+      id: z.string().openapi({
+        description: 'Note ID',
+        example: '1',
+      }),
+    }),
+  },
+  responses: {
+    204: {
+      description: 'OK',
+    },
+    404: {
+      description: 'Reaction not found',
+      content: {
+        'application/json': {
+          schema: z.object({
+            error: NoteNotFound,
+          }),
+        },
+      },
+    },
+    500: {
+      description: 'Internal Server Error',
+      content: {
+        'application/json': {
+          schema: z
+            .object({
+              error: NoteInternal,
+            })
+            .openapi({
+              description: 'Internal Error',
+            }),
+        },
+      },
+    },
+  },
+});
+
 export const CreateBookmarkRoute = createRoute({
   method: 'post',
   tags: ['bookmark'],

--- a/pkg/notes/service/deleteReaction.test.ts
+++ b/pkg/notes/service/deleteReaction.test.ts
@@ -2,7 +2,7 @@ import { Result } from '@mikuroxina/mini-fn';
 import { describe, expect, it } from 'vitest';
 import type { AccountID } from '../../accounts/model/account.js';
 import { InMemoryReactionRepository } from '../adaptor/repository/dummy.js';
-import { NoteNotFoundError } from '../model/errors.js';
+import { NoteNotReactedYetError } from '../model/errors.js';
 import type { NoteID } from '../model/note.js';
 import { Reaction } from '../model/reaction.js';
 import { DeleteReactionService } from './deleteReaction.js';
@@ -25,6 +25,6 @@ describe('DeleteReactionService', () => {
   it('if reaction not found, should return error', async () => {
     const res = await service.handle('999' as NoteID, '2' as AccountID);
     expect(Result.isErr(res)).toBe(true);
-    expect(Result.unwrapErr(res)).toBeInstanceOf(NoteNotFoundError);
+    expect(Result.unwrapErr(res)).toBeInstanceOf(NoteNotReactedYetError);
   });
 });

--- a/pkg/notes/service/deleteReaction.test.ts
+++ b/pkg/notes/service/deleteReaction.test.ts
@@ -1,0 +1,30 @@
+import { Result } from '@mikuroxina/mini-fn';
+import { describe, expect, it } from 'vitest';
+import type { AccountID } from '../../accounts/model/account.js';
+import { InMemoryReactionRepository } from '../adaptor/repository/dummy.js';
+import { NoteNotFoundError } from '../model/errors.js';
+import type { NoteID } from '../model/note.js';
+import { Reaction } from '../model/reaction.js';
+import { DeleteReactionService } from './deleteReaction.js';
+
+describe('DeleteReactionService', () => {
+  const reactionRepo = new InMemoryReactionRepository([
+    Reaction.new({
+      noteID: '1' as NoteID,
+      accountID: '2' as AccountID,
+      body: '👍',
+    }),
+  ]);
+  const service = new DeleteReactionService(reactionRepo);
+
+  it('should delete a reaction', async () => {
+    const res = await service.handle('1' as NoteID, '2' as AccountID);
+    expect(Result.isOk(res)).toBe(true);
+  });
+
+  it('if reaction not found, should return error', async () => {
+    const res = await service.handle('999' as NoteID, '2' as AccountID);
+    expect(Result.isErr(res)).toBe(true);
+    expect(Result.unwrapErr(res)).toBeInstanceOf(NoteNotFoundError);
+  });
+});

--- a/pkg/notes/service/deleteReaction.ts
+++ b/pkg/notes/service/deleteReaction.ts
@@ -1,0 +1,15 @@
+import type { Result } from '@mikuroxina/mini-fn';
+import type { AccountID } from '../../accounts/model/account.js';
+import type { NoteID } from '../model/note.js';
+import type { ReactionRepository } from '../model/repository.js';
+
+export class DeleteReactionService {
+  constructor(private readonly reactionRepository: ReactionRepository) {}
+
+  async handle(
+    noteID: NoteID,
+    accountID: AccountID,
+  ): Promise<Result.Result<Error, void>> {
+    return await this.reactionRepository.deleteByID({ noteID, accountID });
+  }
+}

--- a/pkg/notes/service/deleteReaction.ts
+++ b/pkg/notes/service/deleteReaction.ts
@@ -1,7 +1,10 @@
-import type { Result } from '@mikuroxina/mini-fn';
+import { Ether, type Result } from '@mikuroxina/mini-fn';
 import type { AccountID } from '../../accounts/model/account.js';
 import type { NoteID } from '../model/note.js';
-import type { ReactionRepository } from '../model/repository.js';
+import {
+  type ReactionRepository,
+  reactionRepoSymbol,
+} from '../model/repository.js';
 
 export class DeleteReactionService {
   constructor(private readonly reactionRepository: ReactionRepository) {}
@@ -13,3 +16,12 @@ export class DeleteReactionService {
     return await this.reactionRepository.deleteByID({ noteID, accountID });
   }
 }
+export const deleteReactionSymbol =
+  Ether.newEtherSymbol<DeleteReactionService>();
+export const deleteReaction = Ether.newEther(
+  deleteReactionSymbol,
+  ({ reactionRepository }) => new DeleteReactionService(reactionRepository),
+  {
+    reactionRepository: reactionRepoSymbol,
+  },
+);

--- a/resources/schema.json
+++ b/resources/schema.json
@@ -405,6 +405,102 @@
               "description": "Note created date",
               "example": "2021-01-01T00:00:00Z"
             },
+            "reactions": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "emoji": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "pattern": "[\\u2700-\\u27BF]|[\\uE000-\\uF8FF]|\\uD83C[\\uDC00-\\uDFFF]|\\uD83D[\\uDC00-\\uDFFF]|[\\u2011-\\u26FF]|\\uD83E[\\uDD10-\\uDDFF]"
+                      },
+                      {
+                        "type": "string",
+                        "pattern": "<:(\\w+):(\\d+)>"
+                      }
+                    ],
+                    "description": "Reaction Emoji (Unicode or Custom Emoji)",
+                    "examples": [
+                      "🎉",
+                      "<:custom_emoji:123456789>"
+                    ]
+                  },
+                  "reacted_by": {
+                    "type": "string",
+                    "description": "Reacted account ID",
+                    "example": "38477395"
+                  }
+                },
+                "required": [
+                  "emoji",
+                  "reacted_by"
+                ]
+              },
+              "description": "Reactions"
+            },
+            "attachment_files": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "description": "attachment Medium id",
+                    "example": "39783475"
+                  },
+                  "name": {
+                    "type": "string",
+                    "description": "attachment filename",
+                    "example": "image.jpg"
+                  },
+                  "author_id": {
+                    "type": "string",
+                    "description": "attachment author account id",
+                    "example": "309823457"
+                  },
+                  "hash": {
+                    "type": "string",
+                    "description": "attachment medium blurhash",
+                    "example": "e9f*5oin{dn"
+                  },
+                  "mime": {
+                    "type": "string",
+                    "description": "attachment medium mime type",
+                    "example": "image/jpeg"
+                  },
+                  "nsfw": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "if true, attachment is nsfw"
+                  },
+                  "url": {
+                    "type": "string",
+                    "format": "uri",
+                    "description": "attachment medium url",
+                    "example": "https://images.example.com/image.webp"
+                  },
+                  "thumbnail": {
+                    "type": "string",
+                    "description": "attachment thumbnail url",
+                    "example": "https://images.example.com/image_thumbnail.webp"
+                  }
+                },
+                "required": [
+                  "id",
+                  "name",
+                  "author_id",
+                  "hash",
+                  "mime",
+                  "nsfw",
+                  "url",
+                  "thumbnail"
+                ]
+              },
+              "maxItems": 16,
+              "description": "Note Attachment Media"
+            },
             "author": {
               "type": "object",
               "properties": {
@@ -451,6 +547,8 @@
             "contents_warning_comment",
             "visibility",
             "created_at",
+            "reactions",
+            "attachment_files",
             "author"
           ]
         }
@@ -3344,6 +3442,78 @@
             }
           }
         }
+      },
+      "delete": {
+        "tags": [
+          "reaction"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Note ID",
+              "example": "1"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "OK"
+          },
+          "404": {
+            "description": "Reaction not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "enum": [
+                        "NOTE_NOT_FOUND"
+                      ],
+                      "description": "Note not found"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "enum": [
+                        "INTERNAL_ERROR"
+                      ],
+                      "description": "Internal Error"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "description": "Internal Error"
+                }
+              }
+            }
+          }
+        }
       }
     },
     "/notes/:id/bookmark": {
@@ -3692,9 +3862,300 @@
                   "properties": {
                     "error": {
                       "type": "string",
-                      "default": "",
-                      "description": "Error code",
-                      "example": "TEST_ERROR_CODE"
+                      "enum": [
+                        "FILE_NOT_FOUND"
+                      ],
+                      "description": "File not found"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "enum": [
+                        "INTERNAL_ERROR"
+                      ],
+                      "description": "Internal server error."
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/timeline/home": {
+      "get": {
+        "tags": [
+          "timeline"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "boolean",
+              "description": "If true, only return notes with attachment"
+            },
+            "required": false,
+            "name": "has_attachment",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "boolean",
+              "description": "If true, only return notes without sensitive content"
+            },
+            "required": false,
+            "name": "no_nsfw",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Return notes before this note ID. specified note ID is not included"
+            },
+            "required": false,
+            "name": "before_id",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string",
+                        "description": "Note ID",
+                        "example": "38477395"
+                      },
+                      "content": {
+                        "type": "string",
+                        "description": "Note content",
+                        "example": "hello world!"
+                      },
+                      "contents_warning_comment": {
+                        "type": "string",
+                        "description": "Contents warning comment",
+                        "example": "(if length not 0) This note contains sensitive content"
+                      },
+                      "visibility": {
+                        "type": "string",
+                        "description": "Note visibility (PUBLIC/HOME/FOLLOWERS/DIRECT)",
+                        "example": "PUBLIC"
+                      },
+                      "created_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Note created date",
+                        "example": "2021-01-01T00:00:00Z"
+                      },
+                      "reactions": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "emoji": {
+                              "anyOf": [
+                                {
+                                  "type": "string",
+                                  "pattern": "[\\u2700-\\u27BF]|[\\uE000-\\uF8FF]|\\uD83C[\\uDC00-\\uDFFF]|\\uD83D[\\uDC00-\\uDFFF]|[\\u2011-\\u26FF]|\\uD83E[\\uDD10-\\uDDFF]"
+                                },
+                                {
+                                  "type": "string",
+                                  "pattern": "<:(\\w+):(\\d+)>"
+                                }
+                              ],
+                              "description": "Reaction Emoji (Unicode or Custom Emoji)",
+                              "examples": [
+                                "🎉",
+                                "<:custom_emoji:123456789>"
+                              ]
+                            },
+                            "reacted_by": {
+                              "type": "string",
+                              "description": "Reacted account ID",
+                              "example": "38477395"
+                            }
+                          },
+                          "required": [
+                            "emoji",
+                            "reacted_by"
+                          ]
+                        },
+                        "description": "Reactions"
+                      },
+                      "attachment_files": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "description": "attachment Medium id",
+                              "example": "39783475"
+                            },
+                            "name": {
+                              "type": "string",
+                              "description": "attachment filename",
+                              "example": "image.jpg"
+                            },
+                            "author_id": {
+                              "type": "string",
+                              "description": "attachment author account id",
+                              "example": "309823457"
+                            },
+                            "hash": {
+                              "type": "string",
+                              "description": "attachment medium blurhash",
+                              "example": "e9f*5oin{dn"
+                            },
+                            "mime": {
+                              "type": "string",
+                              "description": "attachment medium mime type",
+                              "example": "image/jpeg"
+                            },
+                            "nsfw": {
+                              "type": "boolean",
+                              "default": false,
+                              "description": "if true, attachment is nsfw"
+                            },
+                            "url": {
+                              "type": "string",
+                              "format": "uri",
+                              "description": "attachment medium url",
+                              "example": "https://images.example.com/image.webp"
+                            },
+                            "thumbnail": {
+                              "type": "string",
+                              "description": "attachment thumbnail url",
+                              "example": "https://images.example.com/image_thumbnail.webp"
+                            }
+                          },
+                          "required": [
+                            "id",
+                            "name",
+                            "author_id",
+                            "hash",
+                            "mime",
+                            "nsfw",
+                            "url",
+                            "thumbnail"
+                          ]
+                        },
+                        "maxItems": 16,
+                        "description": "Note Attachment Media"
+                      },
+                      "author": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "display_name": {
+                            "type": "string"
+                          },
+                          "bio": {
+                            "type": "string"
+                          },
+                          "avatar": {
+                            "type": "string"
+                          },
+                          "header": {
+                            "type": "string"
+                          },
+                          "followed_count": {
+                            "type": "number"
+                          },
+                          "following_count": {
+                            "type": "number"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "name",
+                          "display_name",
+                          "bio",
+                          "avatar",
+                          "header",
+                          "followed_count",
+                          "following_count"
+                        ]
+                      }
+                    },
+                    "required": [
+                      "id",
+                      "content",
+                      "contents_warning_comment",
+                      "visibility",
+                      "created_at",
+                      "reactions",
+                      "attachment_files",
+                      "author"
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Nothing left",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "enum": [
+                        "NOTHING_LEFT"
+                      ],
+                      "description": "No more notes exist"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "enum": [
+                        "INTERNAL_ERROR"
+                      ],
+                      "description": "Internal server error"
                     }
                   },
                   "required": [
@@ -3760,6 +4221,28 @@
               }
             }
           },
+          "403": {
+            "description": "You are blocked by specified account",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "enum": [
+                        "YOU_ARE_BLOCKED"
+                      ],
+                      "description": "You are blocked by the account"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
           "404": {
             "description": "Account not found",
             "content": {
@@ -3768,15 +4251,53 @@
                   "type": "object",
                   "properties": {
                     "error": {
-                      "type": "string",
-                      "default": "",
-                      "description": "Error code",
-                      "example": "TEST_ERROR_CODE"
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "enum": [
+                            "ACCOUNT_NOT_FOUND"
+                          ],
+                          "description": "Account not found."
+                        },
+                        {
+                          "type": "string",
+                          "enum": [
+                            "NOTHING_LEFT"
+                          ],
+                          "description": "No more notes exist"
+                        }
+                      ],
+                      "description": "Error codes",
+                      "example": "ACCOUNT_NOT_FOUND"
                     }
                   },
                   "required": [
                     "error"
-                  ]
+                  ],
+                  "description": "Account not found"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "enum": [
+                        "INTERNAL_ERROR"
+                      ],
+                      "description": "Internal server error"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "description": "Internal server error"
                 }
               }
             }
@@ -3845,15 +4366,52 @@
                   "type": "object",
                   "properties": {
                     "error": {
-                      "type": "string",
-                      "default": "",
-                      "description": "Error code",
-                      "example": "TEST_ERROR_CODE"
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "enum": [
+                            "NOTHING_LEFT"
+                          ],
+                          "description": "No more notes exist"
+                        },
+                        {
+                          "type": "string",
+                          "enum": [
+                            "LIST_NOT_FOUND"
+                          ],
+                          "description": "List not found"
+                        }
+                      ],
+                      "description": "Error codes",
+                      "example": "LIST_NOT_FOUND"
                     }
                   },
                   "required": [
                     "error"
                   ]
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "enum": [
+                        "INTERNAL_ERROR"
+                      ],
+                      "description": "Internal server error"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "description": "Internal server error"
                 }
               }
             }
@@ -3892,7 +4450,7 @@
             }
           },
           "400": {
-            "description": "TITLE_TOO_LONG",
+            "description": "Bad request",
             "content": {
               "application/json": {
                 "schema": {
@@ -3900,14 +4458,39 @@
                   "properties": {
                     "error": {
                       "type": "string",
-                      "default": "",
-                      "description": "Error code",
-                      "example": "TEST_ERROR_CODE"
+                      "enum": [
+                        "TITLE_TOO_LONG"
+                      ],
+                      "description": "List title is too long"
                     }
                   },
                   "required": [
                     "error"
-                  ]
+                  ],
+                  "description": "List title too long"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "enum": [
+                        "INTERNAL_ERROR"
+                      ],
+                      "description": "Internal server error"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "description": "Internal server error"
                 }
               }
             }
@@ -3938,7 +4521,7 @@
             "description": "OK"
           },
           "404": {
-            "description": "LIST_NOTFOUND",
+            "description": "List not found",
             "content": {
               "application/json": {
                 "schema": {
@@ -3946,14 +4529,39 @@
                   "properties": {
                     "error": {
                       "type": "string",
-                      "default": "",
-                      "description": "Error code",
-                      "example": "TEST_ERROR_CODE"
+                      "enum": [
+                        "LIST_NOT_FOUND"
+                      ],
+                      "description": "List not found"
                     }
                   },
                   "required": [
                     "error"
-                  ]
+                  ],
+                  "description": "List not found"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "enum": [
+                        "INTERNAL_ERROR"
+                      ],
+                      "description": "Internal server error"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "description": "Internal server error"
                 }
               }
             }
@@ -4002,7 +4610,7 @@
             }
           },
           "400": {
-            "description": "TITLE_TOO_LONG",
+            "description": "List title too long",
             "content": {
               "application/json": {
                 "schema": {
@@ -4010,9 +4618,33 @@
                   "properties": {
                     "error": {
                       "type": "string",
-                      "default": "",
-                      "description": "Error code",
-                      "example": "TEST_ERROR_CODE"
+                      "enum": [
+                        "TITLE_TOO_LONG"
+                      ],
+                      "description": "List title is too long"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "description": "List title too long"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "List not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "enum": [
+                        "LIST_NOT_FOUND"
+                      ],
+                      "description": "List not found"
                     }
                   },
                   "required": [
@@ -4022,8 +4654,8 @@
               }
             }
           },
-          "404": {
-            "description": "LIST_NOTFOUND",
+          "500": {
+            "description": "Internal error",
             "content": {
               "application/json": {
                 "schema": {
@@ -4031,14 +4663,16 @@
                   "properties": {
                     "error": {
                       "type": "string",
-                      "default": "",
-                      "description": "Error code",
-                      "example": "TEST_ERROR_CODE"
+                      "enum": [
+                        "INTERNAL_ERROR"
+                      ],
+                      "description": "Internal server error"
                     }
                   },
                   "required": [
                     "error"
-                  ]
+                  ],
+                  "description": "Internal server error"
                 }
               }
             }
@@ -4076,7 +4710,7 @@
             }
           },
           "404": {
-            "description": "LIST_NOTFOUND",
+            "description": "List not found",
             "content": {
               "application/json": {
                 "schema": {
@@ -4084,14 +4718,39 @@
                   "properties": {
                     "error": {
                       "type": "string",
-                      "default": "",
-                      "description": "Error code",
-                      "example": "TEST_ERROR_CODE"
+                      "enum": [
+                        "LIST_NOT_FOUND"
+                      ],
+                      "description": "List not found"
                     }
                   },
                   "required": [
                     "error"
-                  ]
+                  ],
+                  "description": "List not found"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "enum": [
+                        "INTERNAL_ERROR"
+                      ],
+                      "description": "Internal server error"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "description": "Internal server error"
                 }
               }
             }
@@ -4116,7 +4775,7 @@
             }
           },
           "404": {
-            "description": "LIST_NOTFOUND",
+            "description": "List not found",
             "content": {
               "application/json": {
                 "schema": {
@@ -4124,14 +4783,39 @@
                   "properties": {
                     "error": {
                       "type": "string",
-                      "default": "",
-                      "description": "Error code",
-                      "example": "TEST_ERROR_CODE"
+                      "enum": [
+                        "LIST_NOT_FOUND"
+                      ],
+                      "description": "List not found"
                     }
                   },
                   "required": [
                     "error"
-                  ]
+                  ],
+                  "description": "List not found"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "enum": [
+                        "INTERNAL_ERROR"
+                      ],
+                      "description": "Internal server error"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "description": "Internal server error"
                 }
               }
             }


### PR DESCRIPTION
close #776 
## What does this PR do?
- リアクションを解除できるように (`DELETE /notes/:id/reaction`

## Additional information
- Repositoryで、リアクション解除を論理削除->物理削除に変更しました
  - noteIDとaccountIDの複合主キーなので、論理削除すると1回しかつけられなくなってしまうため