### PR TITLE
feat: push note to author's home timeline

### DIFF
--- a/pkg/timeline/service/push.test.ts
+++ b/pkg/timeline/service/push.test.ts
@@ -55,6 +55,17 @@ describe('PushTimelineService', () => {
     expect(Result.unwrap(res)).toBe(undefined);
   });
 
+  it('push to author home timeline', async () => {
+    const res = await pushTimelineService.handle(dummyPublicNote);
+    const homeTimeline = await timelineCacheRepository.getHomeTimeline(
+      '100' as AccountID,
+    );
+
+    expect(Result.unwrap(res)).toBe(undefined);
+    expect(Result.isErr(homeTimeline)).toBe(false);
+    expect(Result.unwrap(homeTimeline)).toEqual(['1' as NoteID]);
+  });
+
   it('push to list', async () => {
     const res = await pushTimelineService.handle(dummyPublicNote);
     const listTimeline = await timelineCacheRepository.getListTimeline(

--- a/pkg/timeline/service/push.ts
+++ b/pkg/timeline/service/push.ts
@@ -41,13 +41,6 @@ export class PushTimelineService {
       return followers;
     }
     const unwrappedFollowers = Result.unwrap(followers);
-    // NOTE: add note to author's home timeline
-    unwrappedFollowers.push({
-      id: note.getAuthorID(),
-      name: '@@',
-      nickname: '',
-      bio: '',
-    });
 
     /*
     PUBLIC, HOME, FOLLOWER: OK
@@ -64,13 +57,18 @@ export class PushTimelineService {
     }
 
     // ToDo: bulk insert
-    const res = await Promise.all(
-      unwrappedFollowers.map((v) => {
+    const res = await Promise.all([
+      ...unwrappedFollowers.map((v) => {
         return this.timelineNotesCacheRepository.addNotesToHomeTimeline(v.id, [
           note,
         ]);
       }),
-    );
+      // NOTE: add note to author's home timeline
+      this.timelineNotesCacheRepository.addNotesToHomeTimeline(
+        note.getAuthorID(),
+        [note],
+      ),
+    ]);
     return res.find(Result.isErr) ?? Result.ok(undefined);
   }
 

--- a/pkg/timeline/service/push.ts
+++ b/pkg/timeline/service/push.ts
@@ -41,6 +41,13 @@ export class PushTimelineService {
       return followers;
     }
     const unwrappedFollowers = Result.unwrap(followers);
+    // NOTE: add note to author's home timeline
+    unwrappedFollowers.push({
+      id: note.getAuthorID(),
+      name: '@@',
+      nickname: '',
+      bio: '',
+    });
 
     /*
     PUBLIC, HOME, FOLLOWER: OK


### PR DESCRIPTION
close #781 
## What does this PR do?
- 投稿した本人のホームタイムラインにノートを配信するようにしました
  - Caramelで正しく動作することを確認済み(投稿後のタイムライン自動更新も含め)
