### PR TITLE
fix: valkey client to be initialized only when needed

### DIFF
--- a/pkg/adaptors/valkey.ts
+++ b/pkg/adaptors/valkey.ts
@@ -1,3 +1,5 @@
 import { Redis } from 'ioredis';
 
-export const valkeyClient = new Redis('localhost:6379');
+export const valkeyClient = (): Redis => {
+  return new Redis('localhost:6379');
+};

--- a/pkg/timeline/mod.ts
+++ b/pkg/timeline/mod.ts
@@ -82,7 +82,7 @@ const noteVisibilityService = Cat.cat(noteVisibility).feed(
 ).value;
 
 const timelineCacheRepository = isProduction
-  ? valkeyTimelineCacheRepo(valkeyClient)
+  ? valkeyTimelineCacheRepo(valkeyClient())
   : inMemoryTimelineCacheRepo([]);
 
 const controller = new TimelineController({
@@ -166,7 +166,7 @@ timeline.openapi(GetHomeTimelineRoute, async (c) => {
 
 timeline[GetAccountTimelineRoute.method](
   GetAccountTimelineRoute.path,
-  AuthMiddleware.handle({ forceAuthorized: false }),
+  AuthMiddleware.handle({ forceAuthorized: true }),
 );
 timeline.openapi(GetAccountTimelineRoute, async (c) => {
   const actorID = Option.unwrap(c.get('accountID'));


### PR DESCRIPTION
close #777 
## What does this PR do?
- valkey(redis)のクライアント初期化をproductionモード時のみ行うように
- Intermodule::TimelineModuleの初期化でモードを見てprisma/dummyを切り替えるように

## Additional information
