### PR TITLE
feat: アカウントをID/Name両方で取得できるように

### DIFF
--- a/pkg/accounts/adaptor/controller/account.ts
+++ b/pkg/accounts/adaptor/controller/account.ts
@@ -233,6 +233,34 @@ export class AccountController {
     });
   }
 
+  async getAccountByName(
+    name: string,
+  ): Promise<Result.Result<Error, z.infer<typeof GetAccountResponseSchema>>> {
+    const res = await this.fetchService.fetchAccount(name as AccountName);
+    if (Result.isErr(res)) {
+      return res;
+    }
+
+    return Result.ok({
+      id: res[1].getID(),
+      email: res[1].getMail(),
+      name: res[1].getName() as string,
+      nickname: res[1].getNickname(),
+      bio: res[1].getBio(),
+      // ToDo: fill the following fields
+      avatar: '',
+      header: '',
+      followed_count: 0,
+      following_count: 0,
+      note_count: 0,
+      created_at: res[1].getCreatedAt(),
+      role: res[1].getRole(),
+      frozen: res[1].getFrozen(),
+      status: res[1].getStatus(),
+      silenced: res[1].getSilenced(),
+    });
+  }
+
   async login(
     name: string,
     passphrase: string,

--- a/pkg/accounts/router.ts
+++ b/pkg/accounts/router.ts
@@ -578,13 +578,24 @@ export const RefreshRoute = createRoute({
 export const GetAccountRoute = createRoute({
   method: 'get',
   tags: ['accounts'],
-  path: '/accounts/:id',
+  path: '/accounts/:identifier',
   request: {
     params: z.object({
-      id: z.string().openapi({
-        example: '495849959300385847',
-        description: 'Account ID',
-      }),
+      identifier: z
+        .union([
+          z.string().openapi({
+            example: '@johndoe@example.com',
+            description: 'account name',
+          }),
+          z.string().openapi({
+            example: '31644833000002',
+            description: 'account id',
+          }),
+        ])
+        .openapi({
+          example: '@johndoe@example.com',
+          description: 'account name or id',
+        }),
     }),
   },
   responses: {

--- a/pkg/timeline/adaptor/repository/prisma.ts
+++ b/pkg/timeline/adaptor/repository/prisma.ts
@@ -76,7 +76,7 @@ export class PrismaTimelineRepository implements TimelineRepository {
       ...(filter.beforeId
         ? {
             cursor: {
-              id: filter.beforeId ?? '',
+              id: filter.beforeId,
             },
             // NOTE: Not include specified record
             skip: 1,

--- a/pkg/timeline/adaptor/repository/prisma.ts
+++ b/pkg/timeline/adaptor/repository/prisma.ts
@@ -73,9 +73,16 @@ export class PrismaTimelineRepository implements TimelineRepository {
       orderBy: {
         createdAt: 'desc',
       },
-      cursor: {
-        id: filter.beforeId ?? '',
-      },
+      ...(filter.beforeId
+        ? {
+            cursor: {
+              id: filter.beforeId ?? '',
+            },
+            // NOTE: Not include specified record
+            skip: 1,
+          }
+        : {}),
+      take: this.TIMELINE_NOTE_LIMIT,
     });
 
     return Result.ok(this.deserialize(accountNotes));

--- a/pkg/timeline/service/account.ts
+++ b/pkg/timeline/service/account.ts
@@ -38,7 +38,6 @@ export class AccountTimelineService {
 
     // NOTE: AccountTimeline not include direct note
     const directFiltered = res[1].filter((v) => v.getVisibility() !== 'DIRECT');
-
     const filtered: Note[] = [];
     for (const v of directFiltered) {
       const isVisible = await this.noteVisibilityService.handle({

--- a/resources/schema.json
+++ b/resources/schema.json
@@ -1442,7 +1442,7 @@
         }
       }
     },
-    "/accounts/:id": {
+    "/accounts/:identifier": {
       "get": {
         "tags": [
           "accounts"
@@ -1450,12 +1450,23 @@
         "parameters": [
           {
             "schema": {
-              "type": "string",
-              "description": "Account ID",
-              "example": "495849959300385847"
+              "anyOf": [
+                {
+                  "type": "string",
+                  "description": "account name",
+                  "example": "@johndoe@example.com"
+                },
+                {
+                  "type": "string",
+                  "description": "account id",
+                  "example": "31644833000002"
+                }
+              ],
+              "description": "account name or id",
+              "example": "@johndoe@example.com"
             },
             "required": true,
-            "name": "id",
+            "name": "identifier",
             "in": "path"
           }
         ],
@@ -3478,9 +3489,9 @@
                     "error": {
                       "type": "string",
                       "enum": [
-                        "NOTE_NOT_FOUND"
+                        "NOT_REACTED"
                       ],
-                      "description": "Note not found"
+                      "description": "You did not react to this note"
                     }
                   },
                   "required": [


### PR DESCRIPTION
close #785 
## What does this PR do?
- `GET /accounts/:id`を`GET /accounts/:identifier`に変更
  - IDまたはNameで取得できるように
- APIドキュメントの更新
- PrismaRepositoryの実装ミスで投稿を取得できない問題を修正
  - 同様の実装が数箇所あるはずなので別の箇所についてはIssueを立てて対処します

## Additional information