### PR TITLE
feat: Added cache retention limit to list/home timeline

### DIFF
--- a/pkg/id/mod.ts
+++ b/pkg/id/mod.ts
@@ -105,5 +105,5 @@ export const IDSchema = <T>() =>
  * @param a
  * @param b
  */
-export const compareID = <T>(a: ID<T>, b: ID<T>) =>
+export const compareID = <T>(a: ID<T>, b: ID<T>): number =>
   Number(BigInt(b) - BigInt(a));

--- a/pkg/id/mod.ts
+++ b/pkg/id/mod.ts
@@ -99,3 +99,11 @@ export const IDSchema = <T>() =>
       }
     })
     .transform((s) => s as ID<T>);
+
+/**
+ * Compare two IDs (sort in descending order)
+ * @param a
+ * @param b
+ */
+export const compareID = <T>(a: ID<T>, b: ID<T>) =>
+  Number(BigInt(b) - BigInt(a));

--- a/pkg/notes/service/create.test.ts
+++ b/pkg/notes/service/create.test.ts
@@ -29,7 +29,11 @@ const attachmentRepository = new InMemoryNoteAttachmentRepository(
   [],
 );
 
-const timelineCacheRepository = new InMemoryTimelineCacheRepository();
+const timelineCacheRepository = new InMemoryTimelineCacheRepository([
+  ['101' as AccountID, []],
+  ['102' as AccountID, []],
+  ['103' as AccountID, []],
+]);
 const createService = new CreateService(
   noteRepository,
   new SnowflakeIDGenerator(0, {
@@ -118,12 +122,7 @@ describe('CreateService', () => {
     const res1 = await timelineCacheRepository.getHomeTimeline(
       '103' as AccountID,
     );
-    const res2 = await timelineCacheRepository.getHomeTimeline(
-      '103' as AccountID,
-    );
     expect(Result.isOk(res1)).toBe(true);
-    expect(Result.isOk(res2)).toBe(true);
     expect(Result.unwrap(res1)).toHaveLength(1);
-    expect(Result.unwrap(res2)).toHaveLength(1);
   });
 });

--- a/pkg/timeline/adaptor/repository/dummyCache.ts
+++ b/pkg/timeline/adaptor/repository/dummyCache.ts
@@ -1,6 +1,7 @@
 import { Ether, Result } from '@mikuroxina/mini-fn';
 
 import type { AccountID } from '../../../accounts/model/account.js';
+import { compareID } from '../../../id/mod.js';
 import type { Note, NoteID } from '../../../notes/model/note.js';
 import type { ListID } from '../../model/list.js';
 import {
@@ -75,7 +76,7 @@ export class InMemoryTimelineCacheRepository
     if (!fetched) {
       return Result.err(new Error('Not found'));
     }
-    return Result.ok(fetched.sort((a, b) => Number(BigInt(b) - BigInt(a))));
+    return Result.ok(fetched.sort(compareID));
   }
 
   async getListTimeline(
@@ -85,7 +86,7 @@ export class InMemoryTimelineCacheRepository
     if (!fetched) {
       return Result.err(new Error('Not found'));
     }
-    return Result.ok(fetched.sort((a, b) => Number(BigInt(b) - BigInt(a))));
+    return Result.ok(fetched.sort(compareID));
   }
 
   reset(

--- a/pkg/timeline/adaptor/repository/valkeyCache.ts
+++ b/pkg/timeline/adaptor/repository/valkeyCache.ts
@@ -101,6 +101,40 @@ export class ValkeyTimelineCacheRepository
       );
     }
   }
+
+  async deleteNotesFromHomeTimeline(
+    accountID: AccountID,
+    noteIDs: NoteID[],
+  ): Promise<Result.Result<Error, void>> {
+    try {
+      await this.redisClient.zrem(
+        this.generateObjectKey(accountID, 'home'),
+        ...noteIDs,
+      );
+      return Result.ok(undefined);
+    } catch (e) {
+      return Result.err(
+        new TimelineInternalError('unknown valkey error', { cause: e }),
+      );
+    }
+  }
+
+  async deleteNotesFromListTimeline(
+    listID: ListID,
+    noteIDs: NoteID[],
+  ): Promise<Result.Result<Error, void>> {
+    try {
+      await this.redisClient.zrem(
+        this.generateObjectKey(listID, 'list'),
+        ...noteIDs,
+      );
+      return Result.ok(undefined);
+    } catch (e) {
+      return Result.err(
+        new TimelineInternalError('unknown valkey error', { cause: e }),
+      );
+    }
+  }
 }
 export const valkeyTimelineCacheRepo = (redisClient: Redis) =>
   Ether.newEther(

--- a/pkg/timeline/model/repository.ts
+++ b/pkg/timeline/model/repository.ts
@@ -65,6 +65,25 @@ export interface TimelineNotesCacheRepository {
   getHomeTimeline(
     accountID: AccountID,
   ): Promise<Result.Result<Error, NoteID[]>>;
+
+  /**
+   * @description Delete notes from home timeline
+   * @param accountID
+   * @param noteIDs
+   */
+  deleteNotesFromHomeTimeline(
+    accountID: AccountID,
+    noteIDs: NoteID[],
+  ): Promise<Result.Result<Error, void>>;
+  /**
+   * @description Delete notes from list timeline
+   * @param listID
+   * @param noteIDs
+   */
+  deleteNotesFromListTimeline(
+    listID: ListID,
+    noteIDs: NoteID[],
+  ): Promise<Result.Result<Error, void>>;
 }
 export const timelineNotesCacheRepoSymbol =
   Ether.newEtherSymbol<TimelineNotesCacheRepository>();

--- a/pkg/timeline/service/list.test.ts
+++ b/pkg/timeline/service/list.test.ts
@@ -1,6 +1,5 @@
 import { Result } from '@mikuroxina/mini-fn';
 import { describe, expect, it } from 'vitest';
-import { Note, type NoteID } from '../../notes/model/note.js';
 import { InMemoryTimelineRepository } from '../adaptor/repository/dummy.js';
 import { InMemoryTimelineCacheRepository } from '../adaptor/repository/dummyCache.js';
 import type { ListID } from '../model/list.js';
@@ -13,52 +12,27 @@ import {
 import { ListTimelineService } from './list.js';
 
 describe('ListTimelineService', () => {
-  const sameTimePublicNote = Note.reconstruct({
-    id: '10' as NoteID,
-    authorID: dummyPublicNote.getAuthorID(),
-    content: dummyPublicNote.getContent(),
-    visibility: dummyPublicNote.getVisibility(),
-    contentsWarningComment: dummyPublicNote.getCwComment(),
-    sendTo: dummyPublicNote.getSendTo(),
-    originalNoteID: dummyPublicNote.getOriginalNoteID(),
-    attachmentFileID: dummyPublicNote.getAttachmentFileID(),
-    createdAt: dummyPublicNote.getCreatedAt(),
-    updatedAt: dummyPublicNote.getUpdatedAt(),
-    deletedAt: dummyPublicNote.getDeletedAt(),
-  });
   const cache = new InMemoryTimelineCacheRepository();
-  cache.addNotesToList('1' as ListID, [
-    dummyPublicNote,
-    dummyHomeNote,
-    sameTimePublicNote,
-  ]);
+  cache.addNotesToList('1' as ListID, [dummyPublicNote, dummyHomeNote]);
   const repository = new InMemoryTimelineRepository([
     dummyPublicNote,
     dummyHomeNote,
     dummyFollowersNote,
     dummyDirectNote,
-    sameTimePublicNote,
   ]);
   const service = new ListTimelineService(cache, repository);
 
   it('should fetch list timeline notes', async () => {
     const res = await service.handle('1' as ListID);
     expect(Result.isOk(res)).toBe(true);
-    expect(Result.unwrap(res)).toHaveLength(3);
-    expect(Result.unwrap(res)).toStrictEqual([
-      dummyHomeNote,
-      dummyPublicNote,
-      sameTimePublicNote,
-    ]);
+    expect(Result.unwrap(res)).toHaveLength(2);
+    expect(Result.unwrap(res)).toStrictEqual([dummyHomeNote, dummyPublicNote]);
   });
 
-  it('should notes sorted by createdAt, descending', async () => {
+  it('should notes sorted by ID, descending', async () => {
     const res = await service.handle('1' as ListID);
-    /* NOTE: after ECMAScript 2019, Array.prototype.sort() is stable sort.
-     * So, if two elements have the same createdAt, the order of the elements.
-     */
-    const sorted = [dummyPublicNote, dummyHomeNote, sameTimePublicNote].sort(
-      (a, b) => b.getCreatedAt().getDate() - a.getCreatedAt().getDate(),
+    const sorted = [dummyPublicNote, dummyHomeNote].sort((a, b) =>
+      Number(BigInt(b.getID()) - BigInt(a.getID())),
     );
     expect(Result.isOk(res)).toBe(true);
     expect(Result.unwrap(res)).toStrictEqual(sorted);

--- a/pkg/timeline/service/push.ts
+++ b/pkg/timeline/service/push.ts
@@ -20,7 +20,7 @@ export class PushTimelineService {
     private readonly timelineNotesCacheRepository: TimelineNotesCacheRepository,
     private readonly fetchSubscribedListService: FetchSubscribedListService,
     /**
-     * @description Limit of timeline cache
+     * @description Limit length of timeline caches
      * @private
      */
     private readonly TIMELINE_CACHE_LIMIT = 300,
@@ -35,48 +35,40 @@ export class PushTimelineService {
     timelineID: T extends 'home' ? AccountID : ListID,
   ): Promise<Result.Result<Error, void>> {
     if (timelineType === 'home') {
-      const timeline = await this.timelineNotesCacheRepository.getHomeTimeline(
-        timelineID as AccountID,
-      );
-      if (Result.isErr(timeline)) {
-        return timeline;
+      const timelineRes =
+        await this.timelineNotesCacheRepository.getHomeTimeline(
+          timelineID as AccountID,
+        );
+      if (Result.isErr(timelineRes)) {
+        return timelineRes;
       }
-      const unwrappedTimeline = Result.unwrap(timeline);
-      if (unwrappedTimeline.length >= this.TIMELINE_CACHE_LIMIT) {
-        const oldestNote = unwrappedTimeline[unwrappedTimeline.length - 1];
-        if (!oldestNote) {
-          return Result.err(
-            new TimelineInternalError("Can't get oldest note", { cause: null }),
-          );
-        }
-
+      const timeline = Result.unwrap(timelineRes);
+      if (timeline.length >= this.TIMELINE_CACHE_LIMIT) {
+        const oldNotes = timeline.slice(this.TIMELINE_CACHE_LIMIT - 1);
+        console.log(timeline.length, this.TIMELINE_CACHE_LIMIT);
         return this.timelineNotesCacheRepository.deleteNotesFromHomeTimeline(
           timelineID as AccountID,
-          [oldestNote],
+          oldNotes,
         );
       }
       return Result.ok(undefined);
     }
 
     if (timelineType === 'list') {
-      const timeline = await this.timelineNotesCacheRepository.getListTimeline(
-        timelineID as ListID,
-      );
-      if (Result.isErr(timeline)) {
-        return timeline;
+      const timelineRes =
+        await this.timelineNotesCacheRepository.getListTimeline(
+          timelineID as ListID,
+        );
+      if (Result.isErr(timelineRes)) {
+        return timelineRes;
       }
-      const unwrappedTimeline = Result.unwrap(timeline);
-      if (unwrappedTimeline.length >= this.TIMELINE_CACHE_LIMIT) {
-        const oldestNote = unwrappedTimeline[unwrappedTimeline.length - 1];
-        if (!oldestNote) {
-          return Result.err(
-            new TimelineInternalError("Can't get oldest note", { cause: null }),
-          );
-        }
+      const timeline = Result.unwrap(timelineRes);
+      if (timeline.length >= this.TIMELINE_CACHE_LIMIT) {
+        const oldNotes = timeline.slice(this.TIMELINE_CACHE_LIMIT - 1);
 
         return this.timelineNotesCacheRepository.deleteNotesFromListTimeline(
           timelineID as ListID,
-          [oldestNote],
+          oldNotes,
         );
       }
 


### PR DESCRIPTION
close #801 
## What does this PR do?
- リスト/ホームタイムラインのキャッシュを300件までに制限するように
- ノートのソートに使う要素をCreatedAtからIDに
- テスト用repositoryでリストのキャッシュを正常に行えるように

## Additional information
