### PR TITLE
feat: impl account activation

### DIFF
--- a/pkg/accounts/adaptor/repository/dummy/verifyToken.ts
+++ b/pkg/accounts/adaptor/repository/dummy/verifyToken.ts
@@ -14,24 +14,29 @@ export class InMemoryAccountVerifyTokenRepository
     this.data = new Map();
   }
 
-  create(
+  async create(
     accountID: AccountID,
     token: string,
     expire: Date,
   ): Promise<Result.Result<Error, void>> {
     this.data.set(accountID.toString(), { token, expire });
-    return Promise.resolve(Result.ok(undefined));
+    return Result.ok(undefined);
   }
 
-  findByID(
+  async findByID(
     id: AccountID,
   ): Promise<Option.Option<{ token: string; expire: Date }>> {
     const data = this.data.get(id);
     if (!data) {
-      return Promise.resolve(Option.none());
+      return Option.none();
     }
 
-    return Promise.resolve(Option.some(data));
+    return Option.some(data);
+  }
+
+  async delete(id: AccountID): Promise<Result.Result<Error, void>> {
+    this.data.delete(id);
+    return Result.ok(undefined);
   }
 }
 

--- a/pkg/accounts/adaptor/repository/prisma/prisma.ts
+++ b/pkg/accounts/adaptor/repository/prisma/prisma.ts
@@ -256,6 +256,20 @@ export class PrismaAccountVerifyTokenRepository
       expire: res.expiresAt,
     });
   }
+
+  async delete(id: AccountID): Promise<Result.Result<Error, void>> {
+    try {
+      await this.prisma.accountVerifyToken.delete({
+        where: {
+          accountId: id,
+        },
+      });
+      console.log('done');
+      return Result.ok(undefined);
+    } catch (e) {
+      return Result.err(parsePrismaError(e));
+    }
+  }
 }
 export const prismaVerifyTokenRepo = (client: PrismaClient) =>
   Ether.newEther(

--- a/pkg/accounts/adaptor/repository/prisma/prisma.ts
+++ b/pkg/accounts/adaptor/repository/prisma/prisma.ts
@@ -264,7 +264,6 @@ export class PrismaAccountVerifyTokenRepository
           accountId: id,
         },
       });
-      console.log('done');
       return Result.ok(undefined);
     } catch (e) {
       return Result.err(parsePrismaError(e));

--- a/pkg/accounts/model/repository.ts
+++ b/pkg/accounts/model/repository.ts
@@ -35,6 +35,12 @@ export interface AccountVerifyTokenRepository {
   findByID(
     id: AccountID,
   ): Promise<Option.Option<{ token: string; expire: Date }>>;
+
+  /**
+   * Delete a token by account ID.\
+   * NOTE: If the account ID does not exist, it will return error.
+   * @param id
+   */
   delete(id: AccountID): Promise<Result.Result<Error, void>>;
 }
 export const verifyTokenRepoSymbol =

--- a/pkg/accounts/model/repository.ts
+++ b/pkg/accounts/model/repository.ts
@@ -35,6 +35,7 @@ export interface AccountVerifyTokenRepository {
   findByID(
     id: AccountID,
   ): Promise<Option.Option<{ token: string; expire: Date }>>;
+  delete(id: AccountID): Promise<Result.Result<Error, void>>;
 }
 export const verifyTokenRepoSymbol =
   Ether.newEtherSymbol<AccountVerifyTokenRepository>();

--- a/pkg/accounts/service/verifyToken.test.ts
+++ b/pkg/accounts/service/verifyToken.test.ts
@@ -1,4 +1,4 @@
-import { Result } from '@mikuroxina/mini-fn';
+import { Option, Result } from '@mikuroxina/mini-fn';
 import { describe, expect, it } from 'vitest';
 
 import { MockClock } from '../../id/mod.js';
@@ -40,7 +40,9 @@ describe('VerifyAccountTokenService', () => {
     if (Result.isErr(token)) {
       return;
     }
-
+    expect(Option.isNone(await repository.findByID('1' as AccountID))).toBe(
+      false,
+    );
     const verify = await service.verify('@johndoe@example.com', token[1]);
     if (Result.isErr(verify)) {
       return;
@@ -48,6 +50,9 @@ describe('VerifyAccountTokenService', () => {
 
     expect(Result.isOk(token)).toBe(true);
     expect(Result.isOk(verify)).toBe(true);
+    expect(Option.isNone(await repository.findByID('1' as AccountID))).toBe(
+      true,
+    );
   });
 
   it('expired token', async () => {

--- a/pkg/accounts/service/verifyToken.ts
+++ b/pkg/accounts/service/verifyToken.ts
@@ -98,16 +98,15 @@ export class VerifyAccountTokenService {
       );
     }
 
+    const deleteTokenRes = await this.repository.delete(account.getID());
+    if (Result.isErr(deleteTokenRes)) {
+      return deleteTokenRes;
+    }
+
     account.activate();
     const editRes = await this.accountRepository.edit(account);
     if (Result.isErr(editRes)) {
       return editRes;
-    }
-
-    // tokenを削除する
-    const deleteTokenRes = await this.repository.delete(account.getID());
-    if (Result.isErr(deleteTokenRes)) {
-      return deleteTokenRes;
     }
 
     return Result.ok(undefined);


### PR DESCRIPTION
close #850 
## What does this PR do?
- アカウントの有効化を実装
- 適切にメールアドレス検証トークンを削除できるように
- いくつかの部分で Promise.resolveを使わないように

## Additional information