### PR TITLE
fix!: 認証トークンにリフレッシュトークンを含むようにした

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,8 @@
   "editor.codeActionsOnSave": {
     "source.organizeImports.biome": "explicit",
     "quickfix.biome": "explicit"
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "biomejs.biome"
   }
 }

--- a/pkg/accounts/adaptor/controller/account.ts
+++ b/pkg/accounts/adaptor/controller/account.ts
@@ -311,8 +311,7 @@ export class AccountController {
     }
 
     return Result.ok({
-      authorization_token: res[1].authorizationToken,
-      refresh_token: res[1].refreshToken,
+      authorization_token: Result.unwrap(res),
     });
   }
 

--- a/pkg/accounts/adaptor/validator/schema.ts
+++ b/pkg/accounts/adaptor/validator/schema.ts
@@ -148,11 +148,6 @@ export const LoginResponseSchema = z
       example:
         'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIzZTE2NDQ4MzMwMDAwMDIiLCJpYXQiOjE2NDA5OTUyMDEsInJlZnJlc2hfdG9rZW4iOiJleUpoYkdjaU9pSklVekkxTmlJc0luUjVjQ0k2SWtwWFZDSjkuZXlKemRXSWlPaUl6WlRFMk5EUTRNek13TURBd01ESWlMQ0pwWVhRaU9qRTJOREE1T1RVeU1ERjkud2Q4cWJVcWowWGtCU1hud0FxM0lRYU1nQS1RTFd2MHVKU1NLX3BIVTZCYyJ9.mRUfLIYOGlLuC9D72zBriVvrHYrQgVHW7ntQ-bp5SHs',
     }),
-    refresh_token: z.string().openapi({
-      description: 'refresh token',
-      example:
-        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIzZTE2NDQ4MzMwMDAwMDIiLCJpYXQiOjE2NDA5OTUyMDEsInJlZnJlc2hfdG9rZW4iOiJleUpoYkdjaU9pSklVekkxTmlJc0luUjVjQ0k2SWtwWFZDSjkuZXlKemRXSWlPaUl6WlRFMk5EUTRNek13TURBd01ESWlMQ0pwWVhRaU9qRTJOREE1T1RVeU1ERjkud2Q4cWJVcWowWGtCU1hud0FxM0lRYU1nQS1RTFd2MHVKU1NLX3BIVTZCYyJ9.mRUfLIYOGlLuC9D72zBriVvrHYrQgVHW7ntQ-bp5SHs',
-    }),
   })
   .openapi('LoginResponse');
 

--- a/pkg/accounts/mod.ts
+++ b/pkg/accounts/mod.ts
@@ -129,7 +129,7 @@ const verifyAccountTokenService = Cat.cat(verifyAccountToken)
 const composer = Ether.composeT(Promise.monad);
 const liftOverPromise = Ether.liftEther(Promise.monad);
 
-const authToken = await Cat.cat(authenticateToken).feed(
+const authToken = Cat.cat(authenticateToken).feed(
   composer(liftOverPromise(clock)),
 ).value;
 

--- a/pkg/accounts/service/authenticate.test.ts
+++ b/pkg/accounts/service/authenticate.test.ts
@@ -1,6 +1,7 @@
 import { Result } from '@mikuroxina/mini-fn';
 import { describe, expect, it } from 'vitest';
 
+import { MockClock } from '../../id/mod.js';
 import { Argon2idPasswordEncoder } from '../../password/mod.js';
 import { InMemoryAccountRepository } from '../adaptor/repository/dummy/account.js';
 import { Account, type AccountID } from '../model/account.js';
@@ -33,7 +34,9 @@ describe('AuthenticateService', () => {
       }),
     );
 
-    const authenticationTokenService = await AuthenticationTokenService.new();
+    const authenticationTokenService = await AuthenticationTokenService.new(
+      new MockClock(new Date('2022-01-01T00:00:00Z')),
+    );
 
     const service = new AuthenticateService({
       accountRepository: accountRepository,

--- a/pkg/accounts/service/authenticate.test.ts
+++ b/pkg/accounts/service/authenticate.test.ts
@@ -9,7 +9,7 @@ import { AuthenticateService } from './authenticate.js';
 import { AuthenticationTokenService } from './authenticationTokenService.js';
 
 describe('AuthenticateService', () => {
-  it('Generate valid token pair', async () => {
+  it('Generate valid token', async () => {
     const encoder = new Argon2idPasswordEncoder();
     const passphraseHash = await encoder.encodePassword(
       'じゃすた・いぐざんぽぅ',
@@ -35,7 +35,7 @@ describe('AuthenticateService', () => {
     );
 
     const authenticationTokenService = await AuthenticationTokenService.new(
-      new MockClock(new Date('2022-01-01T00:00:00Z')),
+      new MockClock(new Date()),
     );
 
     const service = new AuthenticateService({
@@ -47,11 +47,7 @@ describe('AuthenticateService', () => {
     const result = Result.unwrap(
       await service.handle('@test@example.com', 'じゃすた・いぐざんぽぅ'),
     );
-    expect(
-      await authenticationTokenService.verify(result.authorizationToken),
-    ).toBe(true);
-    expect(await authenticationTokenService.verify(result.refreshToken)).toBe(
-      true,
-    );
+    expect(await authenticationTokenService.verify(result)).toBe(true);
+    expect(await authenticationTokenService.verify(result)).toBe(true);
   });
 });

--- a/pkg/accounts/service/authenticate.ts
+++ b/pkg/accounts/service/authenticate.ts
@@ -15,6 +15,7 @@ import {
   accountRepoSymbol,
 } from '../model/repository.js';
 import {
+  type AuthenticationToken,
   type AuthenticationTokenService,
   authenticateTokenSymbol,
 } from './authenticationTokenService.js';
@@ -37,7 +38,7 @@ export class AuthenticateService {
   async handle(
     name: AccountName,
     passphrase: string,
-  ): Promise<Result.Result<Error, string>> {
+  ): Promise<Result.Result<Error, AuthenticationToken>> {
     const account = await this.accountRepository.findByName(name);
     if (Option.isNone(account)) {
       return Result.err(

--- a/pkg/accounts/service/authenticate.ts
+++ b/pkg/accounts/service/authenticate.ts
@@ -4,7 +4,6 @@ import {
   type PasswordEncoder,
   passwordEncoderSymbol,
 } from '../../password/mod.js';
-import { addSecondsToDate, convertTo } from '../../time/mod.js';
 import type { AccountName } from '../model/account.js';
 import {
   AccountAuthenticationFailedError,
@@ -19,11 +18,6 @@ import {
   type AuthenticationTokenService,
   authenticateTokenSymbol,
 } from './authenticationTokenService.js';
-
-export interface TokenPair {
-  authorizationToken: string;
-  refreshToken: string;
-}
 
 export class AuthenticateService {
   private readonly accountRepository: AccountRepository;
@@ -43,7 +37,7 @@ export class AuthenticateService {
   async handle(
     name: AccountName,
     passphrase: string,
-  ): Promise<Result.Result<Error, TokenPair>> {
+  ): Promise<Result.Result<Error, string>> {
     const account = await this.accountRepository.findByName(name);
     if (Option.isNone(account)) {
       return Result.err(
@@ -63,14 +57,13 @@ export class AuthenticateService {
       );
     }
 
-    const authorizationToken = await this.authenticationTokenService.generate(
-      Option.unwrap(account).getID(),
-      convertTo(new Date()),
-      convertTo(addSecondsToDate(new Date(), 900)),
-      Option.unwrap(account).getName(),
-    );
+    const authorizationTokenRes =
+      await this.authenticationTokenService.generate(
+        Option.unwrap(account).getID(),
+        Option.unwrap(account).getName(),
+      );
 
-    if (Option.isNone(authorizationToken)) {
+    if (Option.isNone(authorizationTokenRes)) {
       return Result.err(
         new AccountInternalError('Failed to generate authorization token', {
           cause: null,
@@ -78,25 +71,7 @@ export class AuthenticateService {
       );
     }
 
-    const refreshToken = await this.authenticationTokenService.generate(
-      Option.unwrap(account).getID(),
-      convertTo(new Date()),
-      convertTo(addSecondsToDate(new Date(), 2_592_000)),
-      Option.unwrap(account).getName(),
-    );
-
-    if (Option.isNone(refreshToken)) {
-      return Result.err(
-        new AccountInternalError('Failed to generate refresh token', {
-          cause: null,
-        }),
-      );
-    }
-
-    return Result.ok({
-      authorizationToken: Option.unwrap(authorizationToken),
-      refreshToken: Option.unwrap(refreshToken),
-    });
+    return Result.ok(Option.unwrap(authorizationTokenRes));
   }
 }
 

--- a/pkg/accounts/service/authenticationTokenService.test.ts
+++ b/pkg/accounts/service/authenticationTokenService.test.ts
@@ -1,10 +1,13 @@
 import { Option } from '@mikuroxina/mini-fn';
 import { describe, expect, it } from 'vitest';
 
+import { MockClock } from '../../id/mod.js';
 import { convertTo } from '../../time/mod.js';
 import { AuthenticationTokenService } from './authenticationTokenService.js';
 
-const service = await AuthenticationTokenService.new();
+const service = await AuthenticationTokenService.new(
+  new MockClock(new Date('2022-01-01T00:00:00Z')),
+);
 
 describe('AuthenticationTokenService', () => {
   it('verify JWT Token', async () => {

--- a/pkg/accounts/service/authenticationTokenService.test.ts
+++ b/pkg/accounts/service/authenticationTokenService.test.ts
@@ -2,21 +2,14 @@ import { Option } from '@mikuroxina/mini-fn';
 import { describe, expect, it } from 'vitest';
 
 import { MockClock } from '../../id/mod.js';
-import { convertTo } from '../../time/mod.js';
 import { AuthenticationTokenService } from './authenticationTokenService.js';
-
-const service = await AuthenticationTokenService.new(
-  new MockClock(new Date('2022-01-01T00:00:00Z')),
-);
 
 describe('AuthenticationTokenService', () => {
   it('verify JWT Token', async () => {
-    const token = await service.generate(
-      '',
-      convertTo(new Date()),
-      convertTo(new Date('2099-12-31T12:59:59Z')),
-      '',
+    const service = await AuthenticationTokenService.new(
+      new MockClock(new Date()),
     );
+    const token = await service.generate('', '');
     if (Option.isNone(token)) {
       return;
     }
@@ -25,12 +18,10 @@ describe('AuthenticationTokenService', () => {
   });
 
   it('if token expired', async () => {
-    const expired = await service.generate(
-      '',
-      convertTo(new Date('2022-01-01T00:00:00Z')),
-      convertTo(new Date('2022-01-02T00:00:00Z')),
-      '',
+    const service = await AuthenticationTokenService.new(
+      new MockClock(new Date('2022-01-01T00:00:00Z')),
     );
+    const expired = await service.generate('', '');
     if (Option.isNone(expired)) return;
 
     expect(await service.verify(expired[1])).toBe(false);

--- a/pkg/drive/mod.ts
+++ b/pkg/drive/mod.ts
@@ -8,6 +8,7 @@ import {
   authenticateMiddleware,
 } from '../adaptors/authenticateMiddleware.js';
 import { prismaClient } from '../adaptors/prisma.js';
+import { clockSymbol } from '../id/mod.js';
 import { DriveController } from './adaptor/controller/drive.js';
 import { driveModuleLogger } from './adaptor/logger.js';
 import { inMemoryMediaRepo } from './adaptor/repository/dummy.js';
@@ -19,10 +20,20 @@ import { fetchMediaService } from './service/fetch.js';
 const isProduction = process.env.NODE_ENV === 'production';
 const composer = Ether.composeT(Promise.monad);
 const liftOverPromise = Ether.liftEther(Promise.monad);
+
+class Clock {
+  now() {
+    return BigInt(Date.now());
+  }
+}
+const clock = Ether.newEther(clockSymbol, () => new Clock());
+const authToken = await Cat.cat(authenticateToken).feed(
+  composer(liftOverPromise(clock)),
+).value;
+
 const AuthMiddleware = await Ether.runEtherT(
-  Cat.cat(liftOverPromise(authenticateMiddleware)).feed(
-    composer(authenticateToken),
-  ).value,
+  Cat.cat(liftOverPromise(authenticateMiddleware)).feed(composer(authToken))
+    .value,
 );
 
 const mediaRepository = isProduction

--- a/pkg/drive/mod.ts
+++ b/pkg/drive/mod.ts
@@ -27,7 +27,7 @@ class Clock {
   }
 }
 const clock = Ether.newEther(clockSymbol, () => new Clock());
-const authToken = await Cat.cat(authenticateToken).feed(
+const authToken = Cat.cat(authenticateToken).feed(
   composer(liftOverPromise(clock)),
 ).value;
 

--- a/pkg/notes/mod.ts
+++ b/pkg/notes/mod.ts
@@ -88,10 +88,13 @@ const idGenerator = Ether.compose(clock)(snowflakeIDGenerator(0));
 
 const composer = Ether.composeT(Promise.monad);
 const liftOverPromise = Ether.liftEther(Promise.monad);
+
+const authToken = await Cat.cat(authenticateToken).feed(
+  composer(liftOverPromise(clock)),
+).value;
 const AuthMiddleware = await Ether.runEtherT(
-  Cat.cat(liftOverPromise(authenticateMiddleware)).feed(
-    composer(authenticateToken),
-  ).value,
+  Cat.cat(liftOverPromise(authenticateMiddleware)).feed(composer(authToken))
+    .value,
 );
 
 const createServiceObj = Ether.runEther(

--- a/pkg/notes/mod.ts
+++ b/pkg/notes/mod.ts
@@ -89,7 +89,7 @@ const idGenerator = Ether.compose(clock)(snowflakeIDGenerator(0));
 const composer = Ether.composeT(Promise.monad);
 const liftOverPromise = Ether.liftEther(Promise.monad);
 
-const authToken = await Cat.cat(authenticateToken).feed(
+const authToken = Cat.cat(authenticateToken).feed(
   composer(liftOverPromise(clock)),
 ).value;
 const AuthMiddleware = await Ether.runEtherT(

--- a/pkg/timeline/mod.ts
+++ b/pkg/timeline/mod.ts
@@ -79,10 +79,13 @@ const listRepository = isProduction
 
 const liftOverPromise = Ether.liftEther(Promise.monad);
 const composer = Ether.composeT(Promise.monad);
+
+const authToken = await Cat.cat(authenticateToken).feed(
+  composer(liftOverPromise(clock)),
+).value;
 const AuthMiddleware = await Ether.runEtherT(
-  Cat.cat(liftOverPromise(authenticateMiddleware)).feed(
-    composer(authenticateToken),
-  ).value,
+  Cat.cat(liftOverPromise(authenticateMiddleware)).feed(composer(authToken))
+    .value,
 );
 const noteVisibilityService = Cat.cat(noteVisibility).feed(
   Ether.compose(accountModuleEther),

--- a/pkg/timeline/mod.ts
+++ b/pkg/timeline/mod.ts
@@ -80,7 +80,7 @@ const listRepository = isProduction
 const liftOverPromise = Ether.liftEther(Promise.monad);
 const composer = Ether.composeT(Promise.monad);
 
-const authToken = await Cat.cat(authenticateToken).feed(
+const authToken = Cat.cat(authenticateToken).feed(
   composer(liftOverPromise(clock)),
 ).value;
 const AuthMiddleware = await Ether.runEtherT(


### PR DESCRIPTION
close #906 
## What does this PR do?
- 認証トークンのペイロードに`refreshToken`を追加
- `POST /login`から`refresh_token`を削除
- AuthenticationTokenService内部でClockを持つように
  - それに伴うDI周りの更新

## Additional information
