### PR TITLE
feat: 認証トークンを更新できるように

### DIFF
--- a/pkg/accounts/adaptor/controller/account.ts
+++ b/pkg/accounts/adaptor/controller/account.ts
@@ -573,4 +573,8 @@ export class AccountController {
       actorID as AccountID,
     );
   }
+
+  async verifyAuthToken(token: string): Promise<Result.Result<Error, void>> {
+    return this.authenticationTokenService.verify(token);
+  }
 }

--- a/pkg/accounts/adaptor/controller/account.ts
+++ b/pkg/accounts/adaptor/controller/account.ts
@@ -5,6 +5,10 @@ import type { Medium, MediumID } from '../../../drive/model/medium.js';
 import type { AccountID, AccountName } from '../../model/account.js';
 import type { AccountFollow } from '../../model/follow.js';
 import type { AuthenticateService } from '../../service/authenticate.js';
+import type {
+  AuthenticationToken,
+  AuthenticationTokenService,
+} from '../../service/authenticationTokenService.js';
 import type { AccountAvatarService } from '../../service/avatar.js';
 import type { EditService } from '../../service/edit.js';
 import type { FetchService } from '../../service/fetch.js';
@@ -23,6 +27,7 @@ import type {
   GetAccountFollowingSchema,
   GetAccountResponseSchema,
   LoginResponseSchema,
+  RefreshResponseSchema,
   UpdateAccountResponseSchema,
 } from '../validator/schema.js';
 
@@ -40,6 +45,7 @@ export class AccountController {
   private readonly resendTokenService: ResendVerifyTokenService;
   private readonly headerService: AccountHeaderService;
   private readonly avatarService: AccountAvatarService;
+  private readonly authenticationTokenService: AuthenticationTokenService;
 
   constructor(args: {
     registerService: RegisterService;
@@ -55,6 +61,7 @@ export class AccountController {
     resendTokenService: ResendVerifyTokenService;
     headerService: AccountHeaderService;
     avatarService: AccountAvatarService;
+    authenticationTokenService: AuthenticationTokenService;
   }) {
     this.registerService = args.registerService;
     this.editService = args.editService;
@@ -69,6 +76,7 @@ export class AccountController {
     this.resendTokenService = args.resendTokenService;
     this.headerService = args.headerService;
     this.avatarService = args.avatarService;
+    this.authenticationTokenService = args.authenticationTokenService;
   }
 
   async createAccount(
@@ -305,6 +313,21 @@ export class AccountController {
     const res = await this.authenticateService.handle(
       name as AccountName,
       passphrase,
+    );
+    if (Result.isErr(res)) {
+      return res;
+    }
+
+    return Result.ok({
+      authorization_token: Result.unwrap(res),
+    });
+  }
+
+  async refresh(
+    token: string,
+  ): Promise<Result.Result<Error, z.infer<typeof RefreshResponseSchema>>> {
+    const res = await this.authenticationTokenService.renewAuthToken(
+      token as AuthenticationToken,
     );
     if (Result.isErr(res)) {
       return res;

--- a/pkg/accounts/adaptor/validator/schema.ts
+++ b/pkg/accounts/adaptor/validator/schema.ts
@@ -151,15 +151,6 @@ export const LoginResponseSchema = z
   })
   .openapi('LoginResponse');
 
-export const RefreshRequestSchema = z
-  .object({
-    refresh_token: z.string().openapi({
-      description: 'refresh token',
-      example:
-        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIzZTE2NDQ4MzMwMDAwMDIiLCJpYXQiOjE2NDA5OTUyMDEsInJlZnJlc2hfdG9rZW4iOiJleUpoYkdjaU9pSklVekkxTmlJc0luUjVjQ0k2SWtwWFZDSjkuZXlKemRXSWlPaUl6WlRFMk5EUTRNek13TURBd01ESWlMQ0pwWVhRaU9qRTJOREE1T1RVeU1ERjkud2Q4cWJVcWowWGtCU1hud0FxM0lRYU1nQS1RTFd2MHVKU1NLX3BIVTZCYyJ9.mRUfLIYOGlLuC9D72zBriVvrHYrQgVHW7ntQ-bp5SHs',
-    }),
-  })
-  .openapi('RefreshRequest');
 export const RefreshResponseSchema = z
   .object({
     authorization_token: z.string().openapi({

--- a/pkg/accounts/model/errors.ts
+++ b/pkg/accounts/model/errors.ts
@@ -183,6 +183,28 @@ export class AccountMailAddressVerificationTokenInvalidError extends Error {
 }
 
 /**
+ * Authentication token is invalid
+ */
+export class AccountAuthenticationTokenInvalidError extends Error {
+  constructor(message: string, options: { cause: unknown }) {
+    super(message);
+    this.name = 'AccountAuthenticationTokenInvalidError';
+    this.cause = options.cause;
+  }
+}
+
+/**
+ * Authentication token is expired
+ */
+export class AccountAuthenticationTokenExpiredError extends Error {
+  constructor(message: string, options: { cause: unknown }) {
+    super(message);
+    this.name = 'AccountAuthenticationTokenExpiredError';
+    this.cause = options.cause;
+  }
+}
+
+/**
  * Refresh token is invalid
  */
 export class AccountRefreshTokenInvalidError extends Error {

--- a/pkg/accounts/router.ts
+++ b/pkg/accounts/router.ts
@@ -31,7 +31,7 @@ import {
   GetAccountResponseSchema,
   LoginRequestSchema,
   LoginResponseSchema,
-  RefreshRequestSchema,
+  RefreshResponseSchema,
   ResendVerificationEmailRequestSchema,
   SetAccountAvatarRequestSchema,
   UpdateAccountRequestSchema,
@@ -536,20 +536,18 @@ export const RefreshRoute = createRoute({
   tags: ['accounts'],
   path: '/refresh',
   request: {
-    body: {
-      content: {
-        'application/json': {
-          schema: RefreshRequestSchema,
-        },
-      },
-    },
+    headers: z.object({
+      Authorization: z.string().openapi({
+        description: 'Bearer token',
+      }),
+    }),
   },
   responses: {
     200: {
       description: 'OK',
       content: {
         'application/json': {
-          schema: UpdateAccountResponseSchema,
+          schema: RefreshResponseSchema,
         },
       },
     },

--- a/pkg/accounts/service/authenticate.test.ts
+++ b/pkg/accounts/service/authenticate.test.ts
@@ -47,7 +47,8 @@ describe('AuthenticateService', () => {
     const result = Result.unwrap(
       await service.handle('@test@example.com', 'じゃすた・いぐざんぽぅ'),
     );
-    expect(await authenticationTokenService.verify(result)).toBe(true);
-    expect(await authenticationTokenService.verify(result)).toBe(true);
+    expect(Result.isOk(await authenticationTokenService.verify(result))).toBe(
+      true,
+    );
   });
 });

--- a/pkg/accounts/service/authenticationTokenService.test.ts
+++ b/pkg/accounts/service/authenticationTokenService.test.ts
@@ -29,7 +29,6 @@ describe('AuthenticationTokenService', () => {
       new MockClock(new Date('2022-01-01T00:00:00Z')),
     );
     const expired = await service.generate('', '');
-    expect(Option.isSome(expired)).toBe(true);
 
     expect(Result.isOk(await service.verify(Option.unwrap(expired)))).toBe(
       false,
@@ -40,7 +39,6 @@ describe('AuthenticationTokenService', () => {
     // NOTE: mockClock returns only *static* time, this test using a normal clock
     const service = await AuthenticationTokenService.new(new Clock());
     const token = await service.generate('314', '628');
-    expect(Option.isSome(token)).toBe(true);
 
     const { refreshToken: oldRefreshToken, ...oldPayload } = jose.decodeJwt(
       Option.unwrap(token),
@@ -73,7 +71,6 @@ describe('AuthenticationTokenService', () => {
       new MockClock(new Date('2022-01-01T00:00:00Z')),
     );
     const expired = await service.generate('314', '628');
-    expect(Option.isNone(expired)).toBe(false);
 
     const result = await service.renewAuthToken(Option.unwrap(expired));
     expect(Result.isErr(result)).toBe(true);

--- a/pkg/accounts/service/authenticationTokenService.test.ts
+++ b/pkg/accounts/service/authenticationTokenService.test.ts
@@ -1,8 +1,15 @@
-import { Option } from '@mikuroxina/mini-fn';
+import { Option, Result } from '@mikuroxina/mini-fn';
+import * as jose from 'jose';
 import { describe, expect, it } from 'vitest';
 
 import { MockClock } from '../../id/mod.js';
 import { AuthenticationTokenService } from './authenticationTokenService.js';
+
+class Clock {
+  now() {
+    return BigInt(Date.now());
+  }
+}
 
 describe('AuthenticationTokenService', () => {
   it('verify JWT Token', async () => {
@@ -22,8 +29,45 @@ describe('AuthenticationTokenService', () => {
       new MockClock(new Date('2022-01-01T00:00:00Z')),
     );
     const expired = await service.generate('', '');
+    expect(Option.isSome(expired)).toBe(true);
+
+    expect(await service.verify(Option.unwrap(expired))).toBe(false);
+  });
+
+  it('renew: if token is valid, it should return a new token', async () => {
+    // NOTE: mockClock returns only *static* time, this test using a normal clock
+    const service = await AuthenticationTokenService.new(new Clock());
+    const token = await service.generate('314', '628');
+    expect(Option.isSome(token)).toBe(true);
+
+    const { refreshToken: oldRefreshToken, ...oldPayload } = jose.decodeJwt(
+      Option.unwrap(token),
+    );
+
+    await (async (ms) => new Promise((resolve) => setTimeout(resolve, ms)))(
+      1000,
+    );
+
+    const renewed = await service.renewAuthToken(Option.unwrap(token));
+    const { refreshToken: newRefreshToken, ...newPayload } = jose.decodeJwt(
+      Result.unwrap(renewed),
+    );
+
+    // renewed token must be valid token
+    expect(await service.verify(Result.unwrap(renewed))).toBe(true);
+
+    expect(oldPayload).not.toStrictEqual(newPayload);
+    expect(oldRefreshToken).toStrictEqual(newRefreshToken);
+  });
+
+  it('renew: if authToken is expired, it should return error', async () => {
+    const service = await AuthenticationTokenService.new(
+      new MockClock(new Date('2022-01-01T00:00:00Z')),
+    );
+    const expired = await service.generate('314', '628');
     if (Option.isNone(expired)) return;
 
-    expect(await service.verify(expired[1])).toBe(false);
+    const result = await service.renewAuthToken(Option.unwrap(expired));
+    expect(Result.isErr(result)).toBe(true);
   });
 });

--- a/pkg/accounts/service/authenticationTokenService.ts
+++ b/pkg/accounts/service/authenticationTokenService.ts
@@ -3,8 +3,8 @@ import * as jose from 'jose';
 
 import { type Clock, clockSymbol } from '../../id/mod.js';
 import {
+  AccountAuthenticationTokenExpiredError,
   AccountAuthenticationTokenInvalidError,
-  AccountRefreshTokenInvalidError,
 } from '../model/errors.js';
 
 declare const authenticationTokenNominal: unique symbol;
@@ -54,7 +54,7 @@ export class AuthenticationTokenService {
       .setExpirationTime(Number(currentTime / 1000n) + 60 * 60 * 24 * 30)
       .sign(this.privateKey);
 
-    const authToken = (await new jose.SignJWT({
+    const authToken = await new jose.SignJWT({
       accountName: accountName,
       refreshToken,
     })
@@ -63,31 +63,23 @@ export class AuthenticationTokenService {
       .setSubject(subject)
       // Note: 900s = 15min
       .setExpirationTime(Number(currentTime / 1000n) + 60 * 15)
-      .sign(this.privateKey)) as AuthenticationToken;
+      .sign(this.privateKey);
 
-    return Option.some(authToken);
+    return Option.some(authToken as AuthenticationToken);
   }
 
   public async renewAuthToken(
     token: AuthenticationToken,
   ): Promise<Result.Result<Error, AuthenticationToken>> {
-    if (!(await this.verify(token))) {
-      return Result.err(
-        new AccountAuthenticationTokenInvalidError(
-          'Authentication token is invalid',
-          { cause: null },
-        ),
-      );
-    }
-
     const { refreshToken, accountName, sub } = jose.decodeJwt(token);
 
-    if (!(await this.verify(refreshToken as string))) {
-      return Result.err(
-        new AccountRefreshTokenInvalidError('Refresh token is invalid', {
-          cause: null,
-        }),
-      );
+    const authTokenVerifyRes = await this.verify(token);
+    const refreshTokenVerifyRes = await this.verify(refreshToken as string);
+    if (Result.isErr(authTokenVerifyRes)) {
+      return authTokenVerifyRes;
+    }
+    if (Result.isErr(refreshTokenVerifyRes)) {
+      return refreshTokenVerifyRes;
     }
 
     const currentTime = this.clock.now();
@@ -106,12 +98,27 @@ export class AuthenticationTokenService {
     return Result.ok(authToken as AuthenticationToken);
   }
 
-  public async verify(token: string): Promise<boolean> {
+  public async verify(token: string): Promise<Result.Result<Error, void>> {
     try {
       await jose.jwtVerify(token, this.publicKey);
-      return true;
-    } catch {
-      return false;
+      return Result.ok(undefined);
+    } catch (e) {
+      if (e instanceof jose.errors.JWTInvalid) {
+        return Result.err(
+          new AccountAuthenticationTokenInvalidError('Token is invalid', {
+            cause: e,
+          }),
+        );
+      }
+      if (e instanceof jose.errors.JWTExpired) {
+        return Result.err(
+          new AccountAuthenticationTokenExpiredError('Token is expired', {
+            cause: e,
+          }),
+        );
+      }
+
+      return Result.err(e as Error);
     }
   }
 }

--- a/pkg/adaptors/authenticateMiddleware.ts
+++ b/pkg/adaptors/authenticateMiddleware.ts
@@ -1,4 +1,4 @@
-import { Ether, Option } from '@mikuroxina/mini-fn';
+import { Ether, Option, Result } from '@mikuroxina/mini-fn';
 import type { MiddlewareHandler } from 'hono';
 import { createMiddleware } from 'hono/factory';
 
@@ -80,7 +80,9 @@ export class AuthenticateMiddlewareService {
       }
       c.set('token', token);
 
-      const isValidToken = await this.authTokenService.verify(token);
+      const isValidToken = Result.isOk(
+        await this.authTokenService.verify(token),
+      );
       const parsed = this.parseToken(token);
       if (!isValidToken) {
         return c.json({ error: 'UNAUTHORIZED' }, { status: 401 });

--- a/pkg/notes/mod.ts
+++ b/pkg/notes/mod.ts
@@ -1,12 +1,10 @@
 import { OpenAPIHono } from '@hono/zod-openapi';
-import { Cat, Ether, Option, Promise, Result } from '@mikuroxina/mini-fn';
+import { Cat, Ether, Option, Result } from '@mikuroxina/mini-fn';
 
 import { AccountNotFoundError } from '../accounts/model/errors.js';
-import { authenticateToken } from '../accounts/service/authenticationTokenService.js';
 import {
   type AuthMiddlewareVariable,
   AuthenticateMiddlewareService,
-  authenticateMiddleware,
 } from '../adaptors/authenticateMiddleware.js';
 import { prismaClient } from '../adaptors/prisma.js';
 import { clockSymbol, snowflakeIDGenerator } from '../id/mod.js';

--- a/pkg/notes/mod.ts
+++ b/pkg/notes/mod.ts
@@ -5,6 +5,7 @@ import { AccountNotFoundError } from '../accounts/model/errors.js';
 import { authenticateToken } from '../accounts/service/authenticationTokenService.js';
 import {
   type AuthMiddlewareVariable,
+  AuthenticateMiddlewareService,
   authenticateMiddleware,
 } from '../adaptors/authenticateMiddleware.js';
 import { prismaClient } from '../adaptors/prisma.js';
@@ -86,16 +87,7 @@ class Clock {
 const clock = Ether.newEther(clockSymbol, () => new Clock());
 const idGenerator = Ether.compose(clock)(snowflakeIDGenerator(0));
 
-const composer = Ether.composeT(Promise.monad);
-const liftOverPromise = Ether.liftEther(Promise.monad);
-
-const authToken = Cat.cat(authenticateToken).feed(
-  composer(liftOverPromise(clock)),
-).value;
-const AuthMiddleware = await Ether.runEtherT(
-  Cat.cat(liftOverPromise(authenticateMiddleware)).feed(composer(authToken))
-    .value,
-);
+const AuthMiddleware = new AuthenticateMiddlewareService();
 
 const createServiceObj = Ether.runEther(
   Cat.cat(createService)

--- a/pkg/timeline/mod.ts
+++ b/pkg/timeline/mod.ts
@@ -1,12 +1,11 @@
 import { OpenAPIHono } from '@hono/zod-openapi';
-import { Cat, Ether, Option, Promise, Result } from '@mikuroxina/mini-fn';
+import { Cat, Ether, Option, Result } from '@mikuroxina/mini-fn';
 
 import { AccountNotFoundError } from '../accounts/model/errors.js';
-import { authenticateToken } from '../accounts/service/authenticationTokenService.js';
+
 import {
   type AuthMiddlewareVariable,
   AuthenticateMiddlewareService,
-  authenticateMiddleware,
 } from '../adaptors/authenticateMiddleware.js';
 import { prismaClient } from '../adaptors/prisma.js';
 import { valkeyClient } from '../adaptors/valkey.js';

--- a/pkg/timeline/mod.ts
+++ b/pkg/timeline/mod.ts
@@ -5,6 +5,7 @@ import { AccountNotFoundError } from '../accounts/model/errors.js';
 import { authenticateToken } from '../accounts/service/authenticationTokenService.js';
 import {
   type AuthMiddlewareVariable,
+  AuthenticateMiddlewareService,
   authenticateMiddleware,
 } from '../adaptors/authenticateMiddleware.js';
 import { prismaClient } from '../adaptors/prisma.js';
@@ -77,16 +78,7 @@ const listRepository = isProduction
   ? prismaListRepo(prismaClient)
   : inMemoryListRepo();
 
-const liftOverPromise = Ether.liftEther(Promise.monad);
-const composer = Ether.composeT(Promise.monad);
-
-const authToken = Cat.cat(authenticateToken).feed(
-  composer(liftOverPromise(clock)),
-).value;
-const AuthMiddleware = await Ether.runEtherT(
-  Cat.cat(liftOverPromise(authenticateMiddleware)).feed(composer(authToken))
-    .value,
-);
+const AuthMiddleware = new AuthenticateMiddlewareService();
 const noteVisibilityService = Cat.cat(noteVisibility).feed(
   Ether.compose(accountModuleEther),
 ).value;

--- a/resources/schema.json
+++ b/resources/schema.json
@@ -303,16 +303,10 @@
             "type": "string",
             "description": "authorization token",
             "example": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIzZTE2NDQ4MzMwMDAwMDIiLCJpYXQiOjE2NDA5OTUyMDEsInJlZnJlc2hfdG9rZW4iOiJleUpoYkdjaU9pSklVekkxTmlJc0luUjVjQ0k2SWtwWFZDSjkuZXlKemRXSWlPaUl6WlRFMk5EUTRNek13TURBd01ESWlMQ0pwWVhRaU9qRTJOREE1T1RVeU1ERjkud2Q4cWJVcWowWGtCU1hud0FxM0lRYU1nQS1RTFd2MHVKU1NLX3BIVTZCYyJ9.mRUfLIYOGlLuC9D72zBriVvrHYrQgVHW7ntQ-bp5SHs"
-          },
-          "refresh_token": {
-            "type": "string",
-            "description": "refresh token",
-            "example": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIzZTE2NDQ4MzMwMDAwMDIiLCJpYXQiOjE2NDA5OTUyMDEsInJlZnJlc2hfdG9rZW4iOiJleUpoYkdjaU9pSklVekkxTmlJc0luUjVjQ0k2SWtwWFZDSjkuZXlKemRXSWlPaUl6WlRFMk5EUTRNek13TURBd01ESWlMQ0pwWVhRaU9qRTJOREE1T1RVeU1ERjkud2Q4cWJVcWowWGtCU1hud0FxM0lRYU1nQS1RTFd2MHVKU1NLX3BIVTZCYyJ9.mRUfLIYOGlLuC9D72zBriVvrHYrQgVHW7ntQ-bp5SHs"
           }
         },
         "required": [
-          "authorization_token",
-          "refresh_token"
+          "authorization_token"
         ]
       },
       "LoginRequest": {
@@ -343,17 +337,17 @@
           "captcha_token"
         ]
       },
-      "RefreshRequest": {
+      "RefreshResponse": {
         "type": "object",
         "properties": {
-          "refresh_token": {
+          "authorization_token": {
             "type": "string",
-            "description": "refresh token",
+            "description": "authorization token",
             "example": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIzZTE2NDQ4MzMwMDAwMDIiLCJpYXQiOjE2NDA5OTUyMDEsInJlZnJlc2hfdG9rZW4iOiJleUpoYkdjaU9pSklVekkxTmlJc0luUjVjQ0k2SWtwWFZDSjkuZXlKemRXSWlPaUl6WlRFMk5EUTRNek13TURBd01ESWlMQ0pwWVhRaU9qRTJOREE1T1RVeU1ERjkud2Q4cWJVcWowWGtCU1hud0FxM0lRYU1nQS1RTFd2MHVKU1NLX3BIVTZCYyJ9.mRUfLIYOGlLuC9D72zBriVvrHYrQgVHW7ntQ-bp5SHs"
           }
         },
         "required": [
-          "refresh_token"
+          "authorization_token"
         ]
       },
       "ResendVerificationEmailRequest": {
@@ -1606,22 +1600,24 @@
         "tags": [
           "accounts"
         ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/RefreshRequest"
-              }
-            }
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Bearer token"
+            },
+            "required": true,
+            "name": "Authorization",
+            "in": "header"
           }
-        },
+        ],
         "responses": {
           "200": {
             "description": "OK",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/UpdateAccountResponse"
+                  "$ref": "#/components/schemas/RefreshResponse"
                 }
               }
             }
@@ -4344,10 +4340,19 @@
           {
             "schema": {
               "type": "string",
-              "description": "Return notes before this note ID. specified note ID is not included"
+              "description": "Return notes before this note ID. specified note ID is not included. NOTE: after_id and before_id are exclusive."
             },
             "required": false,
             "name": "before_id",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Return notes after this note ID. Specified note is not included. NOTE: after_id and before_id are exclusive."
+            },
+            "required": false,
+            "name": "after_id",
             "in": "query"
           }
         ],
@@ -4620,10 +4625,19 @@
           {
             "schema": {
               "type": "string",
-              "description": "Return notes before this note ID. specified note ID is not included"
+              "description": "Return notes before this note ID. specified note ID is not included. NOTE: after_id and before_id are exclusive."
             },
             "required": false,
             "name": "before_id",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Return notes after this note ID. Specified note is not included. NOTE: after_id and before_id are exclusive."
+            },
+            "required": false,
+            "name": "after_id",
             "in": "query"
           }
         ],
@@ -4757,10 +4771,19 @@
           {
             "schema": {
               "type": "string",
-              "description": "Return notes before this note ID. specified note ID is not included"
+              "description": "Return notes before this note ID. specified note ID is not included. NOTE: after_id and before_id are exclusive."
             },
             "required": false,
             "name": "before_id",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Return notes after this note ID. Specified note is not included. NOTE: after_id and before_id are exclusive."
+            },
+            "required": false,
+            "name": "after_id",
             "in": "query"
           }
         ],
@@ -5233,6 +5256,244 @@
                     "error"
                   ],
                   "description": "Internal server error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "timeline"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "$ref": "#/components/schemas/List ID"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "account_id": {
+                    "$ref": "#/components/schemas/Account ID"
+                  }
+                },
+                "required": [
+                  "account_id"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "OK"
+          },
+          "400": {
+            "description": "Too many members",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "enum": [
+                        "TOO_MANY_TARGETS"
+                      ],
+                      "description": "Too many members to assign list"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "You do not have permission to add member to this list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "enum": [
+                            "NO_PERMISSION"
+                          ],
+                          "description": "No permission to access this object"
+                        },
+                        {
+                          "type": "string",
+                          "enum": [
+                            "YOU_ARE_BLOCKED"
+                          ],
+                          "description": "You are blocked by the account"
+                        }
+                      ]
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "List not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "enum": [
+                            "LIST_NOT_FOUND"
+                          ],
+                          "description": "List not found"
+                        },
+                        {
+                          "type": "string",
+                          "enum": [
+                            "ACCOUNT_NOT_FOUND"
+                          ],
+                          "description": "Account not found."
+                        }
+                      ]
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "timeline"
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "$ref": "#/components/schemas/List ID"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "account_id": {
+                    "$ref": "#/components/schemas/Account ID"
+                  }
+                },
+                "required": [
+                  "account_id"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "OK"
+          },
+          "403": {
+            "description": "You do not have permission to remove member to this list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "enum": [
+                            "NO_PERMISSION"
+                          ],
+                          "description": "No permission to access this object"
+                        },
+                        {
+                          "type": "string",
+                          "enum": [
+                            "YOU_ARE_BLOCKED"
+                          ],
+                          "description": "You are blocked by the account"
+                        }
+                      ]
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "List not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "enum": [
+                            "LIST_NOT_FOUND"
+                          ],
+                          "description": "List not found"
+                        },
+                        {
+                          "type": "string",
+                          "enum": [
+                            "ACCOUNT_NOT_FOUND"
+                          ],
+                          "description": "Account not found."
+                        }
+                      ]
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
                 }
               }
             }


### PR DESCRIPTION
close #907 
## What does this PR do?
- 認証トークンを更新できるように
 - `POST /refresh`の実装
 - `POST /login`から`refresh_token`を削除
- APIドキュメントの更新

## Additional information

