### PR TITLE
refactor(accounts): Remove new Date

### DIFF
--- a/pkg/accounts/mod.ts
+++ b/pkg/accounts/mod.ts
@@ -162,6 +162,7 @@ export const controller = new AccountController({
   ),
   followService: Ether.runEther(
     Cat.cat(follow)
+      .feed(Ether.compose(clock))
       .feed(Ether.compose(accountRepository))
       .feed(Ether.compose(accountFollowRepository)).value,
   ),
@@ -170,6 +171,7 @@ export const controller = new AccountController({
   ),
   registerService: Ether.runEther(
     Cat.cat(register)
+      .feed(Ether.compose(clock))
       .feed(Ether.compose(accountRepository))
       .feed(Ether.compose(idGenerator))
       .feed(Ether.compose(argon2idPasswordEncoder))

--- a/pkg/accounts/service/follow.test.ts
+++ b/pkg/accounts/service/follow.test.ts
@@ -1,6 +1,7 @@
 import { Option, Result } from '@mikuroxina/mini-fn';
 import { describe, expect, it } from 'vitest';
 
+import { MockClock } from '../../id/mod.js';
 import { InMemoryAccountRepository } from '../adaptor/repository/dummy/account.js';
 import { InMemoryAccountFollowRepository } from '../adaptor/repository/dummy/follow.js';
 import { Account, type AccountID } from '../model/account.js';
@@ -42,7 +43,11 @@ await accountRepository.create(
   }),
 );
 const repository = new InMemoryAccountFollowRepository();
-const service = new FollowService(repository, accountRepository);
+const service = new FollowService(
+  repository,
+  accountRepository,
+  new MockClock(new Date('2020-02-02')),
+);
 
 describe('FollowService', () => {
   it('should follow', async () => {

--- a/pkg/accounts/service/follow.test.ts
+++ b/pkg/accounts/service/follow.test.ts
@@ -46,7 +46,7 @@ const repository = new InMemoryAccountFollowRepository();
 const service = new FollowService(
   repository,
   accountRepository,
-  new MockClock(new Date('2020-02-02')),
+  new MockClock(new Date('2023-09-10T00:00:00Z')),
 );
 
 describe('FollowService', () => {

--- a/pkg/accounts/service/follow.ts
+++ b/pkg/accounts/service/follow.ts
@@ -1,5 +1,6 @@
 import { Ether, Option, Result } from '@mikuroxina/mini-fn';
 
+import { type Clock, clockSymbol } from '../../id/mod.js';
 import type { AccountName } from '../model/account.js';
 import { AccountNotFoundError } from '../model/errors.js';
 import { AccountFollow } from '../model/follow.js';
@@ -14,6 +15,7 @@ export class FollowService {
   constructor(
     private readonly followRepository: AccountFollowRepository,
     private readonly accountRepository: AccountRepository,
+    private readonly clock: Clock,
   ) {}
 
   async handle(
@@ -33,10 +35,11 @@ export class FollowService {
       );
     }
 
+    const now = this.clock.now();
     const follow = AccountFollow.new({
       fromID: fromAccount[1].getID(),
       targetID: targetAccount[1].getID(),
-      createdAt: new Date(),
+      createdAt: new Date(Number(now)),
     });
 
     const res = await this.followRepository.follow(follow);
@@ -51,7 +54,11 @@ export class FollowService {
 export const followSymbol = Ether.newEtherSymbol<FollowService>();
 export const follow = Ether.newEther(
   followSymbol,
-  ({ followRepository, accountRepository }) =>
-    new FollowService(followRepository, accountRepository),
-  { followRepository: followRepoSymbol, accountRepository: accountRepoSymbol },
+  ({ followRepository, accountRepository, clock }) =>
+    new FollowService(followRepository, accountRepository, clock),
+  {
+    followRepository: followRepoSymbol,
+    accountRepository: accountRepoSymbol,
+    clock: clockSymbol,
+  },
 );

--- a/pkg/accounts/service/register.test.ts
+++ b/pkg/accounts/service/register.test.ts
@@ -24,6 +24,7 @@ const registerService: RegisterService = new RegisterService({
     repository,
     mockClock,
   ),
+  clock: new MockClock(new Date('2020-02-02')),
 });
 
 const exampleInput = {

--- a/pkg/accounts/service/register.test.ts
+++ b/pkg/accounts/service/register.test.ts
@@ -24,7 +24,7 @@ const registerService: RegisterService = new RegisterService({
     repository,
     mockClock,
   ),
-  clock: new MockClock(new Date('2020-02-02')),
+  clock: new MockClock(new Date('2023-09-10T00:00:00Z')),
 });
 
 const exampleInput = {


### PR DESCRIPTION
Fixes #912.

## What does this PR do?

参照等価でない関数である, 引数なしの `Date` コンストラクタの呼び出しを取り除き, `Clock` インターフェイスを実装したオブジェクトを注入するようにリファクタしました.
