### PR TITLE
feat!: change API endpoint paths from /moduleName to /v0/moduleName (API versioning)

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -28,7 +28,7 @@ export const app = new Hono().get('/doc', async (c) => {
     },
     servers: [
       {
-        url: 'http://localhost:3000',
+        url: 'http://localhost:3000/',
         description: 'Local server',
       },
     ],
@@ -76,7 +76,7 @@ app.use(
 /*
 All routes must be "/"
 (The "/" account cannot be written in the library specification.
- */
+*/
 app.route('/', noteHandlers);
 app.route('/', accounts);
 app.route('/', drive);

--- a/pkg/accounts/router.ts
+++ b/pkg/accounts/router.ts
@@ -48,7 +48,7 @@ const InternalErrorResponseSchema = z
 export const CreateAccountRoute = createRoute({
   method: 'post',
   tags: ['accounts'],
-  path: '/accounts',
+  path: '/v0/accounts',
   request: {
     body: {
       content: {
@@ -109,7 +109,7 @@ export const CreateAccountRoute = createRoute({
 export const UpdateAccountRoute = createRoute({
   method: 'patch',
   tags: ['accounts'],
-  path: '/accounts/:name',
+  path: '/v0/accounts/:name',
   security: [
     {
       bearer: [],
@@ -203,7 +203,7 @@ export const UpdateAccountRoute = createRoute({
 export const FreezeAccountRoute = createRoute({
   method: 'put',
   tags: ['accounts'],
-  path: '/accounts/:name/freeze',
+  path: '/v0/accounts/:name/freeze',
   security: [
     {
       bearer: [],
@@ -278,7 +278,7 @@ export const FreezeAccountRoute = createRoute({
 export const UnFreezeAccountRoute = createRoute({
   method: 'delete',
   tags: ['accounts'],
-  path: '/accounts/:name/freeze',
+  path: '/v0/accounts/:name/freeze',
   security: [
     {
       bearer: [],
@@ -339,7 +339,7 @@ export const UnFreezeAccountRoute = createRoute({
 export const ResendVerificationEmailRoute = createRoute({
   method: 'post',
   tags: ['accounts'],
-  path: '/accounts/:name/resend_verify_email',
+  path: '/v0/accounts/:name/resend_verify_email',
   request: {
     params: z.object({
       name: z.string().min(3).max(64).openapi({
@@ -412,7 +412,7 @@ export const ResendVerificationEmailRoute = createRoute({
 export const VerifyEmailRoute = createRoute({
   method: 'post',
   tags: ['accounts'],
-  path: '/accounts/:name/verify_email',
+  path: '/v0/accounts/:name/verify_email',
   request: {
     params: z.object({
       name: z.string().min(3).max(64).openapi({
@@ -473,7 +473,7 @@ export const VerifyEmailRoute = createRoute({
 export const LoginRoute = createRoute({
   method: 'post',
   tags: ['accounts'],
-  path: '/login',
+  path: '/v0/login',
   request: {
     body: {
       content: {
@@ -534,7 +534,7 @@ export const LoginRoute = createRoute({
 export const RefreshRoute = createRoute({
   method: 'post',
   tags: ['accounts'],
-  path: '/refresh',
+  path: '/v0/refresh',
   request: {
     headers: z.object({
       Authorization: z.string().openapi({
@@ -578,7 +578,7 @@ export const RefreshRoute = createRoute({
 export const GetAccountRoute = createRoute({
   method: 'get',
   tags: ['accounts'],
-  path: '/accounts/:identifier',
+  path: '/v0/accounts/:identifier',
   request: {
     params: z.object({
       identifier: z
@@ -635,7 +635,7 @@ export const GetAccountRoute = createRoute({
 export const SilenceAccountRoute = createRoute({
   method: 'put',
   tags: ['accounts'],
-  path: '/accounts/:name/silence',
+  path: '/v0/accounts/:name/silence',
   security: [
     {
       bearer: [],
@@ -704,7 +704,7 @@ export const SilenceAccountRoute = createRoute({
 export const UnSilenceAccountRoute = createRoute({
   method: 'delete',
   tags: ['accounts'],
-  path: '/accounts/:name/silence',
+  path: '/v0/accounts/:name/silence',
   security: [
     {
       bearer: [],
@@ -773,7 +773,7 @@ export const UnSilenceAccountRoute = createRoute({
 export const FollowAccountRoute = createRoute({
   method: 'post',
   tags: ['accounts'],
-  path: '/accounts/:name/follow',
+  path: '/v0/accounts/:name/follow',
   security: [
     {
       bearer: [],
@@ -842,7 +842,7 @@ export const FollowAccountRoute = createRoute({
 export const UnFollowAccountRoute = createRoute({
   method: 'delete',
   tags: ['accounts'],
-  path: '/accounts/:name/follow',
+  path: '/v0/accounts/:name/follow',
   security: [
     {
       bearer: [],
@@ -911,7 +911,7 @@ export const UnFollowAccountRoute = createRoute({
 export const GetAccountFollowingRoute = createRoute({
   method: 'get',
   tags: ['accounts'],
-  path: '/accounts/:id/following',
+  path: '/v0/accounts/:id/following',
   request: {
     params: z.object({
       id: z.string().min(3).max(64).openapi({
@@ -957,7 +957,7 @@ export const GetAccountFollowingRoute = createRoute({
 export const GetAccountFollowerRoute = createRoute({
   method: 'get',
   tags: ['accounts'],
-  path: '/accounts/:id/follower',
+  path: '/v0/accounts/:id/follower',
   request: {
     params: z.object({
       id: z.string().min(3).max(64).openapi({
@@ -1004,7 +1004,7 @@ export const GetAccountFollowerRoute = createRoute({
 export const SetAccountAvatarRoute = createRoute({
   method: 'post',
   tags: ['accounts'],
-  path: '/accounts/:name/avatar',
+  path: '/v0/accounts/:name/avatar',
   security: [
     {
       bearer: [],
@@ -1072,7 +1072,7 @@ export const SetAccountAvatarRoute = createRoute({
 export const UnsetAccountAvatarRoute = createRoute({
   method: 'delete',
   tags: ['accounts'],
-  path: '/accounts/:name/avatar',
+  path: '/v0/accounts/:name/avatar',
   security: [
     {
       bearer: [],
@@ -1133,7 +1133,7 @@ export const UnsetAccountAvatarRoute = createRoute({
 export const SetAccountHeaderRoute = createRoute({
   method: 'post',
   tags: ['accounts'],
-  path: '/accounts/:name/header',
+  path: '/v0/accounts/:name/header',
   security: [
     {
       bearer: [],
@@ -1201,7 +1201,7 @@ export const SetAccountHeaderRoute = createRoute({
 export const UnsetAccountHeaderRoute = createRoute({
   method: 'delete',
   tags: ['accounts'],
-  path: '/accounts/:name/head',
+  path: '/v0/accounts/:name/head',
   security: [
     {
       bearer: [],

--- a/pkg/drive/router.ts
+++ b/pkg/drive/router.ts
@@ -5,7 +5,7 @@ import { GetDriveMediaResponseSchema } from './adaptor/validator/schema.js';
 
 export const GetMediaRoute = createRoute({
   method: 'get',
-  path: '/drive',
+  path: '/v0/drive',
   tags: ['drive'],
   summary: 'Get uploaded media',
   security: [

--- a/pkg/notes/router.ts
+++ b/pkg/notes/router.ts
@@ -28,7 +28,7 @@ import {
 export const CreateNoteRoute = createRoute({
   method: 'post',
   tags: ['notes'],
-  path: '/notes',
+  path: '/v0/notes',
   security: [
     {
       bearer: [],
@@ -119,7 +119,7 @@ export const CreateNoteRoute = createRoute({
 export const GetNoteRoute = createRoute({
   method: 'get',
   tags: ['notes'],
-  path: '/notes/:id',
+  path: '/v0/notes/:id',
   request: {
     params: z.object({
       id: z.string().openapi({
@@ -171,7 +171,7 @@ export const GetNoteRoute = createRoute({
 export const RenoteRoute = createRoute({
   method: 'post',
   tags: ['notes'],
-  path: '/notes/:id/renote',
+  path: '/v0/notes/:id/renote',
   security: [
     {
       bearer: [],
@@ -268,7 +268,7 @@ export const RenoteRoute = createRoute({
 export const CreateReactionRoute = createRoute({
   method: 'post',
   tags: ['reaction'],
-  path: '/notes/:id/reaction',
+  path: '/v0/notes/:id/reaction',
   security: [
     {
       bearer: [],
@@ -341,7 +341,7 @@ export const CreateReactionRoute = createRoute({
 export const DeleteReactionRoute = createRoute({
   method: 'delete',
   tags: ['reaction'],
-  path: '/notes/:id/reaction',
+  path: '/v0/notes/:id/reaction',
   security: [
     {
       bearer: [],
@@ -389,7 +389,7 @@ export const DeleteReactionRoute = createRoute({
 export const CreateBookmarkRoute = createRoute({
   method: 'post',
   tags: ['bookmark'],
-  path: '/notes/:id/bookmark',
+  path: '/v0/notes/:id/bookmark',
   security: [
     {
       bearer: [],
@@ -446,7 +446,7 @@ export const CreateBookmarkRoute = createRoute({
 export const DeleteBookmarkRoute = createRoute({
   method: 'delete',
   tags: ['bookmark'],
-  path: '/notes/:id/bookmark',
+  path: '/v0/notes/:id/bookmark',
   security: [
     {
       bearer: [],

--- a/pkg/timeline/router.ts
+++ b/pkg/timeline/router.ts
@@ -58,7 +58,7 @@ const timelineFilterQuerySchema = z
 export const GetHomeTimelineRoute = createRoute({
   method: 'get',
   tags: ['timeline'],
-  path: '/timeline/home',
+  path: '/v0/timeline/home',
   request: {
     query: timelineFilterQuerySchema,
   },
@@ -97,7 +97,7 @@ export const GetHomeTimelineRoute = createRoute({
 export const GetAccountTimelineRoute = createRoute({
   method: 'get',
   tags: ['timeline'],
-  path: '/timeline/accounts/:id',
+  path: '/v0/timeline/accounts/:id',
   request: {
     params: z.object({
       id: z.string().openapi('Account ID'),
@@ -160,7 +160,7 @@ export const GetAccountTimelineRoute = createRoute({
 export const GetListTimelineRoute = createRoute({
   method: 'get',
   tags: ['timeline'],
-  path: '/lists/:id/notes',
+  path: '/v0/lists/:id/notes',
   request: {
     params: z.object({
       id: z.string().openapi('List ID'),
@@ -209,7 +209,7 @@ export const GetListTimelineRoute = createRoute({
 export const CreateListRoute = createRoute({
   method: 'post',
   tags: ['timeline'],
-  path: '/lists',
+  path: '/v0/lists',
   security: [
     {
       bearer: [],
@@ -263,7 +263,7 @@ export const CreateListRoute = createRoute({
 export const EditListRoute = createRoute({
   method: 'patch',
   tags: ['timeline'],
-  path: '/lists/:id',
+  path: '/v0/lists/:id',
   security: [
     {
       bearer: [],
@@ -330,7 +330,7 @@ export const EditListRoute = createRoute({
 export const FetchListRoute = createRoute({
   method: 'get',
   tags: ['timeline'],
-  path: '/lists/:id',
+  path: '/v0/lists/:id',
   security: [
     {
       bearer: [],
@@ -384,7 +384,7 @@ export const FetchListRoute = createRoute({
 export const DeleteListRoute = createRoute({
   method: 'delete',
   tags: ['timeline'],
-  path: '/lists',
+  path: '/v0/lists',
   security: [
     {
       bearer: [],
@@ -433,7 +433,7 @@ export const DeleteListRoute = createRoute({
 export const GetListMemberRoute = createRoute({
   method: 'get',
   tags: ['timeline'],
-  path: '/lists/:id/members',
+  path: '/v0/lists/:id/members',
   responses: {
     200: {
       description: 'OK',
@@ -477,7 +477,7 @@ export const GetListMemberRoute = createRoute({
 export const AppendListMemberRoute = createRoute({
   method: 'post',
   tags: ['timeline'],
-  path: '/lists/:id/members',
+  path: '/v0/lists/:id/members',
   security: [
     {
       bearer: [],
@@ -537,7 +537,7 @@ export const AppendListMemberRoute = createRoute({
 export const DeleteListMemberRoute = createRoute({
   method: 'delete',
   tags: ['timeline'],
-  path: '/lists/:id/members',
+  path: '/v0/lists/:id/members',
   security: [
     {
       bearer: [],


### PR DESCRIPTION
close #909 
## What does this PR do?
- すべてのAPIエンドポイントのパスを`/`直下から`/v0`に変更しました．
 - specでは`/api/v0`と定義しましたが，特にそうする必要はなさそうなのでひとまずこうしています
   - `/api`とつけたのはActivityPubなどで必要なエンドポイント名やフロントエンドと同居させる場合の競合の回避を意図したものです

## Additional information
