### PR TITLE
fix: 認証を強制したエンドポイントでトークンが指定されていない場合にOption.none()を返すように

### DIFF
--- a/pkg/adaptors/authenticateMiddleware.ts
+++ b/pkg/adaptors/authenticateMiddleware.ts
@@ -62,6 +62,8 @@ export class AuthenticateMiddlewareService {
         if (options.forceAuthorized) {
           return c.json({ error: 'UNAUTHORIZED' }, { status: 401 });
         }
+        c.set('accountName', Option.none());
+        c.set('accountID', Option.none());
         return await next();
       }
 


### PR DESCRIPTION
close #1062 
## What does this PR do?
- 認証を強制している && トークンが指定されていないとき，`Option.none()`をctxにいれるべきところを`undefined`を入れるようにしていたのを修正
  - related #867 

## Additional information
