### PR TITLE
feat: 通知を既読にする `POST /v0/notification/:id/read`を実装

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -17,7 +17,7 @@ const coreLogger = new Logger({
 
 export const app = new Hono().get('/doc', async (c) => {
   // NOTE: If you create a new module, you must add module API doc base path here.
-  const modulePath: string[] = ['accounts', 'notes', 'drive', 'timeline'];
+  const modulePath: string[] = ['accounts', 'notes', 'drive', 'timeline', "notification"];
   const basePath = 'http://localhost:3000/';
   const openAPIBase = {
     openapi: '3.1.0',

--- a/pkg/notification/adaptor/controller/notification.ts
+++ b/pkg/notification/adaptor/controller/notification.ts
@@ -1,0 +1,29 @@
+import { Result } from '@mikuroxina/mini-fn';
+import type { AccountID } from '../../../accounts/model/account.js';
+import type { NotificationID } from '../../model/notificationBase.js';
+import type { MarkAsReadNotificationService } from '../../service/markAsRead.js';
+
+export class NotificationController {
+  private readonly markAsReadService: MarkAsReadNotificationService;
+
+  constructor(args: {
+    markAsReadService: MarkAsReadNotificationService;
+  }) {
+    this.markAsReadService = args.markAsReadService;
+  }
+
+  async markAsRead(
+    id: string,
+    actorID: string,
+  ): Promise<Result.Result<Error, void>> {
+    const res = await this.markAsReadService.handle(
+      id as NotificationID,
+      actorID as AccountID,
+    );
+    if (Result.isErr(res)) {
+      return res;
+    }
+
+    return Result.ok(undefined);
+  }
+}

--- a/pkg/notification/adaptor/validator/schemas.ts
+++ b/pkg/notification/adaptor/validator/schemas.ts
@@ -1,0 +1,54 @@
+import { z } from '@hono/zod-openapi';
+
+export const notificationActorSchema = z.object({
+  type: z.union([z.literal('account'), z.literal('system')]),
+  id: z.string(),
+  name: z.string(),
+  nickname: z.string(),
+  avatar: z.string().url(),
+});
+
+export const notificationBaseSchema = z.object({
+  id: z.string(),
+  actor: notificationActorSchema,
+  createdAt: z.string().datetime(),
+});
+
+export const followedNotificationSchema = notificationBaseSchema.extend({
+  type: z.literal('followed'),
+});
+
+export const followAcceptedNotificationSchema = notificationBaseSchema.extend({
+  type: z.literal('followAccepted'),
+});
+
+export const followRequestedNotificationSchema = notificationBaseSchema.extend({
+  type: z.literal('followRequested'),
+});
+
+export const mentionedNotificationSchema = notificationBaseSchema.extend({
+  type: z.literal('mentioned'),
+  noteId: z.string(),
+});
+
+export const renotedNotificationSchema = notificationBaseSchema.extend({
+  type: z.literal('renoted'),
+  noteId: z.string(),
+});
+
+export const reactedNotificationSchema = notificationBaseSchema.extend({
+  type: z.literal('reacted'),
+  noteId: z.string(),
+  content: z.string(),
+});
+
+export const GetNotificationsResponseSchema = z.array(
+  z.union([
+    followedNotificationSchema,
+    followAcceptedNotificationSchema,
+    followRequestedNotificationSchema,
+    mentionedNotificationSchema,
+    renotedNotificationSchema,
+    reactedNotificationSchema,
+  ]),
+);

--- a/pkg/notification/mod.ts
+++ b/pkg/notification/mod.ts
@@ -1,0 +1,71 @@
+import { OpenAPIHono } from '@hono/zod-openapi';
+import { Cat, Ether, Option, Result } from '@mikuroxina/mini-fn';
+import {
+  type AuthMiddlewareVariable,
+  AuthenticateMiddlewareService,
+} from '../adaptors/authenticateMiddleware.js';
+import { isProduction } from '../adaptors/env.js';
+import { prismaClient } from '../adaptors/prisma.js';
+import { clockSymbol } from '../id/mod.js';
+import { NotificationController } from './adaptor/controller/notification.js';
+import { inMemoryNotificationRepo } from './adaptor/repository/dummy/notification.js';
+import { prismaNotificationRepo } from './adaptor/repository/prisma/notification.js';
+import { PostMakeAsReadNotificationRoute } from './routes.js';
+import { markAsReadNotification } from './service/markAsRead.js';
+
+class Clock {
+  now() {
+    return BigInt(Date.now());
+  }
+}
+const clock = Ether.newEther(clockSymbol, () => new Clock());
+
+const notificationRepository = isProduction
+  ? prismaNotificationRepo(prismaClient)
+  : inMemoryNotificationRepo();
+
+const controller = new NotificationController({
+  markAsReadService: Ether.runEther(
+    Cat.cat(markAsReadNotification)
+      .feed(Ether.compose(notificationRepository))
+      .feed(Ether.compose(clock)).value,
+  ),
+});
+
+export const notification = new OpenAPIHono<{
+  Variables: AuthMiddlewareVariable;
+}>().doc31('/notification/doc.json', {
+  openapi: '3.1.0',
+  info: {
+    title: 'Notification API',
+    version: '0.1.0',
+  },
+});
+const AuthMiddleware = new AuthenticateMiddlewareService();
+
+notification.openAPIRegistry.registerComponent('securitySchemes', 'Bearer', {
+  type: 'http',
+  scheme: 'bearer',
+});
+
+notification[PostMakeAsReadNotificationRoute.method](
+  PostMakeAsReadNotificationRoute.path,
+  AuthMiddleware.handle({ forceAuthorized: true }),
+);
+notification.openapi(PostMakeAsReadNotificationRoute, async (c) => {
+  const actorID = Option.unwrap(c.get('accountID'));
+  const { id } = c.req.valid('param');
+
+  const res = await controller.markAsRead(id, actorID);
+  if (Result.isErr(res)) {
+    const error = Result.unwrapErr(res);
+
+    if (error.message === 'Not allowed') {
+      return c.json({ error: 'NO_PERMISSION' as const }, 403);
+    }
+
+    return c.json({ error: 'INTERNAL_ERROR' as const }, 500);
+  }
+
+  return new Response(undefined, { status: 204 });
+});

--- a/pkg/notification/routes.ts
+++ b/pkg/notification/routes.ts
@@ -1,0 +1,86 @@
+import { createRoute, z } from '@hono/zod-openapi';
+import {
+  NothingLeft,
+  TimelineInternalError,
+} from '../timeline/adaptor/presenter/errors.js';
+import { GetNotificationsResponseSchema } from './adaptor/validator/schemas.js';
+
+export const GetNotificationsRoute = createRoute({
+  method: 'get',
+  path: '/v0/notifications',
+  description: 'Get notifications',
+  tags: ['notification'],
+  request: {
+    query: z.object({
+      limit: z.coerce.number().min(1).max(50).default(30).optional(),
+      after_id: z.string().optional().openapi({
+        description:
+          'Return notes after this notification ID. Specified notification is not included.',
+      }),
+      include_read: z.coerce.boolean().default(false).optional(),
+    }),
+  },
+  responses: {
+    200: {
+      description: 'OK',
+      content: {
+        'application/json': {
+          schema: GetNotificationsResponseSchema,
+        },
+      },
+    },
+    404: {
+      description: 'Nothing left',
+      content: {
+        'application/json': {
+          schema: z.object({
+            error: NothingLeft,
+          }),
+        },
+      },
+    },
+    500: {
+      description: 'Internal error',
+      content: {
+        'application/json': {
+          schema: z.object({
+            error: TimelineInternalError,
+          }),
+        },
+      },
+    },
+  },
+});
+
+export const PostMakeAsReadNotificationRoute = createRoute({
+  method: 'post',
+  tags: ['notification'],
+  path: '/v0/notifications/:id/read',
+  request: {
+    params: z.object({
+      id: z.string().openapi({
+        description: 'Notification ID',
+      }),
+    }),
+  },
+  responses: {
+    204: {
+      description: 'No content',
+      content: {
+        'application/json': {
+          schema: z.object({}),
+        },
+      },
+    },
+    403: {
+      description: 'Forbidden',
+      content: {
+        'application/json': {
+          schema: z.object({
+            error: z.literal('NO_PERMISSION'),
+          }),
+        },
+      },
+    },
+  },
+});

--- a/pkg/notification/routes.ts
+++ b/pkg/notification/routes.ts
@@ -66,11 +66,6 @@ export const PostMakeAsReadNotificationRoute = createRoute({
   responses: {
     204: {
       description: 'No content',
-      content: {
-        'application/json': {
-          schema: z.object({}),
-        },
-      },
     },
     403: {
       description: 'Forbidden',
@@ -78,6 +73,16 @@ export const PostMakeAsReadNotificationRoute = createRoute({
         'application/json': {
           schema: z.object({
             error: z.literal('NO_PERMISSION'),
+          }),
+        },
+      },
+    },
+    500: {
+      description: 'Internal error',
+      content: {
+        'application/json': {
+          schema: z.object({
+            error: TimelineInternalError,
           }),
         },
       },

--- a/pkg/notification/service/markAsRead.test.ts
+++ b/pkg/notification/service/markAsRead.test.ts
@@ -1,0 +1,57 @@
+import { Option, Result } from '@mikuroxina/mini-fn';
+import { describe, expect, it } from 'vitest';
+import type { AccountID } from '../../accounts/model/account.js';
+import { MockClock } from '../../id/mod.js';
+import { InMemoryNotificationRepository } from '../adaptor/repository/dummy/notification.js';
+import {
+  type CreateFollowedNotificationArgs,
+  FollowedNotification,
+} from '../model/notification.js';
+import type { NotificationID } from '../model/notificationBase.js';
+import { MarkAsReadNotificationService } from './markAsRead.js';
+
+describe('MarkAsReadNotificationService', () => {
+  const testNotificationArgs = {
+    id: '1' as NotificationID,
+    notificationType: 'followed',
+    recipientID: '10' as AccountID,
+    actorType: 'account',
+    actorID: '20' as AccountID,
+    createdAt: new Date(),
+    readAt: Option.none(),
+  } as const satisfies CreateFollowedNotificationArgs;
+
+  const repo = new InMemoryNotificationRepository([
+    FollowedNotification.new(testNotificationArgs),
+    FollowedNotification.reconstruct({
+      ...testNotificationArgs,
+      id: '2' as NotificationID,
+      readAt: Option.some(new Date()),
+    }),
+  ]);
+  const service = new MarkAsReadNotificationService(
+    repo,
+    new MockClock(new Date('2023-09-10T00:00:00Z')),
+  );
+
+  it('Should mark a notification as read', async () => {
+    const res = await service.handle('1' as NotificationID, '10' as AccountID);
+
+    expect(Result.isOk(res)).toBe(true);
+    expect(Result.unwrap(res).getIsRead()).toBe(true);
+  });
+
+  it('Should return an error if the notification is already read', async () => {
+    const res = await service.handle('2' as NotificationID, '10' as AccountID);
+    expect(Result.isErr(res)).toBe(true);
+    expect(Result.unwrapErr(res)).toStrictEqual(
+      new Error('Notification already read'),
+    );
+  });
+
+  it('should return an error if the user is not the recipient', async () => {
+    const res = await service.handle('1' as NotificationID, '30' as AccountID);
+    expect(Result.isErr(res)).toBe(true);
+    expect(Result.unwrapErr(res)).toStrictEqual(new Error('Not allowed'));
+  });
+});

--- a/pkg/notification/service/markAsRead.ts
+++ b/pkg/notification/service/markAsRead.ts
@@ -1,11 +1,14 @@
-import { Result } from '@mikuroxina/mini-fn';
+import { Ether, Result } from '@mikuroxina/mini-fn';
 import type { AccountID } from '../../accounts/model/account.js';
-import type { Clock } from '../../id/mod.js';
+import { type Clock, clockSymbol } from '../../id/mod.js';
 import type {
   Notification,
   NotificationID,
 } from '../model/notificationBase.js';
-import type { NotificationRepository } from '../model/repository/notification.js';
+import {
+  type NotificationRepository,
+  notificationRepoSymbol,
+} from '../model/repository/notification.js';
 
 export class MarkAsReadNotificationService {
   constructor(
@@ -47,3 +50,14 @@ export class MarkAsReadNotificationService {
     return notification.getRecipientID() === accountID;
   }
 }
+export const markAsReadNotificationSymbol =
+  Ether.newEtherSymbol<MarkAsReadNotificationService>();
+export const markAsReadNotification = Ether.newEther(
+  markAsReadNotificationSymbol,
+  ({ notificationRepository, clock }) =>
+    new MarkAsReadNotificationService(notificationRepository, clock),
+  {
+    notificationRepository: notificationRepoSymbol,
+    clock: clockSymbol,
+  },
+);

--- a/pkg/notification/service/markAsRead.ts
+++ b/pkg/notification/service/markAsRead.ts
@@ -1,0 +1,49 @@
+import { Result } from '@mikuroxina/mini-fn';
+import type { AccountID } from '../../accounts/model/account.js';
+import type { Clock } from '../../id/mod.js';
+import type {
+  Notification,
+  NotificationID,
+} from '../model/notificationBase.js';
+import type { NotificationRepository } from '../model/repository/notification.js';
+
+export class MarkAsReadNotificationService {
+  constructor(
+    private readonly notificationRepository: NotificationRepository,
+    private readonly clock: Clock,
+  ) {}
+
+  async handle(
+    notificationID: NotificationID,
+    actorID: AccountID,
+  ): Promise<Result.Result<Error, Notification>> {
+    const notificationRes =
+      await this.notificationRepository.findByID(notificationID);
+    if (Result.isErr(notificationRes)) {
+      return notificationRes;
+    }
+
+    const notification = Result.unwrap(notificationRes);
+
+    if (!this.isAllowed(notification, actorID)) {
+      return Result.err(new Error('Not allowed'));
+    }
+
+    if (notification.getIsRead()) {
+      return Result.err(new Error('Notification already read'));
+    }
+
+    notification.setRead(new Date(Number(this.clock.now())));
+
+    const res = await this.notificationRepository.updateReadAt(notification);
+    if (Result.isErr(res)) {
+      return res;
+    }
+
+    return Result.ok(notification);
+  }
+
+  private isAllowed(notification: Notification, accountID: AccountID): boolean {
+    return notification.getRecipientID() === accountID;
+  }
+}

--- a/resources/schema.json
+++ b/resources/schema.json
@@ -5500,6 +5500,283 @@
           }
         }
       }
+    },
+    "/v0/timeline/bookmarks": {
+      "get": {
+        "tags": [
+          "timeline"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "boolean",
+              "description": "If true, only return notes with attachment"
+            },
+            "required": false,
+            "name": "has_attachment",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "boolean",
+              "description": "If true, only return notes without sensitive content"
+            },
+            "required": false,
+            "name": "no_nsfw",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Return notes before this note ID. specified note ID is not included. NOTE: after_id and before_id are exclusive."
+            },
+            "required": false,
+            "name": "before_id",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Return notes after this note ID. Specified note is not included. NOTE: after_id and before_id are exclusive."
+            },
+            "required": false,
+            "name": "after_id",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string",
+                        "description": "Note ID",
+                        "example": "38477395"
+                      },
+                      "content": {
+                        "type": "string",
+                        "description": "Note content",
+                        "example": "hello world!"
+                      },
+                      "contents_warning_comment": {
+                        "type": "string",
+                        "description": "Contents warning comment",
+                        "example": "(if length not 0) This note contains sensitive content"
+                      },
+                      "visibility": {
+                        "type": "string",
+                        "description": "Note visibility (PUBLIC/HOME/FOLLOWERS/DIRECT)",
+                        "example": "PUBLIC"
+                      },
+                      "created_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Note created date",
+                        "example": "2021-01-01T00:00:00Z"
+                      },
+                      "reactions": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "emoji": {
+                              "anyOf": [
+                                {
+                                  "type": "string",
+                                  "pattern": "[\\u2700-\\u27BF]|[\\uE000-\\uF8FF]|\\uD83C[\\uDC00-\\uDFFF]|\\uD83D[\\uDC00-\\uDFFF]|[\\u2011-\\u26FF]|\\uD83E[\\uDD10-\\uDDFF]"
+                                },
+                                {
+                                  "type": "string",
+                                  "pattern": "<:(\\w+):(\\d+)>"
+                                }
+                              ],
+                              "description": "Reaction Emoji (Unicode or Custom Emoji)",
+                              "examples": [
+                                "🎉",
+                                "<:custom_emoji:123456789>"
+                              ]
+                            },
+                            "reacted_by": {
+                              "type": "string",
+                              "description": "Reacted account ID",
+                              "example": "38477395"
+                            }
+                          },
+                          "required": [
+                            "emoji",
+                            "reacted_by"
+                          ]
+                        },
+                        "description": "Reactions"
+                      },
+                      "attachment_files": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "description": "attachment Medium id",
+                              "example": "39783475"
+                            },
+                            "name": {
+                              "type": "string",
+                              "description": "attachment filename",
+                              "example": "image.jpg"
+                            },
+                            "author_id": {
+                              "type": "string",
+                              "description": "attachment author account id",
+                              "example": "309823457"
+                            },
+                            "hash": {
+                              "type": "string",
+                              "description": "attachment medium blurhash",
+                              "example": "e9f*5oin{dn"
+                            },
+                            "mime": {
+                              "type": "string",
+                              "description": "attachment medium mime type",
+                              "example": "image/jpeg"
+                            },
+                            "nsfw": {
+                              "type": "boolean",
+                              "default": false,
+                              "description": "if true, attachment is nsfw"
+                            },
+                            "url": {
+                              "type": "string",
+                              "format": "uri",
+                              "description": "attachment medium url",
+                              "example": "https://images.example.com/image.webp"
+                            },
+                            "thumbnail": {
+                              "type": "string",
+                              "description": "attachment thumbnail url",
+                              "example": "https://images.example.com/image_thumbnail.webp"
+                            }
+                          },
+                          "required": [
+                            "id",
+                            "name",
+                            "author_id",
+                            "hash",
+                            "mime",
+                            "nsfw",
+                            "url",
+                            "thumbnail"
+                          ]
+                        },
+                        "maxItems": 16,
+                        "description": "Note Attachment Media"
+                      },
+                      "author": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "display_name": {
+                            "type": "string"
+                          },
+                          "bio": {
+                            "type": "string"
+                          },
+                          "avatar": {
+                            "type": "string"
+                          },
+                          "header": {
+                            "type": "string"
+                          },
+                          "followed_count": {
+                            "type": "number"
+                          },
+                          "following_count": {
+                            "type": "number"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "name",
+                          "display_name",
+                          "bio",
+                          "avatar",
+                          "header",
+                          "followed_count",
+                          "following_count"
+                        ]
+                      }
+                    },
+                    "required": [
+                      "id",
+                      "content",
+                      "contents_warning_comment",
+                      "visibility",
+                      "created_at",
+                      "reactions",
+                      "attachment_files",
+                      "author"
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Nothing left",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "enum": [
+                        "NOTHING_LEFT"
+                      ],
+                      "description": "No more notes exist"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "enum": [
+                        "INTERNAL_ERROR"
+                      ],
+                      "description": "Internal server error"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
close #1065 

## What does this PR do?
- `POST /v0/notification/:id/read`を実装しました
　　- 通知の取得API(Serviceまで実装済み)のスキーマも同時に定義しました
- 自動生成APIドキュメントの更新
## Additional information
