### PR TITLE
feat(API)!: add follow relationship filters

### DIFF
--- a/pkg/accounts/adaptor/controller/account.ts
+++ b/pkg/accounts/adaptor/controller/account.ts
@@ -4,7 +4,11 @@ import { Option, Result } from '@mikuroxina/mini-fn';
 import type { Medium, MediumID } from '../../../drive/model/medium.js';
 import type { AccountID, AccountName } from '../../model/account.js';
 import type { AccountFollow } from '../../model/follow.js';
-import type { AccountFollowCount } from '../../model/repository.js';
+import type {
+  AccountFollowCount,
+  FetchFollowerFilter,
+  FetchFollowingFilter,
+} from '../../model/repository.js';
 import type { AuthenticateService } from '../../service/authenticate.js';
 import type {
   AuthenticationToken,
@@ -432,10 +436,16 @@ export class AccountController {
 
   async fetchFollowing(
     id: string,
+    filter?: Option.Option<FetchFollowingFilter>,
   ): Promise<Result.Result<Error, z.infer<typeof GetAccountFollowingSchema>>> {
     const followings = Result.map((v: AccountFollow[]) =>
       v.map((v) => v.getTargetID()),
-    )(await this.fetchFollowService.fetchFollowingsByID(id as AccountID));
+    )(
+      await this.fetchFollowService.fetchFollowingsByID(
+        id as AccountID,
+        filter,
+      ),
+    );
 
     if (Result.isErr(followings)) {
       return followings;
@@ -511,10 +521,13 @@ export class AccountController {
 
   async fetchFollower(
     id: string,
+    filter?: Option.Option<FetchFollowerFilter>,
   ): Promise<Result.Result<Error, z.infer<typeof GetAccountFollowerSchema>>> {
     const followers = Result.map((v: AccountFollow[]) =>
       v.map((v) => v.getFromID()),
-    )(await this.fetchFollowService.fetchFollowersByID(id as AccountID));
+    )(
+      await this.fetchFollowService.fetchFollowersByID(id as AccountID, filter),
+    );
 
     if (Result.isErr(followers)) {
       return followers;

--- a/pkg/accounts/adaptor/repository/prisma/prisma.ts
+++ b/pkg/accounts/adaptor/repository/prisma/prisma.ts
@@ -22,6 +22,8 @@ import {
   type AccountRepository,
   type AccountVerifyTokenRepository,
   accountRepoSymbol,
+  type FetchFollowerFilter,
+  type FetchFollowingFilter,
   followRepoSymbol,
   verifyTokenRepoSymbol,
 } from '../../../model/repository.js';
@@ -326,7 +328,26 @@ export class PrismaAccountFollowRepository implements AccountFollowRepository {
 
   async fetchAllFollowers(
     accountID: AccountID,
+    filter?: Option.Option<FetchFollowerFilter>,
   ): Promise<Result.Result<Error, AccountFollow[]>> {
+    if (filter && Option.isSome(filter)) {
+      const filterValue = Option.unwrap(filter);
+      const whereConditions: Prisma.FollowingWhereInput = {};
+
+      if (filterValue.onlyFollower) {
+        whereConditions.toId = filterValue.actorID;
+      }
+
+      if (filterValue.onlyFollowing) {
+        whereConditions.fromId = filterValue.actorID;
+      }
+
+      const res = await this.prisma.following.findMany({
+        where: whereConditions,
+      });
+      return Result.ok(res.map((f) => this.fromPrismaArgs(f)));
+    }
+
     const res = await this.prisma.following.findMany({
       where: {
         toId: accountID,
@@ -336,7 +357,26 @@ export class PrismaAccountFollowRepository implements AccountFollowRepository {
   }
   async fetchAllFollowing(
     accountID: AccountID,
+    filter?: Option.Option<FetchFollowingFilter>,
   ): Promise<Result.Result<Error, AccountFollow[]>> {
+    if (filter && Option.isSome(filter)) {
+      const filterValue = filter[1];
+      const whereConditions: Prisma.FollowingWhereInput = {};
+
+      if (filterValue.onlyFollower) {
+        whereConditions.toId = filterValue.actorID;
+      }
+
+      if (filterValue.onlyFollowing) {
+        whereConditions.fromId = filterValue.actorID;
+      }
+
+      const res = await this.prisma.following.findMany({
+        where: whereConditions,
+      });
+      return Result.ok(res.map((f) => this.fromPrismaArgs(f)));
+    }
+
     const res = await this.prisma.following.findMany({
       where: {
         fromId: accountID,

--- a/pkg/accounts/model/repository.ts
+++ b/pkg/accounts/model/repository.ts
@@ -53,6 +53,18 @@ export interface AccountFollowCount {
   followers: number;
   following: number;
 }
+
+/**
+ * Base filter for account follow operations
+ */
+export interface AccountFollowBaseFilter {
+  actorID: AccountID;
+  onlyFollower: boolean;
+  onlyFollowing: boolean;
+}
+
+export type FetchFollowingFilter = AccountFollowBaseFilter;
+export type FetchFollowerFilter = AccountFollowBaseFilter;
 export interface AccountFollowRepository {
   follow(follow: AccountFollow): Promise<Result.Result<Error, void>>;
   unfollow(
@@ -61,9 +73,11 @@ export interface AccountFollowRepository {
   ): Promise<Result.Result<Error, void>>;
   fetchAllFollowers(
     accountID: AccountID,
+    filter?: Option.Option<FetchFollowerFilter>,
   ): Promise<Result.Result<Error, AccountFollow[]>>;
   fetchAllFollowing(
     accountID: AccountID,
+    filter?: Option.Option<FetchFollowingFilter>,
   ): Promise<Result.Result<Error, AccountFollow[]>>;
   fetchOrderedFollowers(
     accountID: AccountID,

--- a/pkg/accounts/router.ts
+++ b/pkg/accounts/router.ts
@@ -920,6 +920,14 @@ export const GetAccountFollowingRoute = createRoute({
           'Characters must be [A-Za-z0-9-.] The first and last characters must be [A-Za-z0-9-.]',
       }),
     }),
+    query: z.object({
+      only_followers: z.optional(z.boolean()).openapi({
+        description: 'Filter to accounts that follow the requesting user',
+      }),
+      only_following: z.optional(z.boolean()).openapi({
+        description: 'Filter to accounts that the requesting user follows',
+      }),
+    }),
   },
   responses: {
     200: {
@@ -927,6 +935,20 @@ export const GetAccountFollowingRoute = createRoute({
       content: {
         'application/json': {
           schema: GetAccountFollowingSchema,
+        },
+      },
+    },
+    403: {
+      description: 'Forbidden',
+      content: {
+        'application/json': {
+          schema: z
+            .object({
+              error: NoPermission,
+            })
+            .openapi({
+              description: 'Authentication required when using filters',
+            }),
         },
       },
     },
@@ -966,6 +988,14 @@ export const GetAccountFollowerRoute = createRoute({
           'Characters must be [A-Za-z0-9-.] The first and last characters must be [A-Za-z0-9-.]',
       }),
     }),
+    query: z.object({
+      only_followers: z.optional(z.boolean()).openapi({
+        description: 'Filter to accounts that follow the requesting user',
+      }),
+      only_following: z.optional(z.boolean()).openapi({
+        description: 'Filter to accounts that the requesting user follows',
+      }),
+    }),
   },
   responses: {
     200: {
@@ -973,6 +1003,20 @@ export const GetAccountFollowerRoute = createRoute({
       content: {
         'application/json': {
           schema: GetAccountFollowingSchema,
+        },
+      },
+    },
+    403: {
+      description: 'Forbidden',
+      content: {
+        'application/json': {
+          schema: z
+            .object({
+              error: NoPermission,
+            })
+            .openapi({
+              description: 'Authentication required when using filters',
+            }),
         },
       },
     },

--- a/pkg/accounts/service/fetchFollow.test.ts
+++ b/pkg/accounts/service/fetchFollow.test.ts
@@ -1,10 +1,14 @@
-import { Result } from '@mikuroxina/mini-fn';
-import { describe, expect, it } from 'vitest';
+import { Option, Result } from '@mikuroxina/mini-fn';
+import { beforeAll, describe, expect, it } from 'vitest';
 
 import { InMemoryAccountRepository } from '../adaptor/repository/dummy/account.js';
 import { InMemoryAccountFollowRepository } from '../adaptor/repository/dummy/follow.js';
-import { Account, type AccountID } from '../model/account.js';
+import { Account, type AccountID, type AccountName } from '../model/account.js';
 import { AccountFollow } from '../model/follow.js';
+import type {
+  FetchFollowerFilter,
+  FetchFollowingFilter,
+} from '../model/repository.js';
 import { FetchFollowService } from './fetchFollow.js';
 
 const accountRepository = new InMemoryAccountRepository();
@@ -138,6 +142,392 @@ describe('FetchFollowService', () => {
     expect(Result.unwrap(countRes)).toStrictEqual({
       followers: 1,
       following: 1,
+    });
+  });
+});
+
+describe('FetchFollowService with filters', () => {
+  const filterTestAccountRepo = new InMemoryAccountRepository();
+  const filterTestFollowRepo = new InMemoryAccountFollowRepository();
+  const filterTestService = new FetchFollowService(
+    filterTestFollowRepo,
+    filterTestAccountRepo,
+  );
+
+  const ACTOR_A = '10' as AccountID;
+  const ACTOR_A_NAME = '@actor@example.com' as AccountName;
+  const USER_B = '20' as AccountID;
+  const USER_B_NAME = '@userb@example.com' as AccountName;
+  const USER_C = '30' as AccountID;
+  const USER_C_NAME = '@userc@example.com' as AccountName;
+  const USER_D = '40' as AccountID;
+  const USER_D_NAME = '@userd@example.com' as AccountName;
+  const USER_E = '50' as AccountID;
+  const USER_E_NAME = '@usere@example.com' as AccountName;
+
+  const dummyAccounts = [
+    { id: ACTOR_A, name: ACTOR_A_NAME },
+    { id: USER_B, name: USER_B_NAME },
+    { id: USER_C, name: USER_C_NAME },
+    { id: USER_D, name: USER_D_NAME },
+    { id: USER_E, name: USER_E_NAME },
+  ];
+
+  const setupTestData = async () => {
+    const baseAccount = {
+      bio: '',
+      mail: '',
+      nickname: '',
+      passphraseHash: undefined,
+      frozen: 'normal' as const,
+      role: 'normal' as const,
+      silenced: 'normal' as const,
+      status: 'active' as const,
+      createdAt: new Date(),
+      updatedAt: undefined,
+      deletedAt: undefined,
+    };
+
+    const createData = async (id: AccountID, name: AccountName) => {
+      return filterTestAccountRepo.create(
+        Account.reconstruct({
+          id,
+          name,
+          ...baseAccount,
+        }),
+      );
+    };
+
+    for (const account of dummyAccounts) {
+      await createData(account.id, account.name);
+    }
+
+    const followRelationships: { from: AccountID; target: AccountID }[] = [
+      { from: USER_B, target: ACTOR_A }, // B follows A
+      { from: ACTOR_A, target: USER_C }, // A follows C
+      { from: ACTOR_A, target: USER_D }, // A follows D
+      { from: USER_D, target: ACTOR_A }, // D follows A (mutual follow)
+      // E does not follow anyone
+    ];
+
+    const followCreatedAt = new Date();
+    for (const { from, target } of followRelationships) {
+      await filterTestFollowRepo.follow(
+        AccountFollow.new({
+          fromID: from,
+          targetID: target,
+          createdAt: followCreatedAt,
+        }),
+      );
+    }
+  };
+
+  beforeAll(async () => {
+    await setupTestData();
+  });
+
+  describe('fetchFollowingsByID with filters', () => {
+    it('should return all followings when no filter', async () => {
+      const result = await filterTestService.fetchFollowingsByID(ACTOR_A);
+
+      expect(Result.isOk(result)).toBe(true);
+      const followings = Result.unwrap(result);
+      expect(followings).toHaveLength(2);
+      expect(followings.map((f) => f.getTargetID())).toStrictEqual([
+        USER_C,
+        USER_D,
+      ]);
+    });
+
+    it('should filter only followers when onlyFollower is true', async () => {
+      const filter: FetchFollowingFilter = {
+        actorID: ACTOR_A,
+        onlyFollower: true,
+        onlyFollowing: false,
+      };
+
+      const result = await filterTestService.fetchFollowingsByID(
+        ACTOR_A,
+        Option.some(filter),
+      );
+
+      expect(Result.isOk(result)).toBe(true);
+      const followings = Result.unwrap(result);
+      expect(followings).toHaveLength(1);
+      expect(followings[0]?.getTargetID()).toBe(USER_D);
+    });
+
+    it('should not filter when onlyFollower is false', async () => {
+      const filter: FetchFollowingFilter = {
+        actorID: ACTOR_A,
+        onlyFollower: false,
+        onlyFollowing: false,
+      };
+
+      const result = await filterTestService.fetchFollowingsByID(
+        ACTOR_A,
+        Option.some(filter),
+      );
+
+      expect(Result.isOk(result)).toBe(true);
+      const followings = Result.unwrap(result);
+      expect(followings).toHaveLength(2);
+      expect(followings.map((f) => f.getTargetID())).toStrictEqual([
+        USER_C,
+        USER_D,
+      ]);
+    });
+
+    it('should filter only following when onlyFollowing is true', async () => {
+      const filter: FetchFollowingFilter = {
+        actorID: ACTOR_A,
+        onlyFollower: false,
+        onlyFollowing: true,
+      };
+
+      const result = await filterTestService.fetchFollowingsByID(
+        ACTOR_A,
+        Option.some(filter),
+      );
+
+      expect(Result.isOk(result)).toBe(true);
+      const followings = Result.unwrap(result);
+      expect(followings).toHaveLength(2);
+      expect(followings.map((f) => f.getTargetID())).toStrictEqual([
+        USER_C,
+        USER_D,
+      ]);
+    });
+
+    it('should not filter when onlyFollowing is false', async () => {
+      const filter: FetchFollowingFilter = {
+        actorID: ACTOR_A,
+        onlyFollower: false,
+        onlyFollowing: false,
+      };
+
+      const result = await filterTestService.fetchFollowingsByID(
+        ACTOR_A,
+        Option.some(filter),
+      );
+
+      expect(Result.isOk(result)).toBe(true);
+      const followings = Result.unwrap(result);
+      expect(followings).toHaveLength(2);
+      expect(followings.map((f) => f.getTargetID())).toEqual([USER_C, USER_D]);
+    });
+
+    it('should return mutual follows when both filters are true', async () => {
+      const filter: FetchFollowingFilter = {
+        actorID: ACTOR_A,
+        onlyFollower: true,
+        onlyFollowing: true,
+      };
+
+      const result = await filterTestService.fetchFollowingsByID(
+        ACTOR_A,
+        Option.some(filter),
+      );
+
+      expect(Result.isOk(result)).toBe(true);
+      const followings = Result.unwrap(result);
+      expect(followings).toHaveLength(1);
+      expect(followings[0]?.getTargetID()).toStrictEqual(USER_D);
+    });
+
+    it('should return all followings when both filters are false', async () => {
+      const filter: FetchFollowingFilter = {
+        actorID: ACTOR_A,
+        onlyFollower: false,
+        onlyFollowing: false,
+      };
+
+      const result = await filterTestService.fetchFollowingsByID(
+        ACTOR_A,
+        Option.some(filter),
+      );
+
+      expect(Result.isOk(result)).toBe(true);
+      const followings = Result.unwrap(result);
+      expect(followings).toHaveLength(2);
+      expect(followings.map((f) => f.getTargetID())).toStrictEqual([
+        USER_C,
+        USER_D,
+      ]);
+    });
+  });
+
+  describe('fetchFollowersByID with filters', () => {
+    it('should return all followers when no filter', async () => {
+      const result = await filterTestService.fetchFollowersByID(ACTOR_A);
+
+      expect(Result.isOk(result)).toBe(true);
+      const followers = Result.unwrap(result);
+      expect(followers).toHaveLength(2);
+      expect(followers.map((f) => f.getFromID())).toStrictEqual([
+        USER_B,
+        USER_D,
+      ]);
+    });
+
+    it('should filter only followers when onlyFollower is true', async () => {
+      const filter: FetchFollowerFilter = {
+        actorID: ACTOR_A,
+        onlyFollower: true,
+        onlyFollowing: false,
+      };
+
+      const result = await filterTestService.fetchFollowersByID(
+        ACTOR_A,
+        Option.some(filter),
+      );
+
+      expect(Result.isOk(result)).toBe(true);
+      const followers = Result.unwrap(result);
+      expect(followers).toHaveLength(2);
+      expect(followers.map((f) => f.getFromID())).toStrictEqual([
+        USER_B,
+        USER_D,
+      ]);
+    });
+
+    it('should not filter when onlyFollower is false', async () => {
+      const filter: FetchFollowerFilter = {
+        actorID: ACTOR_A,
+        onlyFollower: false,
+        onlyFollowing: false,
+      };
+
+      const result = await filterTestService.fetchFollowersByID(
+        ACTOR_A,
+        Option.some(filter),
+      );
+
+      expect(Result.isOk(result)).toBe(true);
+      const followers = Result.unwrap(result);
+      expect(followers).toHaveLength(2);
+      expect(followers.map((f) => f.getFromID())).toStrictEqual([
+        USER_B,
+        USER_D,
+      ]);
+    });
+
+    it('should filter only following when onlyFollowing is true', async () => {
+      const filter: FetchFollowerFilter = {
+        actorID: ACTOR_A,
+        onlyFollower: false,
+        onlyFollowing: true,
+      };
+
+      const result = await filterTestService.fetchFollowersByID(
+        ACTOR_A,
+        Option.some(filter),
+      );
+
+      expect(Result.isOk(result)).toBe(true);
+      const followers = Result.unwrap(result);
+      expect(followers).toHaveLength(1);
+      expect(followers[0]?.getFromID()).toStrictEqual(USER_D);
+    });
+
+    it('should not filter when onlyFollowing is false', async () => {
+      const filter: FetchFollowerFilter = {
+        actorID: ACTOR_A,
+        onlyFollower: false,
+        onlyFollowing: false,
+      };
+
+      const result = await filterTestService.fetchFollowersByID(
+        ACTOR_A,
+        Option.some(filter),
+      );
+
+      expect(Result.isOk(result)).toBe(true);
+      const followers = Result.unwrap(result);
+      expect(followers).toHaveLength(2);
+      expect(followers.map((f) => f.getFromID())).toStrictEqual([
+        USER_B,
+        USER_D,
+      ]);
+    });
+
+    it('should return mutual follows when both filters are true', async () => {
+      const filter: FetchFollowerFilter = {
+        actorID: ACTOR_A,
+        onlyFollower: true,
+        onlyFollowing: true,
+      };
+
+      const result = await filterTestService.fetchFollowersByID(
+        ACTOR_A,
+        Option.some(filter),
+      );
+
+      expect(Result.isOk(result)).toBe(true);
+      const followers = Result.unwrap(result);
+      expect(followers).toHaveLength(1);
+      expect(followers[0]?.getFromID()).toStrictEqual(USER_D);
+    });
+
+    it('should return all followers when both filters are false', async () => {
+      const filter: FetchFollowerFilter = {
+        actorID: ACTOR_A,
+        onlyFollower: false,
+        onlyFollowing: false,
+      };
+
+      const result = await filterTestService.fetchFollowersByID(
+        ACTOR_A,
+        Option.some(filter),
+      );
+
+      expect(Result.isOk(result)).toBe(true);
+      const followers = Result.unwrap(result);
+      expect(followers).toHaveLength(2);
+      expect(followers.map((f) => f.getFromID())).toStrictEqual([
+        USER_B,
+        USER_D,
+      ]);
+    });
+  });
+
+  describe('fetchFollowingsByName with filters', () => {
+    it('should work with filters by name', async () => {
+      const filter: FetchFollowingFilter = {
+        actorID: ACTOR_A,
+        onlyFollower: true,
+        onlyFollowing: false,
+      };
+
+      const result = await filterTestService.fetchFollowingsByName(
+        '@actor@example.com',
+        Option.some(filter),
+      );
+
+      expect(Result.isOk(result)).toBe(true);
+      const followings = Result.unwrap(result);
+      expect(followings).toHaveLength(1);
+      expect(followings[0]?.getTargetID()).toStrictEqual(USER_D);
+    });
+  });
+
+  describe('fetchFollowersByName with filters', () => {
+    it('should work with filters by name', async () => {
+      const filter: FetchFollowerFilter = {
+        actorID: ACTOR_A,
+        onlyFollower: false,
+        onlyFollowing: true,
+      };
+
+      const result = await filterTestService.fetchFollowersByName(
+        '@actor@example.com',
+        Option.some(filter),
+      );
+
+      expect(Result.isOk(result)).toBe(true);
+      const followers = Result.unwrap(result);
+      expect(followers).toHaveLength(1);
+      expect(followers[0]?.getFromID()).toStrictEqual(USER_D);
     });
   });
 });

--- a/pkg/accounts/service/fetchFollow.ts
+++ b/pkg/accounts/service/fetchFollow.ts
@@ -8,6 +8,8 @@ import {
   type AccountFollowRepository,
   type AccountRepository,
   accountRepoSymbol,
+  type FetchFollowerFilter,
+  type FetchFollowingFilter,
   followRepoSymbol,
 } from '../model/repository.js';
 
@@ -19,12 +21,14 @@ export class FetchFollowService {
 
   async fetchFollowingsByID(
     id: AccountID,
+    filter?: Option.Option<FetchFollowingFilter>,
   ): Promise<Result.Result<Error, AccountFollow[]>> {
-    return this.accountFollowRepository.fetchAllFollowing(id);
+    return this.accountFollowRepository.fetchAllFollowing(id, filter);
   }
 
   async fetchFollowingsByName(
     name: AccountName,
+    filter?: Option.Option<FetchFollowingFilter>,
   ): Promise<Result.Result<Error, AccountFollow[]>> {
     const resId = Cat.cat(await this.accountRepository.findByName(name))
       .feed(
@@ -38,17 +42,19 @@ export class FetchFollowService {
       return resId;
     }
 
-    return this.fetchFollowingsByID(resId[1]);
+    return this.fetchFollowingsByID(Result.unwrap(resId), filter);
   }
 
   async fetchFollowersByID(
     id: AccountID,
+    filter?: Option.Option<FetchFollowerFilter>,
   ): Promise<Result.Result<Error, AccountFollow[]>> {
-    return this.accountFollowRepository.fetchAllFollowers(id);
+    return this.accountFollowRepository.fetchAllFollowers(id, filter);
   }
 
   async fetchFollowersByName(
     name: AccountName,
+    filter?: Option.Option<FetchFollowerFilter>,
   ): Promise<Result.Result<Error, AccountFollow[]>> {
     const resId = Cat.cat(await this.accountRepository.findByName(name))
       .feed(
@@ -62,7 +68,7 @@ export class FetchFollowService {
       return resId;
     }
 
-    return this.fetchFollowersByID(resId[1]);
+    return this.fetchFollowersByID(Result.unwrap(resId), filter);
   }
 
   async fetchFollowCount(


### PR DESCRIPTION
close #1144 
## What does this PR do?
- `GET /v0/accounts/:id/(following|follower)`にクエリパラメータ`only_followers`/`only_followings`を追加

## Additional information
