### PR TITLE
feat: impl public timeline for all public notes

### DIFF
--- a/pkg/timeline/adaptor/repository/dummy.ts
+++ b/pkg/timeline/adaptor/repository/dummy.ts
@@ -123,9 +123,9 @@ export class InMemoryTimelineRepository implements TimelineRepository {
     // ToDo: filter hasAttachment, noNSFW
 
     if (filter.afterID) {
-      const afterIndex = publicNotes.findIndex(
-        (note) => note.getID() === filter.afterID,
-      );
+      const afterIndex = publicNotes
+        .toReversed()
+        .findIndex((note) => note.getID() === filter.afterID);
 
       if (afterIndex === -1) {
         return Result.ok(publicNotes.slice(0, 20));

--- a/pkg/timeline/adaptor/repository/dummy.ts
+++ b/pkg/timeline/adaptor/repository/dummy.ts
@@ -123,19 +123,19 @@ export class InMemoryTimelineRepository implements TimelineRepository {
     // ToDo: filter hasAttachment, noNSFW
 
     if (filter.afterID) {
-      const afterIndex = publicNotes
-        .toReversed()
-        .findIndex((note) => note.getID() === filter.afterID);
+      const afterIndex = publicNotes.findIndex(
+        (note) => note.getID() === filter.afterID,
+      );
 
       if (afterIndex === -1) {
         return Result.ok(publicNotes.slice(0, 20));
       }
-
-      return Result.ok(publicNotes.slice(afterIndex + 1, afterIndex + 21));
+      const startIndex = Math.max(0, afterIndex - 20);
+      return Result.ok(publicNotes.slice(startIndex, afterIndex));
     }
 
     if (filter.beforeId) {
-      const beforeIndex = publicNotes.findIndex(
+      const beforeIndex = publicNotes.findLastIndex(
         (note) => note.getID() === filter.beforeId,
       );
 

--- a/pkg/timeline/adaptor/repository/dummy.ts
+++ b/pkg/timeline/adaptor/repository/dummy.ts
@@ -123,11 +123,15 @@ export class InMemoryTimelineRepository implements TimelineRepository {
     // ToDo: filter hasAttachment, noNSFW
 
     if (filter.afterID) {
-      const afterIndex = publicNotes
-        .reverse()
-        .findIndex((note) => note.getID() === filter.afterID);
+      const afterIndex = publicNotes.findIndex(
+        (note) => note.getID() === filter.afterID,
+      );
 
-      return Result.ok(publicNotes.slice(afterIndex).reverse().slice(0, 20));
+      if (afterIndex === -1) {
+        return Result.ok(publicNotes.slice(0, 20));
+      }
+
+      return Result.ok(publicNotes.slice(afterIndex + 1, afterIndex + 21));
     }
 
     if (filter.beforeId) {

--- a/pkg/timeline/adaptor/validator/timeline.ts
+++ b/pkg/timeline/adaptor/validator/timeline.ts
@@ -49,6 +49,10 @@ export const GetAccountTimelineResponseSchema = z
 
 export const GetHomeTimelineResponseSchema = z.array(TimelineNoteBaseSchema);
 
+export const GetPublicTimelineResponseSchema = z
+  .array(TimelineNoteBaseSchema)
+  .openapi('GetPublicTimelineResponse');
+
 export const GetListTimelineResponseSchema = z
   .array(
     z.object({

--- a/pkg/timeline/model/repository.ts
+++ b/pkg/timeline/model/repository.ts
@@ -46,6 +46,15 @@ export interface TimelineRepository {
   ): Promise<Result.Result<Error, Note[]>>;
 
   /**
+   * @description Fetch public timeline
+   * @param filter Filter for fetching notes
+   * @return {@link Note}[] list of public Notes, sorted by CreatedAt descending
+   * */
+  getPublicTimeline(
+    filter: FetchHomeTimelineFilter,
+  ): Promise<Result.Result<Error, Note[]>>;
+
+  /**
    * @description Fetch list timeline
    * @param noteId IDs of the notes to be fetched
    * @return {@link Note}[] list of Notes, sorted by CreatedAt descending

--- a/pkg/timeline/router.ts
+++ b/pkg/timeline/router.ts
@@ -21,6 +21,7 @@ import {
   GetHomeTimelineResponseSchema,
   GetListMemberResponseSchema,
   GetListTimelineResponseSchema,
+  GetPublicTimelineResponseSchema,
 } from './adaptor/validator/timeline.js'; /* NOTE: query params must use z.string() \
  cf. https://zenn.dev/loglass/articles/c237d89e238d42 (Japanese)\
  cf. https://github.com/honojs/middleware/issues/200#issuecomment-1773428171 (GitHub Issue)
@@ -64,6 +65,45 @@ export const GetHomeTimelineRoute = createRoute({
       content: {
         'application/json': {
           schema: GetHomeTimelineResponseSchema,
+        },
+      },
+    },
+    404: {
+      description: 'Nothing left',
+      content: {
+        'application/json': {
+          schema: z.object({
+            error: NothingLeft,
+          }),
+        },
+      },
+    },
+    500: {
+      description: 'Internal error',
+      content: {
+        'application/json': {
+          schema: z.object({
+            error: TimelineInternalError,
+          }),
+        },
+      },
+    },
+  },
+});
+
+export const GetPublicTimelineRoute = createRoute({
+  method: 'get',
+  tags: ['timeline'],
+  path: '/v0/timeline/public',
+  request: {
+    query: timelineFilterQuerySchema,
+  },
+  responses: {
+    200: {
+      description: 'OK',
+      content: {
+        'application/json': {
+          schema: GetPublicTimelineResponseSchema,
         },
       },
     },

--- a/pkg/timeline/service/public.test.ts
+++ b/pkg/timeline/service/public.test.ts
@@ -67,6 +67,22 @@ describe('PublicTimelineService', () => {
     }
   });
 
+  it('Successfully get public timeline with afterId filter', async () => {
+    const res = await publicTimelineService.fetchPublicTimeline({
+      hasAttachment: false,
+      noNsfw: false,
+      afterID: dummyPublicNote.getID(),
+    });
+
+    expect(Result.isOk(res)).toBe(true);
+    const notes = Result.unwrap(res);
+
+    expect(notes.length).toBe(1);
+    for (const note of notes) {
+      expect(note.getVisibility()).toBe('PUBLIC');
+    }
+  });
+
   it('Error when both beforeId and afterId are specified', async () => {
     const res = await publicTimelineService.fetchPublicTimeline({
       hasAttachment: false,

--- a/pkg/timeline/service/public.test.ts
+++ b/pkg/timeline/service/public.test.ts
@@ -1,0 +1,80 @@
+import { Option, Result } from '@mikuroxina/mini-fn';
+import { describe, expect, it } from 'vitest';
+
+import type { AccountID } from '../../accounts/model/account.js';
+import { Note, type NoteID } from '../../notes/model/note.js';
+import { InMemoryTimelineRepository } from '../adaptor/repository/dummy.js';
+import {
+  dummyDirectNote,
+  dummyFollowersNote,
+  dummyHomeNote,
+  dummyPublicNote,
+} from '../testData/testData.js';
+import { PublicTimelineService } from './public.js';
+
+const dummyPublicNote2 = Note.new({
+  id: '10' as NoteID,
+  authorID: '200' as AccountID,
+  content: 'Second public note',
+  contentsWarningComment: '',
+  originalNoteID: Option.none(),
+  attachmentFileID: [],
+  sendTo: Option.none(),
+  visibility: 'PUBLIC',
+  createdAt: new Date('2023/09/15 00:00:00'),
+});
+
+describe('PublicTimelineService', () => {
+  const timelineRepository = new InMemoryTimelineRepository([
+    dummyPublicNote,
+    dummyPublicNote2,
+    dummyHomeNote,
+    dummyFollowersNote,
+    dummyDirectNote,
+  ]);
+  const publicTimelineService = new PublicTimelineService(timelineRepository);
+
+  it('Successfully get public timeline with only PUBLIC notes', async () => {
+    const res = await publicTimelineService.fetchPublicTimeline({
+      hasAttachment: false,
+      noNsfw: false,
+    });
+
+    expect(Result.isOk(res)).toBe(true);
+    const notes = Result.unwrap(res);
+
+    // Only PUBLIC notes should be returned
+    expect(notes).toHaveLength(2);
+    for (const note of notes) {
+      expect(note.getVisibility()).toBe('PUBLIC');
+    }
+  });
+
+  it('Successfully get public timeline with beforeId filter', async () => {
+    const res = await publicTimelineService.fetchPublicTimeline({
+      hasAttachment: false,
+      noNsfw: false,
+      beforeId: dummyPublicNote2.getID(),
+    });
+
+    expect(Result.isOk(res)).toBe(true);
+    const notes = Result.unwrap(res);
+
+    // Should return notes before the specified ID
+    expect(notes.length).toBeGreaterThan(0);
+    for (const note of notes) {
+      expect(note.getVisibility()).toBe('PUBLIC');
+    }
+  });
+
+  it('Error when both beforeId and afterId are specified', async () => {
+    const res = await publicTimelineService.fetchPublicTimeline({
+      hasAttachment: false,
+      noNsfw: false,
+      beforeId: dummyPublicNote.getID(),
+      afterID: dummyPublicNote2.getID(),
+    });
+
+    expect(Result.isErr(res)).toBe(true);
+  });
+});

--- a/pkg/timeline/service/public.ts
+++ b/pkg/timeline/service/public.ts
@@ -1,0 +1,27 @@
+import { Ether, type Result } from '@mikuroxina/mini-fn';
+
+import type { Note } from '../../notes/model/note.js';
+import {
+  type FetchHomeTimelineFilter,
+  type TimelineRepository,
+  timelineRepoSymbol,
+} from '../model/repository.js';
+
+export class PublicTimelineService {
+  constructor(private readonly timelineRepository: TimelineRepository) {}
+
+  async fetchPublicTimeline(
+    filter: FetchHomeTimelineFilter,
+  ): Promise<Result.Result<Error, Note[]>> {
+    return await this.timelineRepository.getPublicTimeline(filter);
+  }
+}
+export const publicTimelineSymbol =
+  Ether.newEtherSymbol<PublicTimelineService>();
+export const publicTimeline = Ether.newEther(
+  publicTimelineSymbol,
+  ({ timelineRepository }) => new PublicTimelineService(timelineRepository),
+  {
+    timelineRepository: timelineRepoSymbol,
+  },
+);

--- a/resources/schema.json
+++ b/resources/schema.json
@@ -785,8 +785,7 @@
         },
         "required": [
           "id",
-          "title",
-          "public"
+          "title"
         ]
       },
       "CreateListRequest": {
@@ -804,8 +803,7 @@
           }
         },
         "required": [
-          "title",
-          "public"
+          "title"
         ]
       },
       "EditListResponse": {
@@ -829,8 +827,7 @@
         },
         "required": [
           "id",
-          "title",
-          "public"
+          "title"
         ]
       },
       "EditListRequest": {
@@ -869,8 +866,7 @@
         },
         "required": [
           "id",
-          "title",
-          "public"
+          "title"
         ]
       },
       "GetListMemberResponseSchema": {
@@ -963,6 +959,185 @@
           "required": [
             "account",
             "updatedAt"
+          ]
+        }
+      },
+      "GetPublicTimelineResponse": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string",
+              "example": "38477395",
+              "description": "Note ID"
+            },
+            "content": {
+              "type": "string",
+              "example": "hello world!",
+              "description": "Note content"
+            },
+            "contents_warning_comment": {
+              "type": "string",
+              "example": "(if length not 0) This note contains sensitive content",
+              "description": "Contents warning comment"
+            },
+            "visibility": {
+              "type": "string",
+              "example": "PUBLIC",
+              "description": "Note visibility (PUBLIC/HOME/FOLLOWERS/DIRECT)"
+            },
+            "created_at": {
+              "type": "string",
+              "format": "date-time",
+              "example": "2021-01-01T00:00:00Z",
+              "description": "Note created date"
+            },
+            "reactions": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "emoji": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "pattern": "[\\u2700-\\u27BF]|[\\uE000-\\uF8FF]|\\uD83C[\\uDC00-\\uDFFF]|\\uD83D[\\uDC00-\\uDFFF]|[\\u2011-\\u26FF]|\\uD83E[\\uDD10-\\uDDFF]"
+                      },
+                      {
+                        "type": "string",
+                        "pattern": "<:(\\w+):(\\d+)>"
+                      }
+                    ],
+                    "description": "Reaction Emoji (Unicode or Custom Emoji)",
+                    "examples": [
+                      "🎉",
+                      "<:custom_emoji:123456789>"
+                    ]
+                  },
+                  "reacted_by": {
+                    "type": "string",
+                    "example": "38477395",
+                    "description": "Reacted account ID"
+                  }
+                },
+                "required": [
+                  "emoji",
+                  "reacted_by"
+                ]
+              },
+              "description": "Reactions"
+            },
+            "attachment_files": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "example": "39783475",
+                    "description": "attachment Medium id"
+                  },
+                  "name": {
+                    "type": "string",
+                    "example": "image.jpg",
+                    "description": "attachment filename"
+                  },
+                  "author_id": {
+                    "type": "string",
+                    "example": "309823457",
+                    "description": "attachment author account id"
+                  },
+                  "hash": {
+                    "type": "string",
+                    "example": "e9f*5oin{dn",
+                    "description": "attachment medium blurhash"
+                  },
+                  "mime": {
+                    "type": "string",
+                    "example": "image/jpeg",
+                    "description": "attachment medium mime type"
+                  },
+                  "nsfw": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "if true, attachment is nsfw"
+                  },
+                  "url": {
+                    "type": "string",
+                    "format": "uri",
+                    "example": "https://images.example.com/image.webp",
+                    "description": "attachment medium url"
+                  },
+                  "thumbnail": {
+                    "type": "string",
+                    "example": "https://images.example.com/image_thumbnail.webp",
+                    "description": "attachment thumbnail url"
+                  }
+                },
+                "required": [
+                  "id",
+                  "name",
+                  "author_id",
+                  "hash",
+                  "mime",
+                  "nsfw",
+                  "url",
+                  "thumbnail"
+                ]
+              },
+              "maxItems": 16,
+              "description": "Note Attachment Media"
+            },
+            "author": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "display_name": {
+                  "type": "string"
+                },
+                "bio": {
+                  "type": "string"
+                },
+                "avatar": {
+                  "type": "string"
+                },
+                "header": {
+                  "type": "string"
+                },
+                "followed_count": {
+                  "type": "number"
+                },
+                "following_count": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "id",
+                "name",
+                "display_name",
+                "bio",
+                "avatar",
+                "header",
+                "followed_count",
+                "following_count"
+              ]
+            }
+          },
+          "required": [
+            "id",
+            "content",
+            "contents_warning_comment",
+            "visibility",
+            "created_at",
+            "reactions",
+            "attachment_files",
+            "author"
           ]
         }
       }
@@ -5979,6 +6154,111 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/GetListConversationsResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "enum": [
+                        "INTERNAL_ERROR"
+                      ],
+                      "description": "Internal server error"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v0/timeline/public": {
+      "get": {
+        "tags": [
+          "timeline"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "boolean",
+              "description": "If true, only return notes with attachment"
+            },
+            "required": false,
+            "description": "If true, only return notes with attachment",
+            "name": "has_attachment",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "boolean",
+              "description": "If true, only return notes without sensitive content"
+            },
+            "required": false,
+            "description": "If true, only return notes without sensitive content",
+            "name": "no_nsfw",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Return notes before this note ID. specified note ID is not included. NOTE: after_id and before_id are exclusive."
+            },
+            "required": false,
+            "description": "Return notes before this note ID. specified note ID is not included. NOTE: after_id and before_id are exclusive.",
+            "name": "before_id",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Return notes after this note ID. Specified note is not included. NOTE: after_id and before_id are exclusive."
+            },
+            "required": false,
+            "description": "Return notes after this note ID. Specified note is not included. NOTE: after_id and before_id are exclusive.",
+            "name": "after_id",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetPublicTimelineResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Nothing left",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "enum": [
+                        "NOTHING_LEFT"
+                      ],
+                      "description": "No more notes exist"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
                 }
               }
             }


### PR DESCRIPTION
close #1167 

## What does this PR do?
- I have implemented a public timeline that includes all public posts.
  - new endpoint: `GET /v0/timeline/public`
  - Filters are same as home timeline endpoint.


## Additional information
- update API schemas
- Refactoring: made the conversion logic for filters and limits in `PrismaRepository` more reusable