### PR TITLE
fix: change follow method to perform upsert instead of create

### DIFF
--- a/pkg/accounts/adaptor/repository/prisma/prisma.ts
+++ b/pkg/accounts/adaptor/repository/prisma/prisma.ts
@@ -289,8 +289,17 @@ export class PrismaAccountFollowRepository implements AccountFollowRepository {
 
   async follow(follow: AccountFollow): Promise<Result.Result<Error, void>> {
     try {
-      await this.prisma.following.create({
-        data: {
+      await this.prisma.following.upsert({
+        where: {
+          fromId_toId: {
+            fromId: follow.getFromID(),
+            toId: follow.getTargetID(),
+          },
+        },
+        update: {
+          deletedAt: undefined,
+        },
+        create: {
           fromId: follow.getFromID(),
           toId: follow.getTargetID(),
         },


### PR DESCRIPTION
## What does this PR do?
- フォロー解除時にfollowingレコードを削除するように変更

## Additional information
- 変更は`PrismaAccountFollowRepository`のみです．インメモリ実装はこの問題が発生しないものと考えています
