### PR TITLE
ci: Specify merge_group trigger on build CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches:
       - main
+  merge_group:
+    branches:
+      - main
 
 jobs:
   build:


### PR DESCRIPTION
マージキューを導入するため, ビルド CI に merge_group の指定を追加します.
