### PR TITLE
chore(ci): setup docker image build & publish workflow

### DIFF
--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
related: #1086 

## What does this PR do?
- Dockerイメージをビルドしghcr.ioにpushするワークフローをセットアップしました
  - release(tag publish)時に自動で実行した方が良いでしょうが，まだそこまで考えていないので手動で起動するようにしてあります

## Additional information

