### PR TITLE
fix: Etherに与えるSymbolが違うことでタイムライン取得が失敗するバグの修正

### DIFF
--- a/pkg/intermodule/note.ts
+++ b/pkg/intermodule/note.ts
@@ -17,8 +17,8 @@ import type { NoteID } from '../notes/model/note.js';
 import type { Reaction } from '../notes/model/reaction.js';
 import type { RenoteStatus } from '../notes/model/renoteStatus.js';
 import {
-  type NoteRepository,
   noteAttachmentRepoSymbol,
+  noteRepoSymbol,
   reactionRepoSymbol,
 } from '../notes/model/repository.js';
 import { type FetchService, fetch } from '../notes/service/fetch.js';
@@ -87,10 +87,7 @@ const reactionRepository = Ether.newEther(
   reactionRepoSymbol,
   () => reactionRepoObject,
 );
-const noteRepository = Ether.newEther(
-  Ether.newEtherSymbol<NoteRepository>(),
-  () => noteRepoObject,
-);
+const noteRepository = Ether.newEther(noteRepoSymbol, () => noteRepoObject);
 export const noteModuleFacadeSymbol = Ether.newEtherSymbol<NoteModuleFacade>();
 
 /**


### PR DESCRIPTION
close #1327 
## What does this PR do?
- Ether.newEtherに渡すSymbolが期待するものと違ったことで，undefinedが渡されて依存の呼び出しに失敗していたのを修正


## Additional information
- blameを見ると2024 Sep 29から存在していたようでした...
- ほかにも似たようなバグが存在していそうな雰囲気があります
  - 新しいエンドポイントを親切する時に統合テストを書く などの対策がとれそう