### PR TITLE
chore(ci): change Docker image tag to semantic versioning format

### DIFF
--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -32,7 +32,8 @@ jobs:
         with:
           images: ghcr.io/pulsate-dev/pulsate
           tags: |
-            type=sha,prefix=0.0.1-alpha.,format=short
+            type=semver,pattern={{version}},value=v0.0.1-alpha
+            type=sha,prefix=sha-,format=short
             type=raw,value=latest
           labels: |
             org.opencontainers.image.title=pulsate


### PR DESCRIPTION
関連Issueなしで直接PR出します

## What does this PR do?
- コンテナイメージのタグ名がセマンティックバージョニングの形式に沿った形ではないので正しい形に修正
  - `sha-{COMMIT_HASH}`から`v0.0.1-alpha.{COMMIT_HASH}`に変更

## Additional information
- バージョンはひとまず`v0.0.1`固定にしています