### PR TITLE
fix: add logging and custom error for missing timeline cache keys

### DIFF
--- a/pkg/timeline/adaptor/repository/dummyCache.ts
+++ b/pkg/timeline/adaptor/repository/dummyCache.ts
@@ -3,6 +3,7 @@ import { Ether, Result } from '@mikuroxina/mini-fn';
 import type { AccountID } from '../../../accounts/model/account.js';
 import { compareID } from '../../../id/mod.js';
 import type { Note, NoteID } from '../../../notes/model/note.js';
+import { TimelineCacheNotFoundError } from '../../model/errors.js';
 import type { ListID } from '../../model/list.js';
 import {
   type CacheObjectKey,
@@ -74,7 +75,11 @@ export class InMemoryTimelineCacheRepository
   ): Promise<Result.Result<Error, NoteID[]>> {
     const fetched = this.data.get(this.generateObjectKey(accountID, 'home'));
     if (!fetched) {
-      return Result.err(new Error('Not found'));
+      return Result.err(
+        new TimelineCacheNotFoundError('timeline cache not found', {
+          cause: { timelineType: 'home', id: accountID },
+        }),
+      );
     }
     return Result.ok(fetched.sort(compareID));
   }
@@ -84,7 +89,11 @@ export class InMemoryTimelineCacheRepository
   ): Promise<Result.Result<Error, NoteID[]>> {
     const fetched = this.data.get(this.generateObjectKey(listID, 'list'));
     if (!fetched) {
-      return Result.err(new Error('Not found'));
+      return Result.err(
+        new TimelineCacheNotFoundError('timeline cache not found', {
+          cause: { timelineType: 'list', id: listID },
+        }),
+      );
     }
     return Result.ok(fetched.sort(compareID));
   }
@@ -112,7 +121,11 @@ export class InMemoryTimelineCacheRepository
     const objectKey = this.generateObjectKey(accountID, 'home');
     const fetched = this.data.get(objectKey);
     if (!fetched) {
-      return Result.err(new Error('Not found'));
+      return Result.err(
+        new TimelineCacheNotFoundError('timeline cache not found', {
+          cause: { timelineType: 'home', id: accountID },
+        }),
+      );
     }
     this.data.set(
       objectKey,
@@ -129,7 +142,11 @@ export class InMemoryTimelineCacheRepository
     const objectKey = this.generateObjectKey(listID, 'list');
     const fetched = this.data.get(objectKey);
     if (!fetched) {
-      return Result.err(new Error('Not found'));
+      return Result.err(
+        new TimelineCacheNotFoundError('timeline cache not found', {
+          cause: { timelineType: 'list', id: listID },
+        }),
+      );
     }
     this.data.set(
       objectKey,

--- a/pkg/timeline/model/errors.ts
+++ b/pkg/timeline/model/errors.ts
@@ -107,3 +107,14 @@ export class TimelineInsufficientPermissionError extends Error {
     this.cause = options.cause;
   }
 }
+
+/**
+ * Timeline cache key not found
+ */
+export class TimelineCacheNotFoundError extends Error {
+  constructor(message: string, options: { cause: unknown }) {
+    super(message);
+    this.name = 'TimelineCacheNotFoundError';
+    this.cause = options.cause;
+  }
+}

--- a/pkg/timeline/service/home.ts
+++ b/pkg/timeline/service/home.ts
@@ -2,6 +2,7 @@ import { Ether, Result } from '@mikuroxina/mini-fn';
 
 import type { AccountID } from '../../accounts/model/account.js';
 import type { Note } from '../../notes/model/note.js';
+import { timelineModuleLogger } from '../adaptor/logger.js';
 import {
   type FetchHomeTimelineFilter,
   type TimelineNotesCacheRepository,
@@ -24,7 +25,11 @@ export class HomeTimelineService {
     const noteIDsRes =
       await this.timelineCacheRepository.getHomeTimeline(accountID);
     if (Result.isErr(noteIDsRes)) {
-      return noteIDsRes;
+      timelineModuleLogger.warn(
+        'Failed to get home timeline cache',
+        Result.unwrapErr(noteIDsRes),
+      );
+      return Result.ok([]);
     }
     const noteIDs = Result.unwrap(noteIDsRes);
     const beforeIndex = filter.beforeId

--- a/pkg/timeline/service/list.ts
+++ b/pkg/timeline/service/list.ts
@@ -1,5 +1,6 @@
 import { Ether, Result } from '@mikuroxina/mini-fn';
 import type { Note } from '../../notes/model/note.js';
+import { timelineModuleLogger } from '../adaptor/logger.js';
 import type { ListID } from '../model/list.js';
 import {
   type TimelineNotesCacheRepository,
@@ -24,7 +25,11 @@ export class ListTimelineService {
     const cachedNotesRes =
       await this.timelineCacheRepository.getListTimeline(listID);
     if (Result.isErr(cachedNotesRes)) {
-      return cachedNotesRes;
+      timelineModuleLogger.warn(
+        'Failed to get list timeline cache',
+        Result.unwrapErr(cachedNotesRes),
+      );
+      return Result.ok([]);
     }
     const cachedNotes = Result.unwrap(cachedNotesRes);
 


### PR DESCRIPTION
close #1329 

## What does this PR do?
- タイムラインを構築するためのキャッシュを取得するときに，キーが存在しない時はInternalErrorではなくCacheNotFoundErrorを返すようにしました
  - アカウント作成直後で誰もフォローしていない場合など，キャッシュが構築されていない状態でエラーになってしまうケースを修正

## Additional information
