### PR TITLE
chore(docker): postgresql18のデータ保存先変更に追従

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -15,7 +15,7 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - db_data:/var/lib/postgresql/data
+      - db_data:/var/lib/postgresql
     environment:
       - POSTGRES_USER=pulsate
       - POSTGRES_PASSWORD=pulsate_db_pass


### PR DESCRIPTION
## What does this PR do?
- postgresql v18のアップデートに伴ってデータファイルの保存先が変更され，v17以前のdbを運用していた場合にコンテナが起動しなくなっていた
- 同様にv18のコンテナを新規に動かす場合でも挙動がおかしくなっていました

## Additional information
- psql17までを動かしている場合は一回データをダンプしてリストアし直す必要があります