### PR TITLE
chore(test): attachmentが存在しないなら空配列を返す

### DIFF
--- a/pkg/notes/adaptor/repository/dummy.ts
+++ b/pkg/notes/adaptor/repository/dummy.ts
@@ -3,10 +3,7 @@ import { Ether, Option, Result } from '@mikuroxina/mini-fn';
 import type { AccountID } from '../../../accounts/model/account.js';
 import type { Medium, MediumID } from '../../../drive/model/medium.js';
 import { Bookmark } from '../../model/bookmark.js';
-import {
-  NoteAttachmentNotFoundError,
-  NoteNotReactedYetError,
-} from '../../model/errors.js';
+import { NoteNotReactedYetError } from '../../model/errors.js';
 import type { Note, NoteID } from '../../model/note.js';
 import type { Reaction, ReactionID } from '../../model/reaction.js';
 import { RenoteStatus } from '../../model/renoteStatus.js';


### PR DESCRIPTION
related pulsate-dev/caramel#532

## What does this PR do?
- Devモードにおいて，投稿が拒否される現象を修正しました
  - NoteのAttachmentが存在するかしないかに関わらずAttachmentを取得しようとしており，その部分でエラーになっていました

## Additional information
