### PR TITLE
refactor: アカウントモデルの実装見直し

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "prisma": "7.8.0",
     "sharp": "0.34.5",
     "tslog": "4.10.2",
-    "valibot": "^1.4.0",
+    "valibot": "1.4.0",
     "yaml": "2.8.4"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "prisma": "7.8.0",
     "sharp": "0.34.5",
     "tslog": "4.10.2",
+    "valibot": "^1.4.0",
     "yaml": "2.8.4"
   },
   "peerDependencies": {

--- a/pkg/accounts/adaptor/controller/account.ts
+++ b/pkg/accounts/adaptor/controller/account.ts
@@ -268,9 +268,9 @@ export class AccountController {
       note_count: 0,
       created_at: account.getCreatedAt(),
       role: account.getRole(),
-      frozen: account.getFrozen(),
-      status: account.getStatus(),
-      silenced: account.getSilenced(),
+      frozen: account.isFrozen() ? 'frozen' : 'normal',
+      status: account.isActivated() ? 'active' : 'notActivated',
+      silenced: account.isSilenced() ? 'silenced' : 'normal',
     });
   }
 
@@ -319,9 +319,9 @@ export class AccountController {
       note_count: 0,
       created_at: account.getCreatedAt(),
       role: account.getRole(),
-      frozen: account.getFrozen(),
-      status: account.getStatus(),
-      silenced: account.getSilenced(),
+      frozen: account.isFrozen() ? 'frozen' : 'normal',
+      status: account.isActivated() ? 'active' : 'notActivated',
+      silenced: account.isSilenced() ? 'silenced' : 'normal',
     });
   }
 
@@ -498,9 +498,9 @@ export class AccountController {
           note_count: 0,
           created_at: v.getCreatedAt(),
           role: v.getRole(),
-          frozen: v.getFrozen(),
-          status: v.getStatus(),
-          silenced: v.getSilenced(),
+          frozen: v.isFrozen() ? 'frozen' : 'normal',
+          status: v.isActivated() ? 'active' : 'notActivated',
+          silenced: v.isSilenced() ? 'silenced' : 'normal',
         };
       }),
     );
@@ -576,9 +576,9 @@ export class AccountController {
           note_count: 0,
           created_at: v.getCreatedAt(),
           role: v.getRole(),
-          frozen: v.getFrozen(),
-          status: v.getStatus(),
-          silenced: v.getSilenced(),
+          frozen: v.isFrozen() ? 'frozen' : 'normal',
+          status: v.isActivated() ? 'active' : 'notActivated',
+          silenced: v.isSilenced() ? 'silenced' : 'normal',
         };
       }),
     );

--- a/pkg/accounts/adaptor/repository/prisma/prisma.ts
+++ b/pkg/accounts/adaptor/repository/prisma/prisma.ts
@@ -122,26 +122,9 @@ export class PrismaAccountRepository implements AccountRepository {
       } satisfies Record<AccountRole, number>
     )[account.getRole()];
 
-    const status = (
-      {
-        active: 0,
-        notActivated: 1,
-      } satisfies Record<AccountStatus, number>
-    )[account.getStatus()];
-
-    const frozen = (
-      {
-        normal: 0,
-        frozen: 1,
-      } satisfies Record<AccountFrozen, number>
-    )[account.getFrozen()];
-
-    const silenced = (
-      {
-        normal: 0,
-        silenced: 1,
-      } satisfies Record<AccountSilenced, number>
-    )[account.getSilenced()];
+    const status = account.isActivated() ? 0 : 1;
+    const frozen = account.isFrozen() ? 1 : 0;
+    const silenced = account.isSilenced() ? 1 : 0;
 
     return {
       id: account.getID(),

--- a/pkg/accounts/model/account.test.ts
+++ b/pkg/accounts/model/account.test.ts
@@ -34,7 +34,7 @@ describe('Account', () => {
     expect(account.getPassphraseHash()).toBe(exampleInput.passphraseHash);
     expect(account.getBio()).toBe(exampleInput.bio);
     expect(account.getRole()).toBe(exampleInput.role);
-    expect(account.getStatus()).toBe('notActivated');
+    expect(account.isActivated()).toBe(false);
     expect(account.getCreatedAt()).toBe(exampleInput.createdAt);
     expect(account.getUpdatedAt()).toBe(undefined);
     expect(account.getDeletedAt()).toBe(undefined);

--- a/pkg/accounts/model/account.test.ts
+++ b/pkg/accounts/model/account.test.ts
@@ -1,3 +1,4 @@
+import { Result } from '@mikuroxina/mini-fn';
 import { describe, expect, it } from 'vitest';
 
 import {
@@ -9,7 +10,7 @@ import {
 
 const exampleInput: CreateAccountArgs = {
   id: '1' as AccountID,
-  bio: 'this is john doe’s account!',
+  bio: 'this is john doe"s account!',
   createdAt: new Date('2023-09-10T00:00:00.000Z'),
   mail: 'test@mail.example.com',
   nickname: 'John Doe',
@@ -43,65 +44,35 @@ describe('Account', () => {
   it('account nickname must be less than 256', () => {
     const name = 'a'.repeat(257);
     const account = Account.new(exampleInput);
-    expect(() => account.setNickName(name)).toThrow();
+    expect(Result.isErr(account.setNickName(name))).toBe(true);
   });
 
   it('account bio must be less than 1024 chars', () => {
     const bio = 'a'.repeat(1025);
     const account = Account.new(exampleInput);
-    expect(() => {
-      account.setBio(bio);
-    }).toThrow();
+    expect(Result.isErr(account.setBio(bio))).toBe(true);
   });
 
-  it('can’t change values when account is frozen', () => {
+  it("can't change values when account is frozen", () => {
     const account = Account.new(exampleInput);
     account.setFreeze();
 
-    expect(() => {
-      account.setBio('test');
-    }).toThrow();
-
-    expect(() => {
-      account.setNickName('hello@example.com');
-    }).toThrow();
-
-    expect(() => {
-      account.setPassphraseHash('123');
-    }).toThrow();
-
-    expect(() => {
-      account.setSilence();
-    }).toThrow();
-
-    expect(() => {
-      account.setMail('pulsate@example.com');
-    }).toThrow();
+    expect(Result.isErr(account.setBio('test'))).toBe(true);
+    expect(Result.isErr(account.setNickName('hello@example.com'))).toBe(true);
+    expect(Result.isErr(account.setPassphraseHash('123'))).toBe(true);
+    expect(Result.isErr(account.setSilence())).toBe(true);
+    expect(Result.isErr(account.setMail('pulsate@example.com'))).toBe(true);
   });
 
-  it('deleted account can’t change values', () => {
+  it("deleted account can't change values", () => {
     const account = Account.new(exampleInput);
     account.setDeletedAt(new Date());
 
-    expect(() => {
-      account.setBio('test');
-    }).toThrow();
-
-    expect(() => {
-      account.setNickName('hello@example.com');
-    }).toThrow();
-
-    expect(() => {
-      account.setPassphraseHash('123');
-    }).toThrow();
-
-    expect(() => {
-      account.setSilence();
-    }).toThrow();
-
-    expect(() => {
-      account.setMail('pulsate@example.com');
-    }).toThrow();
+    expect(Result.isErr(account.setBio('test'))).toBe(true);
+    expect(Result.isErr(account.setNickName('hello@example.com'))).toBe(true);
+    expect(Result.isErr(account.setPassphraseHash('123'))).toBe(true);
+    expect(Result.isErr(account.setSilence())).toBe(true);
+    expect(Result.isErr(account.setMail('pulsate@example.com'))).toBe(true);
   });
 });
 

--- a/pkg/accounts/model/account.test.ts
+++ b/pkg/accounts/model/account.test.ts
@@ -25,54 +25,59 @@ const exampleInput: CreateAccountArgs = {
 };
 
 describe('Account', () => {
-  it('generate new instance', () => {
-    const account = Account.new(exampleInput);
+  const account = Account.new(exampleInput);
 
-    expect(account.getID()).toBe(exampleInput.id);
-    expect(account.getName()).toBe(exampleInput.name);
-    expect(account.getMail()).toBe(exampleInput.mail);
-    expect(account.getNickname()).toBe(exampleInput.nickname);
-    expect(account.getPassphraseHash()).toBe(exampleInput.passphraseHash);
-    expect(account.getBio()).toBe(exampleInput.bio);
-    expect(account.getRole()).toBe(exampleInput.role);
-    expect(account.isActivated()).toBe(false);
-    expect(account.getCreatedAt()).toBe(exampleInput.createdAt);
-    expect(account.getUpdatedAt()).toBe(undefined);
-    expect(account.getDeletedAt()).toBe(undefined);
+  it.each([
+    ['id', account.getID(), exampleInput.id],
+    ['name', account.getName(), exampleInput.name],
+    ['mail', account.getMail(), exampleInput.mail],
+    ['nickname', account.getNickname(), exampleInput.nickname],
+    [
+      'passphraseHash',
+      account.getPassphraseHash(),
+      exampleInput.passphraseHash,
+    ],
+    ['bio', account.getBio(), exampleInput.bio],
+    ['role', account.getRole(), exampleInput.role],
+    ['isActivated', account.isActivated(), false],
+    ['createdAt', account.getCreatedAt(), exampleInput.createdAt],
+    ['updatedAt', account.getUpdatedAt(), undefined],
+    ['deletedAt', account.getDeletedAt(), undefined],
+  ])('generates new instance: %s', (_, actual, expected) => {
+    expect(actual).toBe(expected);
   });
 
-  it('account nickname must be less than 256', () => {
-    const name = 'a'.repeat(257);
-    const account = Account.new(exampleInput);
-    expect(Result.isErr(account.setNickName(name))).toBe(true);
+  const validationCases: [
+    string,
+    (a: Account) => Result.Result<Error, void>,
+  ][] = [
+    ['nickname too long', (a) => a.setNickName('a'.repeat(257))],
+    ['bio too long', (a) => a.setBio('a'.repeat(1025))],
+  ];
+
+  it.each(validationCases)('returns error when %s', (_, call) => {
+    expect(Result.isErr(call(Account.new(exampleInput)))).toBe(true);
   });
 
-  it('account bio must be less than 1024 chars', () => {
-    const bio = 'a'.repeat(1025);
-    const account = Account.new(exampleInput);
-    expect(Result.isErr(account.setBio(bio))).toBe(true);
+  const mutationCalls: [string, (a: Account) => Result.Result<Error, void>][] =
+    [
+      ['setBio', (a) => a.setBio('test')],
+      ['setNickName', (a) => a.setNickName('hello@example.com')],
+      ['setPassphraseHash', (a) => a.setPassphraseHash('123')],
+      ['setSilence', (a) => a.setSilence()],
+      ['setMail', (a) => a.setMail('pulsate@example.com')],
+    ];
+
+  it.each(mutationCalls)('%s fails when account is frozen', (_, call) => {
+    const frozen = Account.new(exampleInput);
+    frozen.setFreeze();
+    expect(Result.isErr(call(frozen))).toBe(true);
   });
 
-  it("can't change values when account is frozen", () => {
-    const account = Account.new(exampleInput);
-    account.setFreeze();
-
-    expect(Result.isErr(account.setBio('test'))).toBe(true);
-    expect(Result.isErr(account.setNickName('hello@example.com'))).toBe(true);
-    expect(Result.isErr(account.setPassphraseHash('123'))).toBe(true);
-    expect(Result.isErr(account.setSilence())).toBe(true);
-    expect(Result.isErr(account.setMail('pulsate@example.com'))).toBe(true);
-  });
-
-  it("deleted account can't change values", () => {
-    const account = Account.new(exampleInput);
-    account.setDeletedAt(new Date());
-
-    expect(Result.isErr(account.setBio('test'))).toBe(true);
-    expect(Result.isErr(account.setNickName('hello@example.com'))).toBe(true);
-    expect(Result.isErr(account.setPassphraseHash('123'))).toBe(true);
-    expect(Result.isErr(account.setSilence())).toBe(true);
-    expect(Result.isErr(account.setMail('pulsate@example.com'))).toBe(true);
+  it.each(mutationCalls)('%s fails when account is deleted', (_, call) => {
+    const deleted = Account.new(exampleInput);
+    deleted.setDeletedAt(new Date());
+    expect(Result.isErr(call(deleted))).toBe(true);
   });
 });
 
@@ -81,27 +86,30 @@ describe('AccountNameSchema', () => {
 
   const account = Account.new(exampleInput);
 
-  it('check it is accountname', () => {
-    expect(check(account.getName())).toBe(true);
-
-    expect(check('@name@domain')).toBe(true);
-    expect(check('@name@example.com')).toBe(true);
-    expect(check('@name@xn--example-bs3o55gu19k.com')).toBe(true);
+  it.each([
+    account.getName(),
+    '@name@domain',
+    '@name@example.com',
+    '@name@xn--example-bs3o55gu19k.com',
+  ])('valid account name: %s', (name) => {
+    expect(check(name)).toBe(true);
   });
 
-  it('check it is not accountname', () => {
-    expect(check('@@')).toBe(false);
-    expect(check('@_name_@example.com')).toBe(false);
-    expect(check('@name@domain@what')).toBe(false);
-    expect(check('what@name@domain')).toBe(false);
-    expect(check('@name@example.')).toBe(false);
-    expect(check('@name@.example.com')).toBe(false);
-    expect(check('@name@example-.com')).toBe(false);
-    expect(check('@name@example.com-')).toBe(false);
-    expect(check('@name@-example.com')).toBe(false);
-    expect(check('@name@example.-com')).toBe(false);
-    expect(check('@n_a_m_e_@sharp-#-sharp.com')).toBe(false);
-    expect(check('@query@?.com')).toBe(false);
-    expect(check('@name@日本語example.com')).toBe(false);
+  it.each([
+    '@@',
+    '@_name_@example.com',
+    '@name@domain@what',
+    'what@name@domain',
+    '@name@example.',
+    '@name@.example.com',
+    '@name@example-.com',
+    '@name@example.com-',
+    '@name@-example.com',
+    '@name@example.-com',
+    '@n_a_m_e_@sharp-#-sharp.com',
+    '@query@?.com',
+    '@name@日本語example.com',
+  ])('invalid account name: %s', (name) => {
+    expect(check(name)).toBe(false);
   });
 });

--- a/pkg/accounts/model/account.test.ts
+++ b/pkg/accounts/model/account.test.ts
@@ -11,7 +11,7 @@ import {
 
 const exampleInput: CreateAccountArgs = {
   id: '1' as AccountID,
-  bio: 'this is john doe"s account!',
+  bio: "this is john doe's account!",
   createdAt: new Date('2023-09-10T00:00:00.000Z'),
   mail: 'test@mail.example.com',
   nickname: 'John Doe',

--- a/pkg/accounts/model/account.test.ts
+++ b/pkg/accounts/model/account.test.ts
@@ -1,4 +1,5 @@
 import { Result } from '@mikuroxina/mini-fn';
+import * as v from 'valibot';
 import { describe, expect, it } from 'vitest';
 
 import {
@@ -82,7 +83,8 @@ describe('Account', () => {
 });
 
 describe('AccountNameSchema', () => {
-  const check = (v: unknown) => AccountNameSchema.safeParse(v).success;
+  const check = (input: unknown) =>
+    v.safeParse(AccountNameSchema, input).success;
 
   const account = Account.new(exampleInput);
 

--- a/pkg/accounts/model/account.ts
+++ b/pkg/accounts/model/account.ts
@@ -1,5 +1,6 @@
-import { z } from '@hono/zod-openapi';
 import { Result } from '@mikuroxina/mini-fn';
+import * as v from 'valibot';
+
 import type { ID } from '../../id/type.js';
 import {
   AccountAlreadyDeletedError,
@@ -16,38 +17,36 @@ export type AccountStatus = 'active' | 'notActivated';
 export type AccountFrozen = 'frozen' | 'normal';
 export type AccountSilenced = 'silenced' | 'normal';
 
-export const AccountNameSchema = z
-  .string()
-  .refine((s) => {
+export const AccountNameSchema = v.pipe(
+  v.string(),
+  v.check((s) => {
     const parts = s.split('@');
 
-    // check. @ 区切りで 3 つの文字列に区切ることが出来る
+    // must split into exactly 3 parts by "@"
     if (!((p): p is [string, string, string] => p.length === 3)(parts)) {
       return false;
     }
 
     const [head, name, domain] = parts;
 
-    // check. 最初の文字は @, 最初の @ の手前は空文字
+    // must start with "@": nothing before the first "@"
     if (head.length !== 0) {
       return false;
     }
 
-    // check. 名前は a-z A-Z 0-9 - _ . のみ許容
-    //        但し 1 文字以上, 最初の文字は記号非許容
+    // username: a-z A-Z 0-9 - _ . only; at least 1 char; must start with alphanumeric
     if (!/^[a-zA-Z0-9][\w\-.]*$/.test(name)) {
       return false;
     }
 
     // ref. RFC1035 https://www.rfc-editor.org/rfc/rfc1035#page-8
     //
-    // check. ドメイン名は RFC1035 より "<subdomain>" を参照, 空白は許容しない
-    //        ここでは文字種の検証のみ
+    // domain: follows RFC1035 "<subdomain>"; no whitespace; character set only
     if (!/^[a-zA-Z0-9\-.]+$/.test(domain)) {
       return false;
     }
 
-    // check. RFC1035 より "<label>" を参照
+    // each label follows RFC1035 "<label>"
     for (const label of domain.split('.')) {
       if (!/^[a-zA-Z](?:.*[a-zA-Z0-9])?$/.test(label)) {
         return false;
@@ -55,8 +54,22 @@ export const AccountNameSchema = z
     }
 
     return true;
-  })
-  .transform((s) => s as AccountName);
+  }),
+  v.transform((s) => s as AccountName),
+);
+
+const graphemeLength = (s: string): number =>
+  [...new Intl.Segmenter().segment(s)].length;
+
+const nicknameSchema = v.pipe(
+  v.string(),
+  v.check((s) => graphemeLength(s) <= 256),
+);
+
+const bioSchema = v.pipe(
+  v.string(),
+  v.check((s) => graphemeLength(s) <= 1024),
+);
 
 export interface CreateAccountArgs {
   id: AccountID;
@@ -199,7 +212,7 @@ export class Account {
       );
     }
 
-    if ([...name].length > 256) {
+    if (!v.safeParse(nicknameSchema, name).success) {
       return Result.err(
         new AccountNickNameLengthError('nickname length is too long'),
       );
@@ -249,7 +262,7 @@ export class Account {
       );
     }
 
-    if ([...bio].length > 1024) {
+    if (!v.safeParse(bioSchema, bio).success) {
       return Result.err(new AccountBioLengthError('bio is too long'));
     }
     this.#bio = bio;

--- a/pkg/accounts/model/account.ts
+++ b/pkg/accounts/model/account.ts
@@ -76,59 +76,123 @@ export interface CreateAccountArgs {
 
 export class Account {
   private constructor(arg: CreateAccountArgs) {
-    this.id = arg.id;
-    this.name = arg.name;
-    this.mail = arg.mail;
-    this.nickname = arg.nickname;
-    this.passphraseHash = arg.passphraseHash;
-    this.bio = arg.bio;
-    this.role = arg.role;
-    this.status = arg.status;
-    this.frozen = arg.frozen;
-    this.silenced = arg.silenced;
-    this.createdAt = arg.createdAt;
-    this.updatedAt = arg.updatedAt;
-    this.deletedAt = arg.deletedAt;
+    this.#id = arg.id;
+    this.#name = arg.name;
+    this.#mail = arg.mail;
+    this.#nickname = arg.nickname;
+    this.#passphraseHash = arg.passphraseHash;
+    this.#bio = arg.bio;
+    this.#role = arg.role;
+    this.#status = arg.status;
+    this.#frozen = arg.frozen;
+    this.#silenced = arg.silenced;
+    this.#createdAt = arg.createdAt;
+    this.#updatedAt = arg.updatedAt;
+    this.#deletedAt = arg.deletedAt;
   }
 
-  // 不変
-  private readonly id: AccountID;
+  readonly #id: AccountID;
+  readonly #name: AccountName;
+  readonly #createdAt: Date;
+  #nickname: string;
+  #bio: string;
+  #mail: string;
+  #frozen: AccountFrozen;
+  #role: AccountRole;
+  #passphraseHash?: string;
+  #silenced: AccountSilenced;
+  #status: AccountStatus;
+  #updatedAt?: Date;
+  #deletedAt?: Date;
+
+  // get methods
   getID(): AccountID {
-    return this.id;
+    return this.#id;
   }
 
-  private readonly name: AccountName;
   getName(): AccountName {
-    return this.name;
+    return this.#name;
   }
 
-  private readonly createdAt: Date;
   getCreatedAt(): Date {
-    return this.createdAt;
+    return this.#createdAt;
   }
 
-  // 可変
-  private mail: string;
   getMail(): string {
-    return this.mail;
+    return this.#mail;
   }
-  public setMail(mail: string) {
-    if (this.isDeleted()) {
+
+  getNickname(): string {
+    return this.#nickname;
+  }
+
+  getPassphraseHash(): string | undefined {
+    return this.#passphraseHash;
+  }
+
+  getBio(): string {
+    return this.#bio;
+  }
+
+  getRole(): AccountRole {
+    return this.#role;
+  }
+
+  /**
+   * @deprecated Use isFrozen() instead
+   */
+  getFrozen(): AccountFrozen {
+    return this.#frozen;
+  }
+
+  isFrozen(): boolean {
+    return this.#frozen === 'frozen';
+  }
+
+  /**
+   * @deprecated Use isSilenced() instead
+   */
+  getSilenced(): AccountSilenced {
+    return this.#silenced;
+  }
+
+  isSilenced(): boolean {
+    return this.#silenced === 'silenced';
+  }
+
+  /**
+   * @deprecated Use isActivated() instead
+   */
+  getStatus(): AccountStatus {
+    return this.#status;
+  }
+
+  isActivated(): boolean {
+    return this.#status === 'active';
+  }
+
+  getUpdatedAt(): Date | undefined {
+    return this.#updatedAt;
+  }
+
+  getDeletedAt(): Date | undefined {
+    return this.#deletedAt;
+  }
+
+  // mutation methods
+  setMail(mail: string) {
+    if (this.#isDeleted()) {
       throw new AccountAlreadyDeletedError('account already deleted');
     }
     if (this.isFrozen()) {
       throw new AccountAlreadyFrozenError('account already frozen');
     }
 
-    this.mail = mail;
+    this.#mail = mail;
   }
 
-  private nickname: string;
-  getNickname(): string {
-    return this.nickname;
-  }
-  public setNickName(name: string) {
-    if (this.isDeleted()) {
+  setNickName(name: string) {
+    if (this.#isDeleted()) {
       throw new AccountAlreadyDeletedError('account already deleted');
     }
     if (this.isFrozen()) {
@@ -138,30 +202,22 @@ export class Account {
     if ([...name].length > 256) {
       throw new AccountNickNameLengthError('nickname length is too long');
     }
-    this.nickname = name;
+    this.#nickname = name;
   }
 
-  private passphraseHash?: string;
-  getPassphraseHash(): string | undefined {
-    return this.passphraseHash;
-  }
-  public setPassphraseHash(hash: string) {
-    if (this.isDeleted()) {
+  setPassphraseHash(hash: string) {
+    if (this.#isDeleted()) {
       throw new AccountAlreadyDeletedError('account already deleted');
     }
     if (this.isFrozen()) {
       throw new AccountAlreadyFrozenError('account already frozen');
     }
 
-    this.passphraseHash = hash;
+    this.#passphraseHash = hash;
   }
 
-  private bio: string;
-  getBio(): string {
-    return this.bio;
-  }
-  public setBio(bio: string) {
-    if (this.isDeleted()) {
+  setBio(bio: string) {
+    if (this.#isDeleted()) {
       throw new AccountAlreadyDeletedError('account already deleted');
     }
     if (this.isFrozen()) {
@@ -171,154 +227,105 @@ export class Account {
     if ([...bio].length > 1024) {
       throw new AccountBioLengthError('bio is too long');
     }
-    this.bio = bio;
+    this.#bio = bio;
   }
 
-  private role: AccountRole;
-  getRole(): AccountRole {
-    return this.role;
-  }
-  public toAdmin() {
-    if (this.isDeleted()) {
+  toAdmin() {
+    if (this.#isDeleted()) {
       throw new AccountAlreadyDeletedError('account already deleted');
     }
     if (this.isFrozen()) {
       throw new AccountAlreadyFrozenError('account already frozen');
     }
 
-    this.role = 'admin';
+    this.#role = 'admin';
   }
-  public toNormal() {
-    if (this.isDeleted()) {
+  toNormal() {
+    if (this.#isDeleted()) {
       throw new AccountAlreadyDeletedError('account already deleted');
     }
     if (this.isFrozen()) {
       throw new AccountAlreadyFrozenError('account already frozen');
     }
 
-    this.role = 'normal';
+    this.#role = 'normal';
   }
-  public toModerator() {
-    if (this.isDeleted()) {
+  toModerator() {
+    if (this.#isDeleted()) {
       throw new AccountAlreadyDeletedError('account already deleted');
     }
     if (this.isFrozen()) {
       throw new AccountAlreadyFrozenError('account already frozen');
     }
 
-    this.role = 'moderator';
+    this.#role = 'moderator';
   }
 
-  private frozen: AccountFrozen;
-
-  /**
-   * @deprecated Use isFrozen() instead
-   */
-  getFrozen(): AccountFrozen {
-    return this.frozen;
-  }
-  isFrozen(): boolean {
-    return this.frozen === 'frozen';
-  }
-
-  public setFreeze() {
-    if (this.isDeleted()) {
+  setFreeze() {
+    if (this.#isDeleted()) {
       throw new AccountAlreadyDeletedError('account already deleted');
     }
 
-    this.frozen = 'frozen';
+    this.#frozen = 'frozen';
   }
 
-  public setUnfreeze() {
-    if (this.isDeleted()) {
+  setUnfreeze() {
+    if (this.#isDeleted()) {
       throw new AccountAlreadyDeletedError('account already deleted');
     }
-    this.frozen = 'normal';
+    this.#frozen = 'normal';
   }
 
-  private silenced: AccountSilenced;
-
-  /**
-   * @deprecated Use isSilenced() instead
-   */
-  getSilenced(): AccountSilenced {
-    return this.silenced;
-  }
-  isSilenced(): boolean {
-    return this.silenced === 'silenced';
-  }
-
-  public setSilence() {
-    if (this.isDeleted()) {
+  setSilence() {
+    if (this.#isDeleted()) {
       throw new AccountAlreadyDeletedError('account already deleted');
     }
     if (this.isFrozen()) {
       throw new AccountAlreadyFrozenError('account already frozen');
     }
 
-    this.silenced = 'silenced';
+    this.#silenced = 'silenced';
   }
-  public undoSilence() {
-    if (this.isDeleted()) {
+  undoSilence() {
+    if (this.#isDeleted()) {
       throw new AccountAlreadyDeletedError('account already deleted');
     }
     if (this.isFrozen()) {
       throw new AccountAlreadyFrozenError('account already frozen');
     }
 
-    this.silenced = 'normal';
+    this.#silenced = 'normal';
   }
 
-  private status: AccountStatus;
-
-  /**
-   * @deprecated Use isActivated() instead
-   */
-  getStatus(): AccountStatus {
-    return this.status;
-  }
-
-  isActivated(): boolean {
-    return this.status === 'active';
-  }
-
-  public activate() {
-    if (this.isDeleted()) {
+  activate() {
+    if (this.#isDeleted()) {
       throw new AccountAlreadyDeletedError('account already deleted');
     }
     if (this.isFrozen()) {
       throw new AccountAlreadyFrozenError('account already frozen');
     }
-    this.status = 'active';
+    this.#status = 'active';
   }
 
-  private updatedAt?: Date;
-  getUpdatedAt(): Date | undefined {
-    return this.updatedAt;
-  }
-  public setUpdatedAt(at: Date) {
-    if (this.createdAt > at) {
+  setUpdatedAt(at: Date) {
+    if (this.#createdAt > at) {
       throw new AccountDateInvalidError('updatedAt must be after createdAt');
     }
-    this.updatedAt = at;
+    this.#updatedAt = at;
   }
 
-  private deletedAt?: Date;
-  getDeletedAt(): Date | undefined {
-    return this.deletedAt;
-  }
-  public setDeletedAt(at: Date) {
-    if (this.createdAt > at) {
+  setDeletedAt(at: Date) {
+    if (this.#createdAt > at) {
       throw new AccountDateInvalidError('deletedAt must be after createdAt');
     }
-    this.deletedAt = at;
+    this.#deletedAt = at;
   }
 
-  private isDeleted(): boolean {
-    return this.deletedAt !== undefined;
+  #isDeleted(): boolean {
+    return this.#deletedAt !== undefined;
   }
 
-  public static new(arg: Omit<CreateAccountArgs, 'deletedAt' | 'updatedAt'>) {
+  static new(arg: Omit<CreateAccountArgs, 'deletedAt' | 'updatedAt'>) {
     return new Account({
       id: arg.id,
       mail: arg.mail,
@@ -336,7 +343,7 @@ export class Account {
     });
   }
 
-  public static reconstruct(arg: CreateAccountArgs) {
+  static reconstruct(arg: CreateAccountArgs) {
     return new Account(arg);
   }
 }

--- a/pkg/accounts/model/account.ts
+++ b/pkg/accounts/model/account.ts
@@ -58,8 +58,8 @@ export const AccountNameSchema = v.pipe(
   v.transform((s) => s as AccountName),
 );
 
-const graphemeLength = (s: string): number =>
-  [...new Intl.Segmenter().segment(s)].length;
+const segmenter = new Intl.Segmenter();
+const graphemeLength = (s: string): number => [...segmenter.segment(s)].length;
 
 const nicknameSchema = v.pipe(
   v.string(),

--- a/pkg/accounts/model/account.ts
+++ b/pkg/accounts/model/account.ts
@@ -138,33 +138,12 @@ export class Account {
     return this.#role;
   }
 
-  /**
-   * @deprecated Use isFrozen() instead
-   */
-  getFrozen(): AccountFrozen {
-    return this.#frozen;
-  }
-
   isFrozen(): boolean {
     return this.#frozen === 'frozen';
   }
 
-  /**
-   * @deprecated Use isSilenced() instead
-   */
-  getSilenced(): AccountSilenced {
-    return this.#silenced;
-  }
-
   isSilenced(): boolean {
     return this.#silenced === 'silenced';
-  }
-
-  /**
-   * @deprecated Use isActivated() instead
-   */
-  getStatus(): AccountStatus {
-    return this.#status;
   }
 
   isActivated(): boolean {

--- a/pkg/accounts/model/account.ts
+++ b/pkg/accounts/model/account.ts
@@ -1,5 +1,5 @@
 import { z } from '@hono/zod-openapi';
-
+import { Result } from '@mikuroxina/mini-fn';
 import type { ID } from '../../id/type.js';
 import {
   AccountAlreadyDeletedError,
@@ -159,145 +159,275 @@ export class Account {
   }
 
   // mutation methods
-  setMail(mail: string) {
+  setMail(
+    mail: string,
+  ): Result.Result<
+    AccountAlreadyDeletedError | AccountAlreadyFrozenError,
+    void
+  > {
     if (this.#isDeleted()) {
-      throw new AccountAlreadyDeletedError('account already deleted');
+      return Result.err(
+        new AccountAlreadyDeletedError('account already deleted'),
+      );
     }
     if (this.isFrozen()) {
-      throw new AccountAlreadyFrozenError('account already frozen');
+      return Result.err(
+        new AccountAlreadyFrozenError('account already frozen'),
+      );
     }
 
     this.#mail = mail;
+    return Result.ok(undefined);
   }
 
-  setNickName(name: string) {
+  setNickName(
+    name: string,
+  ): Result.Result<
+    | AccountAlreadyDeletedError
+    | AccountAlreadyFrozenError
+    | AccountNickNameLengthError,
+    void
+  > {
     if (this.#isDeleted()) {
-      throw new AccountAlreadyDeletedError('account already deleted');
+      return Result.err(
+        new AccountAlreadyDeletedError('account already deleted'),
+      );
     }
     if (this.isFrozen()) {
-      throw new AccountAlreadyFrozenError('account already frozen');
+      return Result.err(
+        new AccountAlreadyFrozenError('account already frozen'),
+      );
     }
 
     if ([...name].length > 256) {
-      throw new AccountNickNameLengthError('nickname length is too long');
+      return Result.err(
+        new AccountNickNameLengthError('nickname length is too long'),
+      );
     }
+
     this.#nickname = name;
+    return Result.ok(undefined);
   }
 
-  setPassphraseHash(hash: string) {
+  setPassphraseHash(
+    hash: string,
+  ): Result.Result<
+    AccountAlreadyDeletedError | AccountAlreadyFrozenError,
+    void
+  > {
     if (this.#isDeleted()) {
-      throw new AccountAlreadyDeletedError('account already deleted');
+      return Result.err(
+        new AccountAlreadyDeletedError('account already deleted'),
+      );
     }
     if (this.isFrozen()) {
-      throw new AccountAlreadyFrozenError('account already frozen');
+      return Result.err(
+        new AccountAlreadyFrozenError('account already frozen'),
+      );
     }
 
     this.#passphraseHash = hash;
+    return Result.ok(undefined);
   }
 
-  setBio(bio: string) {
+  setBio(
+    bio: string,
+  ): Result.Result<
+    | AccountAlreadyDeletedError
+    | AccountAlreadyFrozenError
+    | AccountBioLengthError,
+    void
+  > {
     if (this.#isDeleted()) {
-      throw new AccountAlreadyDeletedError('account already deleted');
+      return Result.err(
+        new AccountAlreadyDeletedError('account already deleted'),
+      );
     }
     if (this.isFrozen()) {
-      throw new AccountAlreadyFrozenError('account already frozen');
+      return Result.err(
+        new AccountAlreadyFrozenError('account already frozen'),
+      );
     }
 
     if ([...bio].length > 1024) {
-      throw new AccountBioLengthError('bio is too long');
+      return Result.err(new AccountBioLengthError('bio is too long'));
     }
     this.#bio = bio;
+    return Result.ok(undefined);
   }
 
-  toAdmin() {
+  toAdmin(): Result.Result<
+    AccountAlreadyDeletedError | AccountAlreadyFrozenError,
+    void
+  > {
     if (this.#isDeleted()) {
-      throw new AccountAlreadyDeletedError('account already deleted');
+      return Result.err(
+        new AccountAlreadyDeletedError('account already deleted'),
+      );
     }
     if (this.isFrozen()) {
-      throw new AccountAlreadyFrozenError('account already frozen');
+      return Result.err(
+        new AccountAlreadyFrozenError('account already frozen'),
+      );
     }
 
     this.#role = 'admin';
+    return Result.ok(undefined);
   }
-  toNormal() {
+  toNormal(): Result.Result<
+    AccountAlreadyDeletedError | AccountAlreadyFrozenError,
+    void
+  > {
     if (this.#isDeleted()) {
-      throw new AccountAlreadyDeletedError('account already deleted');
+      return Result.err(
+        new AccountAlreadyDeletedError('account already deleted'),
+      );
     }
     if (this.isFrozen()) {
-      throw new AccountAlreadyFrozenError('account already frozen');
+      return Result.err(
+        new AccountAlreadyFrozenError('account already frozen'),
+      );
     }
 
     this.#role = 'normal';
+    return Result.ok(undefined);
   }
-  toModerator() {
+  toModerator(): Result.Result<
+    AccountAlreadyDeletedError | AccountAlreadyFrozenError,
+    void
+  > {
     if (this.#isDeleted()) {
-      throw new AccountAlreadyDeletedError('account already deleted');
+      return Result.err(
+        new AccountAlreadyDeletedError('account already deleted'),
+      );
     }
     if (this.isFrozen()) {
-      throw new AccountAlreadyFrozenError('account already frozen');
+      return Result.err(
+        new AccountAlreadyFrozenError('account already frozen'),
+      );
     }
 
     this.#role = 'moderator';
+    return Result.ok(undefined);
   }
 
-  setFreeze() {
+  setFreeze(): Result.Result<
+    AccountAlreadyDeletedError | AccountAlreadyFrozenError,
+    void
+  > {
     if (this.#isDeleted()) {
-      throw new AccountAlreadyDeletedError('account already deleted');
+      return Result.err(
+        new AccountAlreadyDeletedError('account already deleted'),
+      );
     }
 
     this.#frozen = 'frozen';
+    return Result.ok(undefined);
   }
 
-  setUnfreeze() {
+  setUnfreeze(): Result.Result<
+    AccountAlreadyDeletedError | AccountAlreadyFrozenError,
+    void
+  > {
     if (this.#isDeleted()) {
-      throw new AccountAlreadyDeletedError('account already deleted');
+      return Result.err(
+        new AccountAlreadyDeletedError('account already deleted'),
+      );
     }
     this.#frozen = 'normal';
+    return Result.ok(undefined);
   }
 
-  setSilence() {
+  setSilence(): Result.Result<
+    AccountAlreadyDeletedError | AccountAlreadyFrozenError,
+    void
+  > {
     if (this.#isDeleted()) {
-      throw new AccountAlreadyDeletedError('account already deleted');
+      return Result.err(
+        new AccountAlreadyDeletedError('account already deleted'),
+      );
     }
     if (this.isFrozen()) {
-      throw new AccountAlreadyFrozenError('account already frozen');
+      return Result.err(
+        new AccountAlreadyFrozenError('account already frozen'),
+      );
     }
 
     this.#silenced = 'silenced';
+    return Result.ok(undefined);
   }
-  undoSilence() {
+  undoSilence(): Result.Result<
+    AccountAlreadyDeletedError | AccountAlreadyFrozenError,
+    void
+  > {
     if (this.#isDeleted()) {
-      throw new AccountAlreadyDeletedError('account already deleted');
+      return Result.err(
+        new AccountAlreadyDeletedError('account already deleted'),
+      );
     }
     if (this.isFrozen()) {
-      throw new AccountAlreadyFrozenError('account already frozen');
+      return Result.err(
+        new AccountAlreadyFrozenError('account already frozen'),
+      );
     }
 
     this.#silenced = 'normal';
+    return Result.ok(undefined);
   }
 
-  activate() {
+  activate(): Result.Result<
+    AccountAlreadyDeletedError | AccountAlreadyFrozenError,
+    void
+  > {
     if (this.#isDeleted()) {
-      throw new AccountAlreadyDeletedError('account already deleted');
+      return Result.err(
+        new AccountAlreadyDeletedError('account already deleted'),
+      );
     }
     if (this.isFrozen()) {
-      throw new AccountAlreadyFrozenError('account already frozen');
+      return Result.err(
+        new AccountAlreadyFrozenError('account already frozen'),
+      );
     }
     this.#status = 'active';
+    return Result.ok(undefined);
   }
 
-  setUpdatedAt(at: Date) {
+  setUpdatedAt(
+    at: Date,
+  ): Result.Result<
+    | AccountAlreadyDeletedError
+    | AccountAlreadyFrozenError
+    | AccountDateInvalidError,
+    void
+  > {
+    if (this.#isDeleted()) {
+      return Result.err(
+        new AccountAlreadyDeletedError('account already deleted'),
+      );
+    }
+    if (this.isFrozen()) {
+      return Result.err(
+        new AccountAlreadyFrozenError('account already frozen'),
+      );
+    }
     if (this.#createdAt > at) {
-      throw new AccountDateInvalidError('updatedAt must be after createdAt');
+      return Result.err(
+        new AccountDateInvalidError('updatedAt must be after createdAt'),
+      );
     }
     this.#updatedAt = at;
+    return Result.ok(undefined);
   }
 
-  setDeletedAt(at: Date) {
+  setDeletedAt(at: Date): Result.Result<AccountDateInvalidError, void> {
     if (this.#createdAt > at) {
-      throw new AccountDateInvalidError('deletedAt must be after createdAt');
+      return Result.err(
+        new AccountDateInvalidError('deletedAt must be after createdAt'),
+      );
     }
     this.#deletedAt = at;
+    return Result.ok(undefined);
   }
 
   #isDeleted(): boolean {

--- a/pkg/accounts/service/edit.ts
+++ b/pkg/accounts/service/edit.ts
@@ -208,7 +208,6 @@ export class EditService {
       return Result.err(new Error('not allowed'));
     }
 
-    // ToDo(laminne): bio length check
     const setResult = account.setBio(bio);
     if (Result.isErr(setResult)) {
       return setResult;

--- a/pkg/accounts/service/edit.ts
+++ b/pkg/accounts/service/edit.ts
@@ -66,19 +66,15 @@ export class EditService {
       );
     }
 
-    try {
-      account.setNickName(nickname);
-      const res = await this.accountRepository.edit(account);
-      if (Result.isErr(res)) {
-        return res;
-      }
-
-      return Result.ok(true);
-    } catch (e) {
-      return Result.err(
-        new AccountInternalError('failed to update account', { cause: e }),
-      );
+    const setResult = account.setNickName(nickname);
+    if (Result.isErr(setResult)) {
+      return setResult;
     }
+    const editResult = await this.accountRepository.edit(account);
+    if (Result.isErr(editResult)) {
+      return editResult;
+    }
+    return Result.ok(true);
   }
 
   async editPassphrase(
@@ -120,22 +116,24 @@ export class EditService {
       );
     }
 
+    let encoded: string;
     try {
-      account.setPassphraseHash(
-        await this.passwordEncoder.encodePassword(newPassphrase),
-      );
-
-      const res = await this.accountRepository.edit(account);
-      if (Result.isErr(res)) {
-        return res;
-      }
-
-      return Result.ok(true);
+      encoded = await this.passwordEncoder.encodePassword(newPassphrase);
     } catch (e) {
       return Result.err(
-        new AccountInternalError('failed to update account', { cause: e }),
+        new AccountInternalError('failed to encode passphrase', { cause: e }),
       );
     }
+
+    const setResult = account.setPassphraseHash(encoded);
+    if (Result.isErr(setResult)) {
+      return setResult;
+    }
+    const editResult = await this.accountRepository.edit(account);
+    if (Result.isErr(editResult)) {
+      return editResult;
+    }
+    return Result.ok(true);
   }
 
   async editEmail(
@@ -175,20 +173,15 @@ export class EditService {
 
     // TODO: add a process to check the email is active
 
-    try {
-      account.setMail(newEmail);
-
-      const res = await this.accountRepository.edit(account);
-      if (Result.isErr(res)) {
-        return res;
-      }
-
-      return Result.ok(true);
-    } catch (e) {
-      return Result.err(
-        new AccountInternalError('failed to update account', { cause: e }),
-      );
+    const setResult = account.setMail(newEmail);
+    if (Result.isErr(setResult)) {
+      return setResult;
     }
+    const editResult = await this.accountRepository.edit(account);
+    if (Result.isErr(editResult)) {
+      return editResult;
+    }
+    return Result.ok(true);
   }
 
   async editBio(
@@ -216,20 +209,15 @@ export class EditService {
     }
 
     // ToDo(laminne): bio length check
-    try {
-      account.setBio(bio);
-
-      const res = await this.accountRepository.edit(account);
-      if (Result.isErr(res)) {
-        return res;
-      }
-
-      return Result.ok(true);
-    } catch (e) {
-      return Result.err(
-        new AccountInternalError('failed to update account', { cause: e }),
-      );
+    const setResult = account.setBio(bio);
+    if (Result.isErr(setResult)) {
+      return setResult;
     }
+    const editResult = await this.accountRepository.edit(account);
+    if (Result.isErr(editResult)) {
+      return editResult;
+    }
+    return Result.ok(true);
   }
 
   private isAllowed(

--- a/pkg/accounts/service/edit.ts
+++ b/pkg/accounts/service/edit.ts
@@ -240,10 +240,7 @@ export class EditService {
     switch (action) {
       case 'edit':
         // NOTE: Frozen account or notActivated account can't edit account information
-        if (
-          actor.getFrozen() === 'frozen' ||
-          actor.getStatus() === 'notActivated'
-        ) {
+        if (actor.isFrozen() || !actor.isActivated()) {
           return false;
         }
 

--- a/pkg/accounts/service/fetch.test.ts
+++ b/pkg/accounts/service/fetch.test.ts
@@ -61,9 +61,9 @@ describe('FetchService', () => {
     expect(account[1].getPassphraseHash()).toBe('hash');
     expect(account[1].getBio()).toBe('');
     expect(account[1].getRole()).toBe('normal');
-    expect(account[1].getFrozen()).toBe('normal');
-    expect(account[1].getSilenced()).toBe('normal');
-    expect(account[1].getStatus()).toBe('notActivated');
+    expect(account[1].isFrozen()).toBe(false);
+    expect(account[1].isSilenced()).toBe(false);
+    expect(account[1].isActivated()).toBe(false);
     expect(account[1].getCreatedAt()).toBeInstanceOf(Date);
   });
 

--- a/pkg/accounts/service/fetch.ts
+++ b/pkg/accounts/service/fetch.ts
@@ -22,12 +22,7 @@ export class FetchService {
       );
     }
 
-    try {
-      const account = Option.unwrap(res);
-      return Result.ok(account);
-    } catch (e) {
-      return Result.err(e as unknown as Error);
-    }
+    return Result.ok(Option.unwrap(res));
   }
 
   async fetchAccountByID(

--- a/pkg/accounts/service/freeze.test.ts
+++ b/pkg/accounts/service/freeze.test.ts
@@ -90,8 +90,7 @@ describe('FreezeService', () => {
 
     await freezeService.setFreeze('@john@example.com', '@alice@example.com');
 
-    expect(account.getFrozen()).toBe('frozen');
-    expect(account.getFrozen()).not.toBe('normal');
+    expect(account.isFrozen()).toBe(true);
   });
 
   it('unset account freeze', async () => {
@@ -103,8 +102,7 @@ describe('FreezeService', () => {
       await repository.findByName('@john@example.com'),
     );
 
-    expect(account.getFrozen()).toBe('normal');
-    expect(account.getFrozen()).not.toBe('frozen');
+    expect(account.isFrozen()).toBe(false);
   });
 
   describe('permission check', () => {
@@ -121,7 +119,7 @@ describe('FreezeService', () => {
 
       expect(Result.isErr(result)).toBe(true);
       expect(result[1]).toStrictEqual(new Error('not allowed'));
-      expect(account.getFrozen()).toBe('normal');
+      expect(account.isFrozen()).toBe(false);
     });
 
     it('cannot freeze/unFreeze if actor is not admin or moderator', async () => {

--- a/pkg/accounts/service/freeze.ts
+++ b/pkg/accounts/service/freeze.ts
@@ -33,12 +33,11 @@ export class FreezeService {
       return Result.err(new Error('not allowed'));
     }
 
-    try {
-      account.setFreeze();
-      return Result.ok(true);
-    } catch (e) {
-      return Result.err(e as unknown as Error);
+    const setResult = account.setFreeze();
+    if (Result.isErr(setResult)) {
+      return setResult;
     }
+    return Result.ok(true);
   }
 
   async undoFreeze(
@@ -64,12 +63,11 @@ export class FreezeService {
       return Result.err(new Error('not allowed'));
     }
 
-    try {
-      account.setUnfreeze();
-      return Result.ok(true);
-    } catch (e) {
-      return Result.err(e as unknown as Error);
+    const setResult = account.setUnfreeze();
+    if (Result.isErr(setResult)) {
+      return setResult;
     }
+    return Result.ok(true);
   }
 
   private isAllowed(

--- a/pkg/accounts/service/freeze.ts
+++ b/pkg/accounts/service/freeze.ts
@@ -85,7 +85,7 @@ export class FreezeService {
         }
 
         // NOTE: actor must be active, not frozen
-        if (actor.getStatus() !== 'active' || actor.getFrozen() !== 'normal') {
+        if (!actor.isActivated() || actor.isFrozen()) {
           return false;
         }
 
@@ -110,7 +110,7 @@ export class FreezeService {
         }
 
         // NOTE: actor must be active, not frozen
-        if (actor.getStatus() !== 'active' || actor.getFrozen() !== 'normal') {
+        if (!actor.isActivated() || actor.isFrozen()) {
           return false;
         }
 

--- a/pkg/accounts/service/register.test.ts
+++ b/pkg/accounts/service/register.test.ts
@@ -53,7 +53,7 @@ describe('RegisterService', () => {
     expect(res[1].getNickname()).toBe(exampleInput.nickname);
     expect(res[1].getBio()).toBe(exampleInput.bio);
     expect(res[1].getRole()).toBe(exampleInput.role);
-    expect(res[1].getStatus()).toBe('notActivated');
+    expect(res[1].isActivated()).toBe(false);
     repository.reset();
   });
 });

--- a/pkg/accounts/service/resendToken.ts
+++ b/pkg/accounts/service/resendToken.ts
@@ -41,7 +41,7 @@ export class ResendVerifyTokenService {
     }
     const account = Option.unwrap(accountRes);
 
-    if (account.getStatus() !== 'notActivated') {
+    if (account.isActivated()) {
       return Option.some(
         new AccountMailAddressAlreadyVerifiedError('account already verified', {
           cause: null,

--- a/pkg/accounts/service/silence.test.ts
+++ b/pkg/accounts/service/silence.test.ts
@@ -47,8 +47,7 @@ describe('SilenceService', () => {
 
     await silenceService.setSilence('@john@example.com', '@alice@example.com');
 
-    expect(account[1].getSilenced()).toBe('silenced');
-    expect(account[1].getSilenced()).not.toBe('normal');
+    expect(account[1].isSilenced()).toBe(true);
   });
 
   it('unset account silence', async () => {
@@ -57,7 +56,6 @@ describe('SilenceService', () => {
 
     await silenceService.undoSilence('@john@example.com', '@alice@example.com');
 
-    expect(account[1].getSilenced()).toBe('normal');
-    expect(account[1].getSilenced()).not.toBe('silenced');
+    expect(account[1].isSilenced()).toBe(false);
   });
 });

--- a/pkg/accounts/service/silence.ts
+++ b/pkg/accounts/service/silence.ts
@@ -91,7 +91,7 @@ export class SilenceService {
         }
 
         // NOTE: actor must be active, not frozen
-        if (actor.getStatus() !== 'active' || actor.getFrozen() !== 'normal') {
+        if (!actor.isActivated() || actor.isFrozen()) {
           return false;
         }
 
@@ -116,7 +116,7 @@ export class SilenceService {
         }
 
         // NOTE: actor must be active, not frozen
-        if (actor.getStatus() !== 'active' || actor.getFrozen() !== 'normal') {
+        if (!actor.isActivated() || actor.isFrozen()) {
           return false;
         }
 

--- a/pkg/accounts/service/silence.ts
+++ b/pkg/accounts/service/silence.ts
@@ -38,12 +38,11 @@ export class SilenceService {
       return Result.err(new Error('not allowed'));
     }
 
-    try {
-      account.setSilence();
-      return Result.ok(true);
-    } catch (e) {
-      return Result.err(e as unknown as Error);
+    const setResult = account.setSilence();
+    if (Result.isErr(setResult)) {
+      return setResult;
     }
+    return Result.ok(true);
   }
 
   async undoSilence(
@@ -70,12 +69,11 @@ export class SilenceService {
       return Result.err(new Error('not allowed'));
     }
 
-    try {
-      account.undoSilence();
-      return Result.ok(true);
-    } catch (e) {
-      return Result.err(e as unknown as Error);
+    const setResult = account.undoSilence();
+    if (Result.isErr(setResult)) {
+      return setResult;
     }
+    return Result.ok(true);
   }
 
   private isAllowed(

--- a/pkg/notes/service/fetch.ts
+++ b/pkg/notes/service/fetch.ts
@@ -44,7 +44,7 @@ export class FetchService {
     }
 
     // if account frozen
-    if (account[1].getFrozen() === 'frozen') {
+    if (account[1].isFrozen()) {
       return Option.none();
     }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,7 +66,7 @@ importers:
         specifier: 4.10.2
         version: 4.10.2
       valibot:
-        specifier: ^1.4.0
+        specifier: 1.4.0
         version: 1.4.0(typescript@6.0.3)
       yaml:
         specifier: 2.8.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,9 @@ importers:
       tslog:
         specifier: 4.10.2
         version: 4.10.2
+      valibot:
+        specifier: ^1.4.0
+        version: 1.4.0(typescript@6.0.3)
       yaml:
         specifier: 2.8.4
         version: 2.8.4
@@ -1733,6 +1736,14 @@ packages:
       typescript:
         optional: true
 
+  valibot@1.4.0:
+    resolution: {integrity: sha512-iC/x7fVcSyOwlm/VSt7RlHnzNGLGvR9GnxdifUeWoCJo0q4ZZvrVkIHC6faTlkxG47I2Y4UrFquPuVHCrOnrLg==}
+    peerDependencies:
+      typescript: '>=5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   vite@7.3.1:
     resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -3187,6 +3198,10 @@ snapshots:
   undici-types@7.16.0: {}
 
   valibot@1.2.0(typescript@6.0.3):
+    optionalDependencies:
+      typescript: 6.0.3
+
+  valibot@1.4.0(typescript@6.0.3):
     optionalDependencies:
       typescript: 6.0.3
 


### PR DESCRIPTION
close #1602 

## What does this PR do?
Accountモデルの実装を見直しました
- 例外を返すメソッドはResultに置き換え
- `@deprecated`なメソッドを廃止，新しいものに置き換え
- メンバ変数/メソッドでハードプライベートを利用するように
- zodで書かれていたバリデーションスキーマをvalibotに移植，値の変更や生成時のチェックで使うように
- モデルのテストをテーブルテスト化し，複数のケースを書きやすくした

## Additional information

