### PR TITLE
refactor: InactiveAccount/AccountFollowの実装見直し

### DIFF
--- a/pkg/accounts/adaptor/repository/prisma/prisma.ts
+++ b/pkg/accounts/adaptor/repository/prisma/prisma.ts
@@ -416,7 +416,8 @@ export class PrismaAccountFollowRepository implements AccountFollowRepository {
       fromID: args.fromId as AccountID,
       targetID: args.toId as AccountID,
       createdAt: args.createdAt,
-      deletedAt: args.deletedAt === null ? undefined : args.deletedAt,
+      deletedAt:
+        args.deletedAt === null ? Option.none() : Option.some(args.deletedAt),
     });
   }
 }

--- a/pkg/accounts/model/follow.test.ts
+++ b/pkg/accounts/model/follow.test.ts
@@ -1,19 +1,18 @@
-import { Option } from '@mikuroxina/mini-fn';
+import { Option, Result } from '@mikuroxina/mini-fn';
 import { describe, expect, it } from 'vitest';
 
 import type { AccountID } from './account.js';
-import { AccountFollow, type CreateAccountFollowArgs } from './follow.js';
+import { AccountFollow } from './follow.js';
 
 describe('AccountFollow', () => {
   it('generate new instance', () => {
-    const exampleInput: CreateAccountFollowArgs = {
+    const exampleInput = {
       fromID: '1' as AccountID,
       targetID: '2' as AccountID,
       createdAt: new Date('2023-09-10T00:00:00.000Z'),
-      deletedAt: new Date('2023-09-10T10:00:00.000Z'),
     };
 
-    const follow = AccountFollow.new(exampleInput);
+    const follow = Result.unwrap(AccountFollow.new(exampleInput));
 
     expect(follow.getFromID()).toBe(exampleInput.fromID);
     expect(follow.getTargetID()).toBe(exampleInput.targetID);

--- a/pkg/accounts/model/follow.ts
+++ b/pkg/accounts/model/follow.ts
@@ -1,12 +1,21 @@
-import { Option } from '@mikuroxina/mini-fn';
+import { Option, Result } from '@mikuroxina/mini-fn';
 
 import type { AccountID } from './account.js';
 
-export interface CreateAccountFollowArgs {
+export interface AccountFollowConstructorArgs {
   fromID: AccountID;
   targetID: AccountID;
   createdAt: Date;
-  deletedAt?: Date;
+  deletedAt: Option.Option<Date>;
+}
+type AccountFollowArgs = Omit<AccountFollowConstructorArgs, 'deletedAt'>;
+
+export class AccountFollowDateInvalidError extends Error {
+  override readonly name = 'AccountFollowDateInvalidError' as const;
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.cause = options?.cause;
+  }
 }
 
 /*
@@ -16,58 +25,55 @@ export interface CreateAccountFollowArgs {
  *
  * */
 export class AccountFollow {
-  // 必要な情報: フォロー元のアカウントID, フォロー先のアカウントID, created, deleted
-  private constructor(args: CreateAccountFollowArgs) {
-    this.fromID = args.fromID;
-    this.targetID = args.targetID;
-    this.createdAt = args.createdAt;
-    if (!args.deletedAt) {
-      this.deletedAt = Option.none();
-      return;
-    }
-    if (args.deletedAt > args.createdAt) {
-      throw new Error('deletedAt must be later than createdAt');
-    }
+  readonly #fromID: AccountID;
+  readonly #targetID: AccountID;
+  readonly #createdAt: Date;
+  #deletedAt: Option.Option<Date>;
 
-    this.deletedAt = Option.some(args.deletedAt);
+  private constructor(args: AccountFollowConstructorArgs) {
+    this.#fromID = args.fromID;
+    this.#targetID = args.targetID;
+    this.#createdAt = args.createdAt;
+    this.#deletedAt = args.deletedAt;
   }
 
-  public static new(args: Omit<CreateAccountFollowArgs, 'deletedAt'>) {
-    return new AccountFollow({ ...args, deletedAt: undefined });
+  public static new(
+    args: AccountFollowArgs,
+  ): Result.Result<never, AccountFollow> {
+    return Result.ok(new AccountFollow({ ...args, deletedAt: Option.none() }));
   }
 
-  public static reconstruct(args: CreateAccountFollowArgs) {
+  public static reconstruct(args: AccountFollowConstructorArgs): AccountFollow {
     return new AccountFollow(args);
   }
 
-  private readonly fromID: AccountID;
-
-  public getFromID(): AccountID {
-    return this.fromID;
+  getFromID(): AccountID {
+    return this.#fromID;
   }
 
-  private readonly targetID: AccountID;
-
-  public getTargetID(): AccountID {
-    return this.targetID;
+  getTargetID(): AccountID {
+    return this.#targetID;
   }
 
-  private readonly createdAt: Date;
-
-  public getCreatedAt(): Date {
-    return this.createdAt;
+  getCreatedAt(): Date {
+    return this.#createdAt;
   }
 
-  private deletedAt: Option.Option<Date>;
-
-  public getDeletedAt(): Option.Option<Date> {
-    return this.deletedAt;
+  getDeletedAt(): Option.Option<Date> {
+    return this.#deletedAt;
   }
 
-  public setDeletedAt(deletedAt: Date) {
-    if (this.createdAt > deletedAt) {
-      throw new Error('deletedAt must be later than createdAt');
+  setDeletedAt(
+    deletedAt: Date,
+  ): Result.Result<AccountFollowDateInvalidError, void> {
+    if (this.#createdAt > deletedAt) {
+      return Result.err(
+        new AccountFollowDateInvalidError(
+          'deletedAt must be later than createdAt',
+        ),
+      );
     }
-    this.deletedAt = Option.some(deletedAt);
+    this.#deletedAt = Option.some(deletedAt);
+    return Result.ok(undefined);
   }
 }

--- a/pkg/accounts/model/inactiveAccount.test.ts
+++ b/pkg/accounts/model/inactiveAccount.test.ts
@@ -1,3 +1,4 @@
+import { Result } from '@mikuroxina/mini-fn';
 import { describe, expect, it } from 'vitest';
 
 import type { AccountID, CreateAccountArgs } from './account.js';
@@ -30,13 +31,15 @@ const exampleActivateArgs: CreateAccountArgs = {
 
 describe('InactiveAccount', () => {
   it('generate new instance', () => {
-    const account = InactiveAccount.new(exampleInput);
+    const account = Result.unwrap(InactiveAccount.new(exampleInput));
     expect(account.isActivated()).toBe(false);
   });
 
   it('activate account', () => {
-    const inactiveAccount = InactiveAccount.new(exampleInput);
-    const account = inactiveAccount.activate(exampleActivateArgs);
+    const inactiveAccount = Result.unwrap(InactiveAccount.new(exampleInput));
+    const account = Result.unwrap(
+      inactiveAccount.activate(exampleActivateArgs),
+    );
 
     expect(account.getID()).toBe(exampleInput.id);
     expect(account.getName()).toBe(exampleInput.name);
@@ -55,16 +58,15 @@ describe('InactiveAccount', () => {
   });
 
   it('already activated', () => {
-    const inactiveAccount = InactiveAccount.new(exampleInput);
+    const inactiveAccount = Result.unwrap(InactiveAccount.new(exampleInput));
     inactiveAccount.activate(exampleActivateArgs);
 
-    expect(() => {
-      inactiveAccount.activate(exampleActivateArgs);
-    }).toThrow();
+    const result = inactiveAccount.activate(exampleActivateArgs);
+    expect(Result.isErr(result)).toBe(true);
   });
 
   it('get account property', () => {
-    const account = InactiveAccount.new(exampleInput);
+    const account = Result.unwrap(InactiveAccount.new(exampleInput));
 
     expect(account.getID()).toBe(exampleInput.id);
     expect(account.getName()).toBe(exampleInput.name);

--- a/pkg/accounts/model/inactiveAccount.ts
+++ b/pkg/accounts/model/inactiveAccount.ts
@@ -1,3 +1,5 @@
+import { Result } from '@mikuroxina/mini-fn';
+
 import {
   Account,
   type AccountID,
@@ -16,55 +18,68 @@ export type ActivateArgs = Omit<
   keyof Omit<CreateInactiveAccountArgs, 'activated'>
 >;
 
-export class AlreadyActivatedError extends Error {
-  constructor(message = 'This account was already activated.') {
-    super(message);
+export class AccountAlreadyActivatedError extends Error {
+  override readonly name = 'AccountAlreadyActivatedError' as const;
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.cause = options?.cause;
   }
 }
 
 export class InactiveAccount {
   constructor(arg: CreateInactiveAccountArgs) {
-    this.id = arg.id;
-    this.name = arg.name;
-    this.mail = arg.mail;
-    this.activated = false;
+    this.#id = arg.id;
+    this.#name = arg.name;
+    this.#mail = arg.mail;
+    this.#activated = false;
   }
 
-  private activated: boolean;
+  #activated: boolean;
   isActivated(): boolean {
-    return this.activated;
+    return this.#activated;
   }
 
-  private readonly id: AccountID;
+  readonly #id: AccountID;
   getID(): string {
-    return this.id;
+    return this.#id;
   }
 
-  private readonly name: AccountName;
+  readonly #name: AccountName;
   getName(): string {
-    return this.name;
+    return this.#name;
   }
 
-  private readonly mail: string;
+  readonly #mail: string;
   getMail(): string {
-    return this.mail;
+    return this.#mail;
   }
 
-  public activate(args: ActivateArgs): Account {
+  public activate(
+    args: ActivateArgs,
+  ): Result.Result<AccountAlreadyActivatedError, Account> {
     if (this.isActivated()) {
-      throw new AlreadyActivatedError();
+      return Result.err(
+        new AccountAlreadyActivatedError('This account was already activated.'),
+      );
     }
 
-    this.activated = true;
-    return Account.new({
-      id: this.id,
-      name: this.name,
-      mail: this.mail,
-      ...args,
-    });
+    this.#activated = true;
+    return Result.ok(
+      Account.reconstruct({
+        id: this.#id,
+        name: this.#name,
+        mail: this.#mail,
+        ...args,
+        status: 'active',
+        updatedAt: undefined,
+        deletedAt: undefined,
+      }),
+    );
   }
 
-  static new(arg: CreateInactiveAccountArgs): InactiveAccount {
-    return new InactiveAccount(arg);
+  static new(
+    arg: CreateInactiveAccountArgs,
+  ): Result.Result<never, InactiveAccount> {
+    return Result.ok(new InactiveAccount(arg));
   }
 }

--- a/pkg/accounts/model/inactiveAccount.ts
+++ b/pkg/accounts/model/inactiveAccount.ts
@@ -54,7 +54,7 @@ export class InactiveAccount {
     return this.#mail;
   }
 
-  public activate(
+  activate(
     args: ActivateArgs,
   ): Result.Result<AccountAlreadyActivatedError, Account> {
     if (this.isActivated()) {

--- a/pkg/accounts/service/fetchFollow.test.ts
+++ b/pkg/accounts/service/fetchFollow.test.ts
@@ -49,19 +49,23 @@ const createdAt = new Date();
 const repository = new InMemoryAccountFollowRepository();
 
 await repository.follow(
-  AccountFollow.new({
-    fromID: '1' as AccountID,
-    targetID: '2' as AccountID,
-    createdAt,
-  }),
+  Result.unwrap(
+    AccountFollow.new({
+      fromID: '1' as AccountID,
+      targetID: '2' as AccountID,
+      createdAt,
+    }),
+  ),
 );
 
 await repository.follow(
-  AccountFollow.new({
-    fromID: '2' as AccountID,
-    targetID: '1' as AccountID,
-    createdAt,
-  }),
+  Result.unwrap(
+    AccountFollow.new({
+      fromID: '2' as AccountID,
+      targetID: '1' as AccountID,
+      createdAt,
+    }),
+  ),
 );
 
 const service = new FetchFollowService(repository, accountRepository);
@@ -79,11 +83,13 @@ describe('FetchFollowService', () => {
     }
 
     expect(resFollows[1]).toStrictEqual([
-      AccountFollow.new({
-        fromID: '1' as AccountID,
-        targetID: '2' as AccountID,
-        createdAt,
-      }),
+      Result.unwrap(
+        AccountFollow.new({
+          fromID: '1' as AccountID,
+          targetID: '2' as AccountID,
+          createdAt,
+        }),
+      ),
     ]);
   });
 
@@ -94,11 +100,13 @@ describe('FetchFollowService', () => {
     }
 
     expect(resFollows[1]).toStrictEqual([
-      AccountFollow.new({
-        fromID: '1' as AccountID,
-        targetID: '2' as AccountID,
-        createdAt,
-      }),
+      Result.unwrap(
+        AccountFollow.new({
+          fromID: '1' as AccountID,
+          targetID: '2' as AccountID,
+          createdAt,
+        }),
+      ),
     ]);
   });
 
@@ -109,11 +117,13 @@ describe('FetchFollowService', () => {
     }
 
     expect(resFollows[1]).toStrictEqual([
-      AccountFollow.new({
-        fromID: '2' as AccountID,
-        targetID: '1' as AccountID,
-        createdAt,
-      }),
+      Result.unwrap(
+        AccountFollow.new({
+          fromID: '2' as AccountID,
+          targetID: '1' as AccountID,
+          createdAt,
+        }),
+      ),
     ]);
   });
 
@@ -124,11 +134,13 @@ describe('FetchFollowService', () => {
     }
 
     expect(resFollows[1]).toStrictEqual([
-      AccountFollow.new({
-        fromID: '2' as AccountID,
-        targetID: '1' as AccountID,
-        createdAt,
-      }),
+      Result.unwrap(
+        AccountFollow.new({
+          fromID: '2' as AccountID,
+          targetID: '1' as AccountID,
+          createdAt,
+        }),
+      ),
     ]);
   });
 

--- a/pkg/accounts/service/follow.ts
+++ b/pkg/accounts/service/follow.ts
@@ -36,11 +36,13 @@ export class FollowService {
     }
 
     const now = this.clock.now();
-    const follow = AccountFollow.new({
-      fromID: fromAccount[1].getID(),
-      targetID: targetAccount[1].getID(),
-      createdAt: new Date(Number(now)),
-    });
+    const follow = Result.unwrap(
+      AccountFollow.new({
+        fromID: fromAccount[1].getID(),
+        targetID: targetAccount[1].getID(),
+        createdAt: new Date(Number(now)),
+      }),
+    );
 
     const res = await this.followRepository.follow(follow);
     if (Result.isErr(res)) {

--- a/pkg/accounts/service/relationships.test.ts
+++ b/pkg/accounts/service/relationships.test.ts
@@ -36,11 +36,13 @@ const createMockFollow = (
   targetId: string,
   dayOffset = 0,
 ): AccountFollow => {
-  return AccountFollow.new({
-    fromID: fromId as AccountID,
-    targetID: targetId as AccountID,
-    createdAt: new Date(`2024-01-${10 + dayOffset}T12:00:00Z`),
-  });
+  return Result.unwrap(
+    AccountFollow.new({
+      fromID: fromId as AccountID,
+      targetID: targetId as AccountID,
+      createdAt: new Date(`2024-01-${10 + dayOffset}T12:00:00Z`),
+    }),
+  );
 };
 
 describe('FetchRelationshipService', () => {

--- a/pkg/accounts/service/unfollow.test.ts
+++ b/pkg/accounts/service/unfollow.test.ts
@@ -1,4 +1,4 @@
-import { Option } from '@mikuroxina/mini-fn';
+import { Option, Result } from '@mikuroxina/mini-fn';
 import { describe, expect, it } from 'vitest';
 
 import { InMemoryAccountRepository } from '../adaptor/repository/dummy/account.js';
@@ -43,11 +43,13 @@ await accountRepository.create(
   }),
 );
 const repository = new InMemoryAccountFollowRepository([
-  AccountFollow.new({
-    fromID: '1' as AccountID,
-    targetID: '2' as AccountID,
-    createdAt: new Date(),
-  }),
+  Result.unwrap(
+    AccountFollow.new({
+      fromID: '1' as AccountID,
+      targetID: '2' as AccountID,
+      createdAt: new Date(),
+    }),
+  ),
 ]);
 const service = new UnfollowService(repository, accountRepository);
 

--- a/pkg/accounts/testData/testData.ts
+++ b/pkg/accounts/testData/testData.ts
@@ -1,3 +1,5 @@
+import { Result } from '@mikuroxina/mini-fn';
+
 import type { PartialAccount } from '../../intermodule/account.js';
 import {
   Account,
@@ -110,19 +112,25 @@ export const partialAccount2: PartialAccount = {
 export const partialAccounts = [partialAccount1, partialAccount2];
 
 export const dummyfollows: AccountFollow[] = [
-  AccountFollow.new({
-    fromID: '101' as AccountID,
-    targetID: '102' as AccountID,
-    createdAt: new Date('2023-09-12T00:00:00Z'),
-  }),
-  AccountFollow.new({
-    fromID: '102' as AccountID,
-    targetID: '101' as AccountID,
-    createdAt: new Date('2023-09-13T00:00:00Z'),
-  }),
-  AccountFollow.new({
-    fromID: '103' as AccountID,
-    targetID: '101' as AccountID,
-    createdAt: new Date('2023-09-14T00:00:00Z'),
-  }),
+  Result.unwrap(
+    AccountFollow.new({
+      fromID: '101' as AccountID,
+      targetID: '102' as AccountID,
+      createdAt: new Date('2023-09-12T00:00:00Z'),
+    }),
+  ),
+  Result.unwrap(
+    AccountFollow.new({
+      fromID: '102' as AccountID,
+      targetID: '101' as AccountID,
+      createdAt: new Date('2023-09-13T00:00:00Z'),
+    }),
+  ),
+  Result.unwrap(
+    AccountFollow.new({
+      fromID: '103' as AccountID,
+      targetID: '101' as AccountID,
+      createdAt: new Date('2023-09-14T00:00:00Z'),
+    }),
+  ),
 ];


### PR DESCRIPTION
close #1617 

## What does this PR do?
- InactiveAccount/AccountFollowの実装を見直しました
- 入力値がおかしいときに使う専用のエラークラスを定義して使うようにしました
- deletedAtをOption.Option にしました

## Additional information
