### PR TITLE
refactor: EditServiceの制約チェックをモデルへ移動，細々したAccountモジュールのモデル周りのバグ修正

### DIFF
--- a/pkg/accounts/adaptor/repository/dummy/account.test.ts
+++ b/pkg/accounts/adaptor/repository/dummy/account.test.ts
@@ -13,9 +13,6 @@ describe('InMemoryAccountRepository', () => {
       nickname: 'John Doe',
       bio: 'Hello, World!',
       role: 'normal',
-      frozen: 'normal',
-      silenced: 'normal',
-      status: 'active',
       createdAt: new Date('2023-09-10T12:00:00Z'),
     }),
     Account.new({
@@ -25,9 +22,6 @@ describe('InMemoryAccountRepository', () => {
       nickname: 'Alice',
       bio: 'Hello, World!',
       role: 'normal',
-      frozen: 'normal',
-      silenced: 'normal',
-      status: 'active',
       createdAt: new Date('2023-09-11T12:00:00Z'),
     }),
     Account.new({
@@ -37,9 +31,6 @@ describe('InMemoryAccountRepository', () => {
       nickname: 'bob',
       bio: 'Hello, World!',
       role: 'normal',
-      frozen: 'normal',
-      silenced: 'normal',
-      status: 'active',
       createdAt: new Date('2023-09-12T12:00:00Z'),
     }),
   ];

--- a/pkg/accounts/model/account.errors.ts
+++ b/pkg/accounts/model/account.errors.ts
@@ -37,3 +37,19 @@ export class AccountAlreadyFrozenError extends Error {
     this.cause = options?.cause;
   }
 }
+
+export class AccountMailAddressLengthError extends Error {
+  override readonly name = 'AccountMailAddressLengthError' as const;
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.cause = options?.cause;
+  }
+}
+
+export class AccountPassphraseRequirementsNotMetError extends Error {
+  override readonly name = 'AccountPassphraseRequirementsNotMetError' as const;
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.cause = options?.cause;
+  }
+}

--- a/pkg/accounts/model/account.test.ts
+++ b/pkg/accounts/model/account.test.ts
@@ -54,10 +54,33 @@ describe('Account', () => {
   ][] = [
     ['nickname too long', (a) => a.setNickName('a'.repeat(257))],
     ['bio too long', (a) => a.setBio('a'.repeat(1025))],
+    ['mail too short', (a) => a.setMail('a'.repeat(6))],
+    ['mail too long', (a) => a.setMail('a'.repeat(320))],
   ];
+
+  it('allows empty string as nickname (no nickname set)', () => {
+    const account = Account.new(exampleInput);
+    expect(Result.isOk(account.setNickName(''))).toBe(true);
+  });
 
   it.each(validationCases)('returns error when %s', (_, call) => {
     expect(Result.isErr(call(Account.new(exampleInput)))).toBe(true);
+  });
+
+  describe('validatePassphrase', () => {
+    it.each([
+      { title: 'length 8', passphrase: 'a'.repeat(8) },
+      { title: 'length 512', passphrase: 'a'.repeat(512) },
+    ])('succeeds when $title', ({ passphrase }) => {
+      expect(Result.isOk(Account.validatePassphrase(passphrase))).toBe(true);
+    });
+
+    it.each([
+      { title: 'too short', passphrase: 'a'.repeat(7) },
+      { title: 'too long', passphrase: 'a'.repeat(513) },
+    ])('fails when $title', ({ passphrase }) => {
+      expect(Result.isErr(Account.validatePassphrase(passphrase))).toBe(true);
+    });
   });
 
   const mutationCalls: [string, (a: Account) => Result.Result<Error, void>][] =

--- a/pkg/accounts/model/account.ts
+++ b/pkg/accounts/model/account.ts
@@ -7,7 +7,9 @@ import {
   AccountAlreadyFrozenError,
   AccountBioLengthError,
   AccountDateInvalidError,
+  AccountMailAddressLengthError,
   AccountNickNameLengthError,
+  AccountPassphraseRequirementsNotMetError,
 } from './account.errors.js';
 
 export type AccountID = ID<Account>;
@@ -61,9 +63,20 @@ export const AccountNameSchema = v.pipe(
 const segmenter = new Intl.Segmenter();
 const graphemeLength = (s: string): number => [...segmenter.segment(s)].length;
 
+// empty string is allowed (means "no nickname set"); non-empty must be <= 256
 const nicknameSchema = v.pipe(
   v.string(),
-  v.check((s) => graphemeLength(s) <= 256),
+  v.check((s) => graphemeLength(s) === 0 || graphemeLength(s) <= 256),
+);
+
+const mailSchema = v.pipe(
+  v.string(),
+  v.check((s) => s.length >= 7 && s.length <= 319),
+);
+
+const passphraseSchema = v.pipe(
+  v.string(),
+  v.check((s) => s.length >= 8 && s.length <= 512),
 );
 
 const bioSchema = v.pipe(
@@ -175,7 +188,9 @@ export class Account {
   setMail(
     mail: string,
   ): Result.Result<
-    AccountAlreadyDeletedError | AccountAlreadyFrozenError,
+    | AccountAlreadyDeletedError
+    | AccountAlreadyFrozenError
+    | AccountMailAddressLengthError,
     void
   > {
     if (this.#isDeleted()) {
@@ -186,6 +201,14 @@ export class Account {
     if (this.isFrozen()) {
       return Result.err(
         new AccountAlreadyFrozenError('account already frozen'),
+      );
+    }
+
+    if (!v.safeParse(mailSchema, mail).success) {
+      return Result.err(
+        new AccountMailAddressLengthError(
+          'mail address length is out of range',
+        ),
       );
     }
 
@@ -447,7 +470,12 @@ export class Account {
     return this.#deletedAt !== undefined;
   }
 
-  static new(arg: Omit<CreateAccountArgs, 'deletedAt' | 'updatedAt'>) {
+  static new(
+    arg: Omit<
+      CreateAccountArgs,
+      'deletedAt' | 'updatedAt' | 'frozen' | 'silenced' | 'status'
+    >,
+  ) {
     return new Account({
       id: arg.id,
       mail: arg.mail,
@@ -463,6 +491,19 @@ export class Account {
       updatedAt: undefined,
       deletedAt: undefined,
     });
+  }
+
+  static validatePassphrase(
+    passphrase: string,
+  ): Result.Result<AccountPassphraseRequirementsNotMetError, void> {
+    if (!v.safeParse(passphraseSchema, passphrase).success) {
+      return Result.err(
+        new AccountPassphraseRequirementsNotMetError(
+          'passphrase requirements not met',
+        ),
+      );
+    }
+    return Result.ok(undefined);
   }
 
   static reconstruct(arg: CreateAccountArgs) {

--- a/pkg/accounts/service/edit.test.ts
+++ b/pkg/accounts/service/edit.test.ts
@@ -50,6 +50,10 @@ describe('EditService', () => {
         title: 'when nickname length 1',
         nickname: 'a',
       },
+      {
+        title: 'when nickname is empty (no nickname)',
+        nickname: '',
+      },
     ])('should be success to update $title', async ({ nickname }) => {
       //
       const updateRes = await editService.editNickname(
@@ -66,10 +70,6 @@ describe('EditService', () => {
     });
 
     it.each([
-      {
-        title: 'nickname length shorter more than 1',
-        nickname: '',
-      },
       {
         title: 'nickname length more than 256',
         nickname: 'a'.repeat(257),

--- a/pkg/accounts/service/edit.ts
+++ b/pkg/accounts/service/edit.ts
@@ -4,28 +4,14 @@ import {
   type PasswordEncoder,
   passwordEncoderSymbol,
 } from '../../internal/password/mod.js';
-import type { Account, AccountName } from '../model/account.js';
-import {
-  AccountInternalError,
-  AccountMailAddressLengthError,
-  AccountNicknameTooLongError,
-  AccountNicknameTooShortError,
-  AccountNotFoundError,
-  AccountPassphraseRequirementsNotMetError,
-} from '../model/errors.js';
+import { Account, type AccountName } from '../model/account.js';
+import { AccountInternalError, AccountNotFoundError } from '../model/errors.js';
 import {
   type AccountRepository,
   accountRepoSymbol,
 } from '../model/repository.js';
 
 export class EditService {
-  private readonly nicknameShortest = 1;
-  private readonly nicknameLongest = 256;
-  private readonly passphraseShortest = 8;
-  private readonly passphraseLongest = 512;
-  private readonly emailShortest = 7;
-  private readonly emailLongest = 319;
-
   constructor(
     private accountRepository: AccountRepository,
     private passwordEncoder: PasswordEncoder,
@@ -53,17 +39,6 @@ export class EditService {
 
     if (!this.isAllowed('edit', actor, account)) {
       return Result.err(new Error('not allowed'));
-    }
-
-    if (nickname.length < this.nicknameShortest) {
-      return Result.err(
-        new AccountNicknameTooShortError('nickname too short', { cause: null }),
-      );
-    }
-    if (nickname.length > this.nicknameLongest) {
-      return Result.err(
-        new AccountNicknameTooLongError('nickname too long', { cause: null }),
-      );
     }
 
     const setResult = account.setNickName(nickname);
@@ -101,19 +76,9 @@ export class EditService {
       return Result.err(new Error('not allowed'));
     }
 
-    if (newPassphrase.length < this.passphraseShortest) {
-      return Result.err(
-        new AccountPassphraseRequirementsNotMetError('passphrase too short', {
-          cause: null,
-        }),
-      );
-    }
-    if (newPassphrase.length > this.passphraseLongest) {
-      return Result.err(
-        new AccountPassphraseRequirementsNotMetError('passphrase too long', {
-          cause: null,
-        }),
-      );
+    const validateResult = Account.validatePassphrase(newPassphrase);
+    if (Result.isErr(validateResult)) {
+      return validateResult;
     }
 
     let encoded: string;
@@ -158,17 +123,6 @@ export class EditService {
 
     if (!this.isAllowed('edit', actor, account)) {
       return Result.err(new Error('not allowed'));
-    }
-
-    if (newEmail.length < this.emailShortest) {
-      return Result.err(
-        new AccountMailAddressLengthError('email too short', { cause: null }),
-      );
-    }
-    if (newEmail.length > this.emailLongest) {
-      return Result.err(
-        new AccountMailAddressLengthError('email too long', { cause: null }),
-      );
     }
 
     // TODO: add a process to check the email is active

--- a/pkg/accounts/service/fetch.test.ts
+++ b/pkg/accounts/service/fetch.test.ts
@@ -14,9 +14,6 @@ const testAccounts = [
     passphraseHash: 'hash',
     bio: '',
     role: 'normal',
-    frozen: 'normal',
-    silenced: 'normal',
-    status: 'notActivated',
     createdAt: new Date('2023-09-10T12:00:00Z'),
   }),
   Account.new({
@@ -26,9 +23,6 @@ const testAccounts = [
     nickname: 'Alice',
     bio: 'Hello, World!',
     role: 'normal',
-    frozen: 'normal',
-    silenced: 'normal',
-    status: 'active',
     createdAt: new Date('2023-09-11T12:00:00Z'),
   }),
   Account.new({
@@ -38,9 +32,6 @@ const testAccounts = [
     nickname: 'bob',
     bio: 'Hello, World!',
     role: 'normal',
-    frozen: 'normal',
-    silenced: 'normal',
-    status: 'active',
     createdAt: new Date('2023-09-12T12:00:00Z'),
   }),
 ];
@@ -89,9 +80,6 @@ describe('FetchService', () => {
         passphraseHash: 'hash',
         bio: '',
         role: 'normal',
-        frozen: 'normal',
-        silenced: 'normal',
-        status: 'notActivated',
         createdAt: new Date('2023-09-10T12:00:00.000Z'),
       }),
     );

--- a/pkg/accounts/service/freeze.ts
+++ b/pkg/accounts/service/freeze.ts
@@ -37,6 +37,10 @@ export class FreezeService {
     if (Result.isErr(setResult)) {
       return setResult;
     }
+    const saveResult = await this.accountRepository.edit(account);
+    if (Result.isErr(saveResult)) {
+      return saveResult;
+    }
     return Result.ok(true);
   }
 
@@ -66,6 +70,10 @@ export class FreezeService {
     const setResult = account.setUnfreeze();
     if (Result.isErr(setResult)) {
       return setResult;
+    }
+    const saveResult = await this.accountRepository.edit(account);
+    if (Result.isErr(saveResult)) {
+      return saveResult;
     }
     return Result.ok(true);
   }

--- a/pkg/accounts/service/register.ts
+++ b/pkg/accounts/service/register.ts
@@ -89,9 +89,6 @@ export class RegisterService {
       passphraseHash: passphraseHash,
       bio: bio,
       role: role,
-      frozen: 'normal',
-      silenced: 'normal',
-      status: 'notActivated',
       createdAt: new Date(Number(now)),
     });
     const res = await this.accountRepository.create(account);

--- a/pkg/accounts/service/resendToken.test.ts
+++ b/pkg/accounts/service/resendToken.test.ts
@@ -19,9 +19,6 @@ await repository.create(
     passphraseHash: 'hash',
     bio: '',
     role: 'normal',
-    frozen: 'normal',
-    silenced: 'normal',
-    status: 'notActivated',
     createdAt: new Date(),
   }),
 );

--- a/pkg/accounts/service/silence.test.ts
+++ b/pkg/accounts/service/silence.test.ts
@@ -1,61 +1,62 @@
 import { Option } from '@mikuroxina/mini-fn';
-import { afterEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 
 import { InMemoryAccountRepository } from '../adaptor/repository/dummy/account.js';
 import { Account, type AccountID } from '../model/account.js';
 import { SilenceService } from './silence.js';
 
-const testNormalAccount = Account.reconstruct({
-  id: '1' as AccountID,
-  name: '@john@example.com',
-  mail: 'johndoe@example.com',
-  nickname: 'John Doe',
-  passphraseHash: 'hash',
-  bio: '',
-  role: 'normal',
-  frozen: 'normal',
-  silenced: 'normal',
-  status: 'active',
-  createdAt: new Date(),
-});
-const testAdminAccount = Account.reconstruct({
-  id: '2' as AccountID,
-  name: '@alice@example.com',
-  mail: 'alice@example.com',
-  nickname: 'Alice',
-  passphraseHash: 'hash',
-  bio: '',
-  role: 'admin',
-  frozen: 'normal',
-  silenced: 'normal',
-  status: 'active',
-  createdAt: new Date(),
-});
-const repository = new InMemoryAccountRepository([
-  testNormalAccount,
-  testAdminAccount,
-]);
-
+const repository = new InMemoryAccountRepository();
 const silenceService = new SilenceService(repository);
 
+const resetRepository = () => {
+  repository.reset([
+    Account.reconstruct({
+      id: '1' as AccountID,
+      name: '@john@example.com',
+      mail: 'johndoe@example.com',
+      nickname: 'John Doe',
+      passphraseHash: 'hash',
+      bio: '',
+      role: 'normal',
+      frozen: 'normal',
+      silenced: 'normal',
+      status: 'active',
+      createdAt: new Date(),
+    }),
+    Account.reconstruct({
+      id: '2' as AccountID,
+      name: '@alice@example.com',
+      mail: 'alice@example.com',
+      nickname: 'Alice',
+      passphraseHash: 'hash',
+      bio: '',
+      role: 'admin',
+      frozen: 'normal',
+      silenced: 'normal',
+      status: 'active',
+      createdAt: new Date(),
+    }),
+  ]);
+};
+
 describe('SilenceService', () => {
-  afterEach(() => repository.reset());
+  beforeEach(() => resetRepository());
 
   it('set account silence', async () => {
-    const account = await repository.findByName('@john@example.com');
-    if (Option.isNone(account)) return;
-
     await silenceService.setSilence('@john@example.com', '@alice@example.com');
 
+    const account = await repository.findByName('@john@example.com');
+    if (Option.isNone(account)) return;
     expect(account[1].isSilenced()).toBe(true);
   });
 
   it('unset account silence', async () => {
-    const account = await repository.findByName('@john@example.com');
-    if (Option.isNone(account)) return;
+    await silenceService.setSilence('@john@example.com', '@alice@example.com');
 
     await silenceService.undoSilence('@john@example.com', '@alice@example.com');
 
+    const account = await repository.findByName('@john@example.com');
+    if (Option.isNone(account)) return;
     expect(account[1].isSilenced()).toBe(false);
   });
 });

--- a/pkg/accounts/service/silence.ts
+++ b/pkg/accounts/service/silence.ts
@@ -42,6 +42,10 @@ export class SilenceService {
     if (Result.isErr(setResult)) {
       return setResult;
     }
+    const saveResult = await this.accountRepository.edit(account);
+    if (Result.isErr(saveResult)) {
+      return saveResult;
+    }
     return Result.ok(true);
   }
 
@@ -72,6 +76,10 @@ export class SilenceService {
     const setResult = account.undoSilence();
     if (Result.isErr(setResult)) {
       return setResult;
+    }
+    const saveResult = await this.accountRepository.edit(account);
+    if (Result.isErr(saveResult)) {
+      return saveResult;
     }
     return Result.ok(true);
   }
@@ -119,7 +127,7 @@ export class SilenceService {
         }
 
         // NOTE: undoSilence action is allowed for only admin / moderator
-        if (actor.getRole() !== 'admin' || actor.getRole() !== 'moderator') {
+        if (actor.getRole() !== 'admin' && actor.getRole() !== 'moderator') {
           return false;
         }
 

--- a/pkg/timeline/service/account.test.ts
+++ b/pkg/timeline/service/account.test.ts
@@ -74,9 +74,6 @@ describe('AccountTimelineService', () => {
     nickname: 'John Doe',
     passphraseHash: '',
     role: 'normal',
-    silenced: 'normal',
-    status: 'active',
-    frozen: 'normal',
     createdAt: new Date(),
   });
   const partialAccount1: PartialAccount = {


### PR DESCRIPTION
close #1625 

## What does this PR do?
- EditServiceでモデル側で実装されているバリデーションを別途実装していたので分離しました
  - モデル側でもエラーを増やす/ミューテーションメソッドのチェックを増やすなど対応しています

## Additional information
- Accountモジュールでモデル周りに存在したバグを2箇所修正しています
