### PR TITLE
feat: 仮登録アカウントをAccountから分離

### DIFF
--- a/pkg/accounts/adaptor/controller/account.ts
+++ b/pkg/accounts/adaptor/controller/account.ts
@@ -95,9 +95,7 @@ export class AccountController {
     const res = await this.registerService.handle(
       name as AccountName,
       email,
-      '',
       passphrase,
-      '',
       'normal',
     );
 

--- a/pkg/accounts/adaptor/repository/dummy/inactiveAccount.ts
+++ b/pkg/accounts/adaptor/repository/dummy/inactiveAccount.ts
@@ -1,4 +1,5 @@
 import { Ether, Option, Result } from '@mikuroxina/mini-fn';
+import type { AccountID } from '../../../model/account.js';
 import type { InactiveAccount } from '../../../model/inactiveAccount.js';
 import {
   type InactiveAccountRepository,
@@ -38,6 +39,15 @@ export class InMemoryInactiveAccountRepository
     }
 
     return Promise.resolve(Option.some(account));
+  }
+
+  delete(id: AccountID): Promise<Result.Result<Error, void>> {
+    const account = Array.from(this.data).find((a) => a.getID() === id);
+    if (!account) {
+      return Promise.resolve(Result.ok(undefined));
+    }
+    this.data.delete(account);
+    return Promise.resolve(Result.ok(undefined));
   }
 }
 

--- a/pkg/accounts/adaptor/repository/prisma/inactiveAccount.ts
+++ b/pkg/accounts/adaptor/repository/prisma/inactiveAccount.ts
@@ -1,7 +1,11 @@
 import { Ether, Option, Result } from '@mikuroxina/mini-fn';
 import type { PrismaClient } from '../../../../adaptors/prisma/client.js';
 import type { prismaClient } from '../../../../adaptors/prisma.js';
-import type { AccountID, AccountName } from '../../../model/account.js';
+import type {
+  AccountID,
+  AccountName,
+  AccountRole,
+} from '../../../model/account.js';
 import { InactiveAccount } from '../../../model/inactiveAccount.js';
 import {
   type InactiveAccountRepository,
@@ -19,12 +23,22 @@ export class PrismaInactiveAccountRepository
   constructor(private readonly prisma: PrismaClient) {}
 
   async create(account: InactiveAccount): Promise<Result.Result<Error, void>> {
+    const role = (
+      {
+        normal: 0,
+        moderator: 1,
+        admin: 2,
+      } satisfies Record<AccountRole, number>
+    )[account.getRole()];
+
     try {
       await this.prisma.inactiveAccount.create({
         data: {
           id: account.getID(),
           name: account.getName(),
           mail: account.getMail(),
+          passphraseHash: account.getPassphraseHash(),
+          role,
         },
       });
     } catch (e) {
@@ -68,10 +82,21 @@ export class PrismaInactiveAccountRepository
     if (args === null) {
       throw new Error('failed to serialize');
     }
+    const role =
+      (
+        {
+          0: 'normal',
+          1: 'moderator',
+          2: 'admin',
+        } satisfies Record<number, AccountRole>
+      )[args.role] ?? 'normal';
+
     return InactiveAccount.reconstruct({
       id: args.id as AccountID,
       name: args.name as AccountName,
       mail: args.mail,
+      passphraseHash: args.passphraseHash,
+      role,
     });
   }
 }

--- a/pkg/accounts/adaptor/repository/prisma/inactiveAccount.ts
+++ b/pkg/accounts/adaptor/repository/prisma/inactiveAccount.ts
@@ -1,0 +1,82 @@
+import { Ether, Option, Result } from '@mikuroxina/mini-fn';
+import type { PrismaClient } from '../../../../adaptors/prisma/client.js';
+import type { prismaClient } from '../../../../adaptors/prisma.js';
+import type { AccountID, AccountName } from '../../../model/account.js';
+import { InactiveAccount } from '../../../model/inactiveAccount.js';
+import {
+  type InactiveAccountRepository,
+  inactiveAccountRepoSymbol,
+} from '../../../model/repository.js';
+import { parsePrismaError } from './prisma.js';
+
+type InactiveAccountPrismaArgs = Awaited<
+  ReturnType<typeof prismaClient.inactiveAccount.findUnique>
+>;
+
+export class PrismaInactiveAccountRepository
+  implements InactiveAccountRepository
+{
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async create(account: InactiveAccount): Promise<Result.Result<Error, void>> {
+    try {
+      await this.prisma.inactiveAccount.create({
+        data: {
+          id: account.getID(),
+          name: account.getName(),
+          mail: account.getMail(),
+        },
+      });
+    } catch (e) {
+      return Result.err(parsePrismaError(e));
+    }
+    return Result.ok(undefined);
+  }
+
+  async findByName(name: string): Promise<Option.Option<InactiveAccount>> {
+    const res = await this.prisma.inactiveAccount.findUnique({
+      where: { name },
+    });
+    if (!res) {
+      return Option.none();
+    }
+    return Option.some(this.fromPrismaArgs(res));
+  }
+
+  async findByMail(mail: string): Promise<Option.Option<InactiveAccount>> {
+    const res = await this.prisma.inactiveAccount.findUnique({
+      where: { mail },
+    });
+    if (!res) {
+      return Option.none();
+    }
+    return Option.some(this.fromPrismaArgs(res));
+  }
+
+  async delete(id: AccountID): Promise<Result.Result<Error, void>> {
+    try {
+      await this.prisma.inactiveAccount.delete({
+        where: { id },
+      });
+    } catch (e) {
+      return Result.err(parsePrismaError(e));
+    }
+    return Result.ok(undefined);
+  }
+
+  private fromPrismaArgs(args: InactiveAccountPrismaArgs): InactiveAccount {
+    if (args === null) {
+      throw new Error('failed to serialize');
+    }
+    return InactiveAccount.reconstruct({
+      id: args.id as AccountID,
+      name: args.name as AccountName,
+      mail: args.mail,
+    });
+  }
+}
+export const prismaInactiveAccountRepo = (client: PrismaClient) =>
+  Ether.newEther(
+    inactiveAccountRepoSymbol,
+    () => new PrismaInactiveAccountRepository(client),
+  );

--- a/pkg/accounts/adaptor/repository/prisma/inactiveAccount.ts
+++ b/pkg/accounts/adaptor/repository/prisma/inactiveAccount.ts
@@ -11,6 +11,7 @@ import {
   type InactiveAccountRepository,
   inactiveAccountRepoSymbol,
 } from '../../../model/repository.js';
+import { accountModuleLogger } from '../../logger.js';
 import { parsePrismaError } from './prisma.js';
 
 type InactiveAccountPrismaArgs = Awaited<
@@ -82,21 +83,27 @@ export class PrismaInactiveAccountRepository
     if (args === null) {
       throw new Error('failed to serialize');
     }
-    const role =
-      (
-        {
-          0: 'normal',
-          1: 'moderator',
-          2: 'admin',
-        } satisfies Record<number, AccountRole>
-      )[args.role] ?? 'normal';
+    const role = (
+      {
+        0: 'normal',
+        1: 'moderator',
+        2: 'admin',
+      } satisfies Record<number, AccountRole>
+    )[args.role];
+
+    if (role === undefined) {
+      accountModuleLogger.warn(
+        `Unknown role value: ${args.role} for InactiveAccount id: ${args.id}, falling back to 'normal'`,
+      );
+    }
+    const resolvedRole: AccountRole = role ?? 'normal';
 
     return InactiveAccount.reconstruct({
       id: args.id as AccountID,
       name: args.name as AccountName,
       mail: args.mail,
       passphraseHash: args.passphraseHash,
-      role,
+      role: resolvedRole,
     });
   }
 }

--- a/pkg/accounts/mod.ts
+++ b/pkg/accounts/mod.ts
@@ -21,9 +21,11 @@ import { InMemoryAccountRepository } from './adaptor/repository/dummy/account.js
 import { inMemoryAccountAvatarRepo } from './adaptor/repository/dummy/avatar.js';
 import { newFollowRepo } from './adaptor/repository/dummy/follow.js';
 import { inMemoryAccountHeaderRepo } from './adaptor/repository/dummy/header.js';
+import { inactiveAccountRepo } from './adaptor/repository/dummy/inactiveAccount.js';
 import { verifyTokenRepo } from './adaptor/repository/dummy/verifyToken.js';
 import { prismaAccountAvatarRepo } from './adaptor/repository/prisma/avatar.js';
 import { prismaAccountHeaderRepo } from './adaptor/repository/prisma/header.js';
+import { prismaInactiveAccountRepo } from './adaptor/repository/prisma/inactiveAccount.js';
 import {
   PrismaAccountRepository,
   prismaFollowRepo,
@@ -53,6 +55,7 @@ import {
   AccountRefreshTokenInvalidError,
 } from './model/errors.js';
 import { accountRepoSymbol } from './model/repository.js';
+
 import {
   CreateAccountRoute,
   FollowAccountRoute,
@@ -127,6 +130,10 @@ class Clock {
 const clock = Ether.newEther(clockSymbol, () => new Clock());
 const idGenerator = Ether.compose(clock)(snowflakeIDGenerator(0));
 
+const inactiveAccountRepository = isProduction
+  ? prismaInactiveAccountRepo(prismaClient)
+  : inactiveAccountRepo;
+
 const verifyAccountTokenService = Cat.cat(verifyAccountToken)
   .feed(Ether.compose(clock))
   .feed(
@@ -134,6 +141,7 @@ const verifyAccountTokenService = Cat.cat(verifyAccountToken)
       isProduction ? prismaVerifyTokenRepo(prismaClient) : verifyTokenRepo,
     ),
   )
+  .feed(Ether.compose(inactiveAccountRepository))
   .feed(Ether.compose(accountRepository)).value;
 
 const composer = Ether.composeT(Promise.monad);
@@ -173,8 +181,7 @@ export const controller = new AccountController({
   ),
   registerService: Ether.runEther(
     Cat.cat(register)
-      .feed(Ether.compose(clock))
-      .feed(Ether.compose(accountRepository))
+      .feed(Ether.compose(inactiveAccountRepository))
       .feed(Ether.compose(idGenerator))
       .feed(Ether.compose(argon2idPasswordEncoder))
       .feed(
@@ -198,7 +205,7 @@ export const controller = new AccountController({
   ),
   resendTokenService: Ether.runEther(
     Cat.cat(resendToken)
-      .feed(Ether.compose(accountRepository))
+      .feed(Ether.compose(inactiveAccountRepository))
       .feed(Ether.compose(verifyAccountTokenService))
       .feed(
         Ether.compose(

--- a/pkg/accounts/model/account.test.ts
+++ b/pkg/accounts/model/account.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it } from 'vitest';
 import {
   Account,
   type AccountID,
-  AccountNameSchema,
+  accountNameSchema,
   type CreateAccountArgs,
 } from './account.js';
 
@@ -107,7 +107,7 @@ describe('Account', () => {
 
 describe('AccountNameSchema', () => {
   const check = (input: unknown) =>
-    v.safeParse(AccountNameSchema, input).success;
+    v.safeParse(accountNameSchema, input).success;
 
   const account = Account.new(exampleInput);
 

--- a/pkg/accounts/model/account.ts
+++ b/pkg/accounts/model/account.ts
@@ -19,7 +19,7 @@ export type AccountStatus = 'active' | 'notActivated';
 export type AccountFrozen = 'frozen' | 'normal';
 export type AccountSilenced = 'silenced' | 'normal';
 
-export const AccountNameSchema = v.pipe(
+export const accountNameSchema = v.pipe(
   v.string(),
   v.check((s) => {
     const parts = s.split('@');
@@ -69,7 +69,7 @@ const nicknameSchema = v.pipe(
   v.check((s) => graphemeLength(s) === 0 || graphemeLength(s) <= 256),
 );
 
-const mailSchema = v.pipe(
+export const mailSchema = v.pipe(
   v.string(),
   v.check((s) => s.length >= 7 && s.length <= 319),
 );

--- a/pkg/accounts/model/inactiveAccount.test.ts
+++ b/pkg/accounts/model/inactiveAccount.test.ts
@@ -35,6 +35,22 @@ describe('InactiveAccount', () => {
     expect(account.isActivated()).toBe(false);
   });
 
+  it('fail to create with too short mail', () => {
+    const result = InactiveAccount.new({
+      ...exampleInput,
+      mail: 'a@b.c',
+    });
+    expect(Result.isErr(result)).toBe(true);
+  });
+
+  it('fail to create with too long mail', () => {
+    const result = InactiveAccount.new({
+      ...exampleInput,
+      mail: `${'a'.repeat(320)}@example.com`,
+    });
+    expect(Result.isErr(result)).toBe(true);
+  });
+
   it('activate account', () => {
     const inactiveAccount = Result.unwrap(InactiveAccount.new(exampleInput));
     const account = Result.unwrap(

--- a/pkg/accounts/model/inactiveAccount.test.ts
+++ b/pkg/accounts/model/inactiveAccount.test.ts
@@ -1,8 +1,9 @@
 import { Result } from '@mikuroxina/mini-fn';
 import { describe, expect, it } from 'vitest';
 
-import type { AccountID, CreateAccountArgs } from './account.js';
+import type { AccountID } from './account.js';
 import {
+  type ActivateArgs,
   type CreateInactiveAccountArgs,
   InactiveAccount,
 } from './inactiveAccount.js';
@@ -11,22 +12,12 @@ const exampleInput: CreateInactiveAccountArgs = {
   id: '1' as AccountID,
   name: '@johndoe@social.example.com',
   mail: 'test@mail.example.com',
-};
-
-const exampleActivateArgs: CreateAccountArgs = {
-  id: '1' as AccountID,
-  bio: "this is john doe's account!",
-  createdAt: new Date('2023-09-10T00:00:00.000Z'),
-  mail: 'test@mail.example.com',
-  nickname: 'John Doe',
   passphraseHash: 'leknflkwnrigohidvlk',
   role: 'admin',
-  status: 'active',
-  frozen: 'frozen',
-  silenced: 'silenced',
-  name: '@johndoe@social.example.com',
-  updatedAt: new Date('2023-09-10T09:00:00.000Z'),
-  deletedAt: new Date('2023-09-10T10:00:00.000Z'),
+};
+
+const exampleActivateArgs: ActivateArgs = {
+  createdAt: new Date('2023-09-10T00:00:00.000Z'),
 };
 
 describe('InactiveAccount', () => {
@@ -60,15 +51,14 @@ describe('InactiveAccount', () => {
     expect(account.getID()).toBe(exampleInput.id);
     expect(account.getName()).toBe(exampleInput.name);
     expect(account.getMail()).toBe(exampleInput.mail);
-    expect(account.getNickname()).toBe(exampleActivateArgs.nickname);
-    expect(account.getPassphraseHash()).toBe(
-      exampleActivateArgs.passphraseHash,
-    );
-    expect(account.getBio()).toBe(exampleActivateArgs.bio);
-    expect(account.getRole()).toBe(exampleActivateArgs.role);
+    expect(account.getNickname()).toBe('');
+    expect(account.getPassphraseHash()).toBe(exampleInput.passphraseHash);
+    expect(account.getBio()).toBe('');
+    expect(account.getRole()).toBe(exampleInput.role);
     expect(account.getCreatedAt()).toBe(exampleActivateArgs.createdAt);
     expect(account.getUpdatedAt()).toBe(undefined);
     expect(account.getDeletedAt()).toBe(undefined);
+    expect(account.isActivated()).toBe(true);
 
     expect(inactiveAccount.isActivated()).toBe(true);
   });
@@ -87,5 +77,7 @@ describe('InactiveAccount', () => {
     expect(account.getID()).toBe(exampleInput.id);
     expect(account.getName()).toBe(exampleInput.name);
     expect(account.getMail()).toBe(exampleInput.mail);
+    expect(account.getPassphraseHash()).toBe(exampleInput.passphraseHash);
+    expect(account.getRole()).toBe(exampleInput.role);
   });
 });

--- a/pkg/accounts/model/inactiveAccount.ts
+++ b/pkg/accounts/model/inactiveAccount.ts
@@ -1,10 +1,12 @@
 import { Result } from '@mikuroxina/mini-fn';
-
+import * as v from 'valibot';
+import { AccountMailAddressLengthError } from './account.errors.js';
 import {
   Account,
   type AccountID,
   type AccountName,
   type CreateAccountArgs,
+  mailSchema,
 } from './account.js';
 
 export interface CreateInactiveAccountArgs {
@@ -27,7 +29,7 @@ export class AccountAlreadyActivatedError extends Error {
 }
 
 export class InactiveAccount {
-  constructor(arg: CreateInactiveAccountArgs) {
+  private constructor(arg: CreateInactiveAccountArgs) {
     this.#id = arg.id;
     this.#name = arg.name;
     this.#mail = arg.mail;
@@ -79,7 +81,18 @@ export class InactiveAccount {
 
   static new(
     arg: CreateInactiveAccountArgs,
-  ): Result.Result<never, InactiveAccount> {
+  ): Result.Result<AccountMailAddressLengthError, InactiveAccount> {
+    if (!v.safeParse(mailSchema, arg.mail).success) {
+      return Result.err(
+        new AccountMailAddressLengthError(
+          'mail address length is out of range',
+        ),
+      );
+    }
     return Result.ok(new InactiveAccount(arg));
+  }
+
+  static reconstruct(arg: CreateInactiveAccountArgs): InactiveAccount {
+    return new InactiveAccount(arg);
   }
 }

--- a/pkg/accounts/model/inactiveAccount.ts
+++ b/pkg/accounts/model/inactiveAccount.ts
@@ -5,7 +5,7 @@ import {
   Account,
   type AccountID,
   type AccountName,
-  type CreateAccountArgs,
+  type AccountRole,
   mailSchema,
 } from './account.js';
 
@@ -13,12 +13,13 @@ export interface CreateInactiveAccountArgs {
   id: AccountID;
   name: AccountName;
   mail: string;
+  passphraseHash: string;
+  role: AccountRole;
 }
 
-export type ActivateArgs = Omit<
-  CreateAccountArgs,
-  keyof Omit<CreateInactiveAccountArgs, 'activated'>
->;
+export interface ActivateArgs {
+  createdAt: Date;
+}
 
 export class AccountAlreadyActivatedError extends Error {
   override readonly name = 'AccountAlreadyActivatedError' as const;
@@ -33,6 +34,8 @@ export class InactiveAccount {
     this.#id = arg.id;
     this.#name = arg.name;
     this.#mail = arg.mail;
+    this.#passphraseHash = arg.passphraseHash;
+    this.#role = arg.role;
     this.#activated = false;
   }
 
@@ -42,18 +45,28 @@ export class InactiveAccount {
   }
 
   readonly #id: AccountID;
-  getID(): string {
+  getID(): AccountID {
     return this.#id;
   }
 
   readonly #name: AccountName;
-  getName(): string {
+  getName(): AccountName {
     return this.#name;
   }
 
   readonly #mail: string;
   getMail(): string {
     return this.#mail;
+  }
+
+  readonly #passphraseHash: string;
+  getPassphraseHash(): string {
+    return this.#passphraseHash;
+  }
+
+  readonly #role: AccountRole;
+  getRole(): AccountRole {
+    return this.#role;
   }
 
   activate(
@@ -71,8 +84,14 @@ export class InactiveAccount {
         id: this.#id,
         name: this.#name,
         mail: this.#mail,
-        ...args,
+        passphraseHash: this.#passphraseHash,
+        role: this.#role,
+        nickname: '',
+        bio: '',
+        createdAt: args.createdAt,
         status: 'active',
+        frozen: 'normal',
+        silenced: 'normal',
         updatedAt: undefined,
         deletedAt: undefined,
       }),

--- a/pkg/accounts/model/repository.ts
+++ b/pkg/accounts/model/repository.ts
@@ -21,6 +21,7 @@ export interface InactiveAccountRepository {
   create(account: InactiveAccount): Promise<Result.Result<Error, void>>;
   findByName(name: string): Promise<Option.Option<InactiveAccount>>;
   findByMail(mail: string): Promise<Option.Option<InactiveAccount>>;
+  delete(id: AccountID): Promise<Result.Result<Error, void>>;
 }
 export const inactiveAccountRepoSymbol =
   Ether.newEtherSymbol<InactiveAccountRepository>();

--- a/pkg/accounts/service/register.test.ts
+++ b/pkg/accounts/service/register.test.ts
@@ -4,34 +4,34 @@ import { notificationModule } from '../../intermodule/notification.js';
 import { MockClock, SnowflakeIDGenerator } from '../../internal/id/mod.js';
 import { Argon2idPasswordEncoder } from '../../internal/password/mod.js';
 import { InMemoryAccountRepository } from '../adaptor/repository/dummy/account.js';
+import { InMemoryInactiveAccountRepository } from '../adaptor/repository/dummy/inactiveAccount.js';
 import { InMemoryAccountVerifyTokenRepository } from '../adaptor/repository/dummy/verifyToken.js';
 import type { AccountName, AccountRole } from '../model/account.js';
 import { RegisterService } from './register.js';
 import { VerifyAccountTokenService } from './verifyToken.js';
 
-const repository = new InMemoryAccountRepository();
+const inactiveAccountRepository = new InMemoryInactiveAccountRepository();
+const accountRepository = new InMemoryAccountRepository();
 const verifyRepository = new InMemoryAccountVerifyTokenRepository();
 const mockClock = new MockClock(new Date('2023-09-10T00:00:00Z'));
 
 const registerService: RegisterService = new RegisterService({
-  repository,
+  repository: inactiveAccountRepository,
   idGenerator: new SnowflakeIDGenerator(1, mockClock),
   passwordEncoder: new Argon2idPasswordEncoder(),
   notificationModule: notificationModule,
   verifyAccountTokenService: new VerifyAccountTokenService(
     verifyRepository,
-    repository,
+    inactiveAccountRepository,
+    accountRepository,
     mockClock,
   ),
-  clock: new MockClock(new Date('2023-09-10T00:00:00Z')),
 });
 
 const exampleInput = {
   name: '@john_doe@example.com' as AccountName,
   mail: 'johndoe@example.com',
-  nickname: 'John Doe',
   passphrase: 'password',
-  bio: 'Hello, World!',
   role: 'normal' as AccountRole,
 };
 
@@ -40,19 +40,15 @@ describe('RegisterService', () => {
     const res = await registerService.handle(
       exampleInput.name,
       exampleInput.mail,
-      exampleInput.nickname,
       exampleInput.passphrase,
-      exampleInput.bio,
       exampleInput.role,
     );
     if (Result.isErr(res)) return;
 
     expect(res[1].getName()).toBe(exampleInput.name);
     expect(res[1].getMail()).toBe(exampleInput.mail);
-    expect(res[1].getNickname()).toBe(exampleInput.nickname);
-    expect(res[1].getBio()).toBe(exampleInput.bio);
     expect(res[1].getRole()).toBe(exampleInput.role);
     expect(res[1].isActivated()).toBe(false);
-    repository.reset();
+    inactiveAccountRepository.reset();
   });
 });

--- a/pkg/accounts/service/register.ts
+++ b/pkg/accounts/service/register.ts
@@ -4,8 +4,6 @@ import {
   notificationModuleFacadeSymbol,
 } from '../../intermodule/notification.js';
 import {
-  type Clock,
-  clockSymbol,
   type SnowflakeIDGenerator,
   snowflakeIDGeneratorSymbol,
 } from '../../internal/id/mod.js';
@@ -13,14 +11,11 @@ import {
   type PasswordEncoder,
   passwordEncoderSymbol,
 } from '../../internal/password/mod.js';
+import type { Account, AccountName, AccountRole } from '../model/account.js';
+import { InactiveAccount } from '../model/inactiveAccount.js';
 import {
-  Account,
-  type AccountName,
-  type AccountRole,
-} from '../model/account.js';
-import {
-  type AccountRepository,
-  accountRepoSymbol,
+  type InactiveAccountRepository,
+  inactiveAccountRepoSymbol,
 } from '../model/repository.js';
 import {
   type VerifyAccountTokenService,
@@ -36,42 +31,38 @@ export class AccountAlreadyExistsError extends Error {
 }
 
 export class RegisterService {
-  private readonly accountRepository: AccountRepository;
+  private readonly inactiveAccountRepository: InactiveAccountRepository;
   private readonly snowflakeIDGenerator: SnowflakeIDGenerator;
   private readonly passwordEncoder: PasswordEncoder;
   private readonly notificationModule: NotificationModuleFacade;
   private readonly verifyAccountTokenService: VerifyAccountTokenService;
-  private readonly clock: Clock;
 
   constructor(arg: {
-    repository: AccountRepository;
+    repository: InactiveAccountRepository;
     idGenerator: SnowflakeIDGenerator;
     passwordEncoder: PasswordEncoder;
     notificationModule: NotificationModuleFacade;
     verifyAccountTokenService: VerifyAccountTokenService;
-    clock: Clock;
   }) {
-    this.accountRepository = arg.repository;
+    this.inactiveAccountRepository = arg.repository;
     this.snowflakeIDGenerator = arg.idGenerator;
     this.passwordEncoder = arg.passwordEncoder;
     this.notificationModule = arg.notificationModule;
     this.verifyAccountTokenService = arg.verifyAccountTokenService;
-    this.clock = arg.clock;
   }
 
   public async handle(
     name: AccountName,
     mail: string,
-    nickname: string,
     passphrase: string,
-    bio: string,
     role: AccountRole,
-  ): Promise<Result.Result<Error, Account>> {
+  ): Promise<Result.Result<Error, InactiveAccount>> {
     if (await this.isExists(mail, name)) {
       return Result.err(
         new AccountAlreadyExistsError('account already exists'),
       );
     }
+
     const passphraseHash =
       await this.passwordEncoder.encodePassword(passphrase);
     const generatedIDRes = this.snowflakeIDGenerator.generate<Account>();
@@ -80,18 +71,19 @@ export class RegisterService {
     }
     const generatedID = Result.unwrap(generatedIDRes);
 
-    const now = this.clock.now();
-    const account = Account.new({
+    const accountRes = InactiveAccount.new({
       id: generatedID,
-      name: name,
-      mail: mail,
-      nickname: nickname,
-      passphraseHash: passphraseHash,
-      bio: bio,
-      role: role,
-      createdAt: new Date(Number(now)),
+      name,
+      mail,
+      passphraseHash,
+      role,
     });
-    const res = await this.accountRepository.create(account);
+    if (Result.isErr(accountRes)) {
+      return accountRes;
+    }
+    const account = Result.unwrap(accountRes);
+
+    const res = await this.inactiveAccountRepository.create(account);
     if (Result.isErr(res)) {
       return res;
     }
@@ -114,14 +106,9 @@ export class RegisterService {
     return Result.ok(account);
   }
 
-  /**
-   * @param mail account mail addr
-   * @param name account name (e.g. "@me@example.com" )
-   * @returns account is exist
-   */
   private async isExists(mail: string, name: string): Promise<boolean> {
-    const byName = await this.accountRepository.findByName(name);
-    const byMail = await this.accountRepository.findByMail(mail);
+    const byName = await this.inactiveAccountRepository.findByName(name);
+    const byMail = await this.inactiveAccountRepository.findByMail(mail);
 
     return Option.isSome(byName) || Option.isSome(byMail);
   }
@@ -132,11 +119,10 @@ export const register = Ether.newEther(
   registerSymbol,
   (deps) => new RegisterService(deps),
   {
-    repository: accountRepoSymbol,
+    repository: inactiveAccountRepoSymbol,
     idGenerator: snowflakeIDGeneratorSymbol,
     passwordEncoder: passwordEncoderSymbol,
     notificationModule: notificationModuleFacadeSymbol,
     verifyAccountTokenService: verifyAccountTokenSymbol,
-    clock: clockSymbol,
   },
 );

--- a/pkg/accounts/service/resendToken.test.ts
+++ b/pkg/accounts/service/resendToken.test.ts
@@ -3,58 +3,51 @@ import { afterEach, describe, expect, it } from 'vitest';
 import { notificationModule } from '../../intermodule/notification.js';
 import { MockClock } from '../../internal/id/mod.js';
 import { InMemoryAccountRepository } from '../adaptor/repository/dummy/account.js';
+import { InMemoryInactiveAccountRepository } from '../adaptor/repository/dummy/inactiveAccount.js';
 import { InMemoryAccountVerifyTokenRepository } from '../adaptor/repository/dummy/verifyToken.js';
-import { Account, type AccountID } from '../model/account.js';
+import type { AccountID } from '../model/account.js';
 import { AccountNotFoundError } from '../model/errors.js';
+import { InactiveAccount } from '../model/inactiveAccount.js';
 import { ResendVerifyTokenService } from './resendToken.js';
 import { VerifyAccountTokenService } from './verifyToken.js';
 
-const repository = new InMemoryAccountRepository();
-await repository.create(
-  Account.new({
+const inactiveAccountRepository = new InMemoryInactiveAccountRepository();
+await inactiveAccountRepository.create(
+  InactiveAccount.reconstruct({
     id: '1' as AccountID,
     name: '@john@example.com',
     mail: 'johndoe@example.com',
-    nickname: 'John Doe',
     passphraseHash: 'hash',
-    bio: '',
     role: 'normal',
-    createdAt: new Date(),
   }),
 );
+
 const verifyRepository = new InMemoryAccountVerifyTokenRepository();
 const accountRepository = new InMemoryAccountRepository();
-await accountRepository.create(
-  Account.reconstruct({
-    id: '1' as AccountID,
-    name: '@john@example.com',
-    bio: '',
-    frozen: 'normal',
-    mail: '',
-    nickname: '',
-    role: 'normal',
-    silenced: 'normal',
-    status: 'active',
-    passphraseHash: undefined,
-    createdAt: new Date(),
-    deletedAt: undefined,
-    updatedAt: undefined,
-  }),
-);
 const mockClock = new MockClock(new Date('2023-09-10T00:00:00Z'));
 
 const verifyAccountTokenService = new VerifyAccountTokenService(
   verifyRepository,
+  inactiveAccountRepository,
   accountRepository,
   mockClock,
 );
 
 describe('ResendVerifyTokenService', () => {
-  afterEach(() => repository.reset());
+  afterEach(() => inactiveAccountRepository.reset());
 
   it('resend verify token', async () => {
+    await inactiveAccountRepository.create(
+      InactiveAccount.reconstruct({
+        id: '1' as AccountID,
+        name: '@john@example.com',
+        mail: 'johndoe@example.com',
+        passphraseHash: 'hash',
+        role: 'normal',
+      }),
+    );
     const service = new ResendVerifyTokenService(
-      repository,
+      inactiveAccountRepository,
       verifyAccountTokenService,
       notificationModule,
     );
@@ -64,7 +57,7 @@ describe('ResendVerifyTokenService', () => {
 
   it('when account not found', async () => {
     const service = new ResendVerifyTokenService(
-      repository,
+      inactiveAccountRepository,
       verifyAccountTokenService,
       notificationModule,
     );

--- a/pkg/accounts/service/resendToken.ts
+++ b/pkg/accounts/service/resendToken.ts
@@ -4,13 +4,10 @@ import {
   notificationModuleFacadeSymbol,
 } from '../../intermodule/notification.js';
 import type { AccountName } from '../model/account.js';
+import { AccountNotFoundError } from '../model/errors.js';
 import {
-  AccountMailAddressAlreadyVerifiedError,
-  AccountNotFoundError,
-} from '../model/errors.js';
-import {
-  type AccountRepository,
-  accountRepoSymbol,
+  type InactiveAccountRepository,
+  inactiveAccountRepoSymbol,
 } from '../model/repository.js';
 import {
   type VerifyAccountTokenService,
@@ -18,36 +15,28 @@ import {
 } from './verifyToken.js';
 
 export class ResendVerifyTokenService {
-  private readonly accountRepository: AccountRepository;
+  private readonly inactiveAccountRepository: InactiveAccountRepository;
   private readonly verifyAccountTokenService: VerifyAccountTokenService;
   private readonly notificationModule: NotificationModuleFacade;
 
   constructor(
-    accountRepository: AccountRepository,
+    inactiveAccountRepository: InactiveAccountRepository,
     verifyAccountTokenService: VerifyAccountTokenService,
     notificationModule: NotificationModuleFacade,
   ) {
-    this.accountRepository = accountRepository;
+    this.inactiveAccountRepository = inactiveAccountRepository;
     this.verifyAccountTokenService = verifyAccountTokenService;
     this.notificationModule = notificationModule;
   }
 
   async handle(name: AccountName): Promise<Option.Option<Error>> {
-    const accountRes = await this.accountRepository.findByName(name);
+    const accountRes = await this.inactiveAccountRepository.findByName(name);
     if (Option.isNone(accountRes)) {
       return Option.some(
         new AccountNotFoundError('account not found', { cause: null }),
       );
     }
     const account = Option.unwrap(accountRes);
-
-    if (account.isActivated()) {
-      return Option.some(
-        new AccountMailAddressAlreadyVerifiedError('account already verified', {
-          cause: null,
-        }),
-      );
-    }
 
     const tokenRes = await this.verifyAccountTokenService.generate(
       account.getName(),
@@ -71,14 +60,18 @@ export const resendTokenSymbol =
   Ether.newEtherSymbol<ResendVerifyTokenService>();
 export const resendToken = Ether.newEther(
   resendTokenSymbol,
-  ({ accountRepository, verifyAccountTokenService, notificationModule }) =>
+  ({
+    inactiveAccountRepository,
+    verifyAccountTokenService,
+    notificationModule,
+  }) =>
     new ResendVerifyTokenService(
-      accountRepository,
+      inactiveAccountRepository,
       verifyAccountTokenService,
       notificationModule,
     ),
   {
-    accountRepository: accountRepoSymbol,
+    inactiveAccountRepository: inactiveAccountRepoSymbol,
     verifyAccountTokenService: verifyAccountTokenSymbol,
     notificationModule: notificationModuleFacadeSymbol,
   },

--- a/pkg/accounts/service/verifyToken.test.ts
+++ b/pkg/accounts/service/verifyToken.test.ts
@@ -2,33 +2,31 @@ import { Option, Result } from '@mikuroxina/mini-fn';
 import { describe, expect, it } from 'vitest';
 import { MockClock } from '../../internal/id/mod.js';
 import { InMemoryAccountRepository } from '../adaptor/repository/dummy/account.js';
+import { InMemoryInactiveAccountRepository } from '../adaptor/repository/dummy/inactiveAccount.js';
 import { InMemoryAccountVerifyTokenRepository } from '../adaptor/repository/dummy/verifyToken.js';
-import { Account, type AccountID } from '../model/account.js';
+import type { AccountID } from '../model/account.js';
+import { InactiveAccount } from '../model/inactiveAccount.js';
 import { VerifyAccountTokenService } from './verifyToken.js';
 
 const repository = new InMemoryAccountVerifyTokenRepository();
+const inactiveAccountRepository = new InMemoryInactiveAccountRepository();
 const accountRepository = new InMemoryAccountRepository();
-await accountRepository.create(
-  Account.reconstruct({
+
+await inactiveAccountRepository.create(
+  InactiveAccount.reconstruct({
     id: '1' as AccountID,
     name: '@johndoe@example.com',
-    nickname: '',
-    mail: '',
-    bio: '',
-    frozen: 'normal',
+    mail: 'johndoe@example.com',
+    passphraseHash: 'hash',
     role: 'normal',
-    silenced: 'normal',
-    status: 'active',
-    passphraseHash: undefined,
-    createdAt: new Date(),
-    updatedAt: undefined,
-    deletedAt: undefined,
   }),
 );
+
 const mockClock = new MockClock(new Date('2023-09-10T00:00:00Z'));
 
 const service = new VerifyAccountTokenService(
   repository,
+  inactiveAccountRepository,
   accountRepository,
   mockClock,
 );
@@ -57,6 +55,7 @@ describe('VerifyAccountTokenService', () => {
   it('expired token', async () => {
     const dummyService = new VerifyAccountTokenService(
       repository,
+      inactiveAccountRepository,
       accountRepository,
       mockClock,
     );

--- a/pkg/accounts/service/verifyToken.ts
+++ b/pkg/accounts/service/verifyToken.ts
@@ -10,21 +10,19 @@ import {
   type AccountRepository,
   type AccountVerifyTokenRepository,
   accountRepoSymbol,
+  type InactiveAccountRepository,
+  inactiveAccountRepoSymbol,
   verifyTokenRepoSymbol,
 } from '../model/repository.js';
 
 export class VerifyAccountTokenService {
   constructor(
     private readonly repository: AccountVerifyTokenRepository,
+    private readonly inactiveAccountRepository: InactiveAccountRepository,
     private readonly accountRepository: AccountRepository,
     private readonly clock: Clock,
   ) {}
 
-  /**
-   * Generate a token for account mail address verification.
-   * @param accountName
-   * @returns if success: void, if failure: Error
-   */
   async generate(
     accountName: AccountName,
   ): Promise<Result.Result<Error, string>> {
@@ -37,7 +35,8 @@ export class VerifyAccountTokenService {
 
     const encodedToken = Buffer.from(verifyToken).toString('base64url');
 
-    const account = await this.accountRepository.findByName(accountName);
+    const account =
+      await this.inactiveAccountRepository.findByName(accountName);
     if (Option.isNone(account)) {
       return Result.err(
         new AccountNotFoundError('account not found', { cause: null }),
@@ -56,25 +55,20 @@ export class VerifyAccountTokenService {
     return Result.ok(encodedToken);
   }
 
-  /**
-   * Verify a token for account mail address verification.
-   * @param accountName
-   * @param token
-   * @returns if success: void, if failure: Error
-   */
   async verify(
     accountName: AccountName,
     token: string,
   ): Promise<Result.Result<Error, void>> {
-    const accountRes = await this.accountRepository.findByName(accountName);
-    if (Option.isNone(accountRes)) {
+    const inactiveAccountRes =
+      await this.inactiveAccountRepository.findByName(accountName);
+    if (Option.isNone(inactiveAccountRes)) {
       return Result.err(
         new AccountNotFoundError('account not found', { cause: null }),
       );
     }
-    const account = Option.unwrap(accountRes);
+    const inactiveAccount = Option.unwrap(inactiveAccountRes);
 
-    const tokenRes = await this.repository.findByID(account.getID());
+    const tokenRes = await this.repository.findByID(inactiveAccount.getID());
     if (Option.isNone(tokenRes)) {
       return Result.err(
         new AccountNotFoundError('account not found', { cause: null }),
@@ -98,15 +92,31 @@ export class VerifyAccountTokenService {
       );
     }
 
-    const deleteTokenRes = await this.repository.delete(account.getID());
+    const deleteTokenRes = await this.repository.delete(
+      inactiveAccount.getID(),
+    );
     if (Result.isErr(deleteTokenRes)) {
       return deleteTokenRes;
     }
 
-    account.activate();
-    const editRes = await this.accountRepository.edit(account);
-    if (Result.isErr(editRes)) {
-      return editRes;
+    const activateRes = inactiveAccount.activate({
+      createdAt: new Date(Number(this.clock.now())),
+    });
+    if (Result.isErr(activateRes)) {
+      return Result.err(activateRes[1]);
+    }
+    const account = Result.unwrap(activateRes);
+
+    const createRes = await this.accountRepository.create(account);
+    if (Result.isErr(createRes)) {
+      return createRes;
+    }
+
+    const deleteInactiveRes = await this.inactiveAccountRepository.delete(
+      inactiveAccount.getID(),
+    );
+    if (Result.isErr(deleteInactiveRes)) {
+      return deleteInactiveRes;
     }
 
     return Result.ok(undefined);
@@ -117,14 +127,21 @@ export const verifyAccountTokenSymbol =
   Ether.newEtherSymbol<VerifyAccountTokenService>();
 export const verifyAccountToken = Ether.newEther(
   verifyAccountTokenSymbol,
-  ({ verifyTokenRepository, accountRepository, clock }) =>
+  ({
+    verifyTokenRepository,
+    inactiveAccountRepository,
+    accountRepository,
+    clock,
+  }) =>
     new VerifyAccountTokenService(
       verifyTokenRepository,
+      inactiveAccountRepository,
       accountRepository,
       clock,
     ),
   {
     verifyTokenRepository: verifyTokenRepoSymbol,
+    inactiveAccountRepository: inactiveAccountRepoSymbol,
     accountRepository: accountRepoSymbol,
     clock: clockSymbol,
   },

--- a/pkg/notification/adaptor/controller/notification.ts
+++ b/pkg/notification/adaptor/controller/notification.ts
@@ -56,7 +56,7 @@ export class NotificationController {
   ): Promise<
     Result.Result<Error, z.infer<typeof GetNotificationsResponseSchema>>
   > {
-    if (!!options.afterID && !!options.beforeID) {
+    if (options.afterID && options.beforeID) {
       return Result.err(
         new Error('Cannot specify both after_id and before_id'),
       );

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -198,6 +198,15 @@ model AccountVerifyToken {
   @@map("account_verify_token")
 }
 
+model InactiveAccount {
+  id        String   @id
+  name      String   @unique
+  mail      String   @unique
+  createdAt DateTime @default(now()) @map("created_at")
+
+  @@map("inactive_account")
+}
+
 model Notification {
   id               String    @id
   recipientID      String    @map("recipient_id")

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -34,9 +34,8 @@ model Account {
   reaction           Reaction[]
   bookmark           Bookmark[]
   listMember         ListMember[]
-  medium             Medium[]
-  accountVerifyToken AccountVerifyToken[]
-  list               List[]
+  medium Medium[]
+  list   List[]
 
   recievedNotification Notification[] @relation("recipient")
   sentNotification     Notification[] @relation("actor")
@@ -190,19 +189,23 @@ model NoteAttachment {
 }
 
 model AccountVerifyToken {
-  accountId String   @id @map("account_id")
-  account   Account  @relation(fields: [accountId], references: [id])
-  token     String
-  expiresAt DateTime @map("expires_at")
+  accountId       String          @id @map("account_id")
+  inactiveAccount InactiveAccount @relation(fields: [accountId], references: [id])
+  token           String
+  expiresAt       DateTime        @map("expires_at")
 
   @@map("account_verify_token")
 }
 
 model InactiveAccount {
-  id        String   @id
-  name      String   @unique
-  mail      String   @unique
-  createdAt DateTime @default(now()) @map("created_at")
+  id             String   @id
+  name           String   @unique
+  mail           String   @unique
+  passphraseHash String   @map("passphrase_hash")
+  role           Int      @default(0)
+  createdAt      DateTime @default(now()) @map("created_at")
+
+  accountVerifyToken AccountVerifyToken?
 
   @@map("inactive_account")
 }


### PR DESCRIPTION
related #1629 (スコープが大きいので分割してやっています)

## What does this PR do?
- 仮登録状態のアカウント(InactiveAccount)をAccountから完全に分離しました
  - それに伴っていくらかメソッドの追加/ディレクトリ構造の変更を行っています
- RegisterServiceがずっとAccountを生成していたミスを修正
- PrismaRepositoryで不正なroleが指定された場合，normalへのフォールバック時にログを出すように

## Additional information
- マージ後作業:
  - 仮登録アカウントでできない操作を洗い出す
  - トークンに仮登録アカウントであるかのフラグを付与する？
    - ミドルウェアレベルで仮登録アカウントかを判定できる
