### PR TITLE
refactor: ダイレクトNoteをNoteから分離

### DIFF
--- a/pkg/notes/adaptor/controller/note.ts
+++ b/pkg/notes/adaptor/controller/note.ts
@@ -28,12 +28,10 @@ export class NoteController {
     visibility: string;
     contentsWarningComment: string;
     attachmentFileID: string[];
-    sendTo?: string;
   }): Promise<Result.Result<Error, z.infer<typeof CreateNoteResponseSchema>>> {
     const noteRes = await this.createService.handle(
       args.content,
       args.contentsWarningComment,
-      !args.sendTo ? Option.none() : Option.some(args.sendTo as AccountID),
       args.authorID as AccountID,
       args.attachmentFileID as MediumID[],
       args.visibility as NoteVisibility,
@@ -56,9 +54,6 @@ export class NoteController {
       content: note.getContent(),
       visibility: note.getVisibility(),
       contents_warning_comment: note.getCwComment(),
-      send_to: Option.isSome(note.getSendTo())
-        ? Option.unwrap(note.getSendTo())
-        : undefined,
       author_id: note.getAuthorID(),
       created_at: note.getCreatedAt().toUTCString(),
       attachment_files: attachments.map((v) => {
@@ -123,9 +118,6 @@ export class NoteController {
       id: note.getID(),
       content: note.getContent(),
       contents_warning_comment: note.getCwComment(),
-      send_to: Option.isSome(note.getSendTo())
-        ? Option.unwrap(note.getSendTo())
-        : undefined,
       visibility: note.getVisibility(),
       created_at: note.getCreatedAt().toUTCString(),
       attachment_files: attachments.map((v) => {

--- a/pkg/notes/adaptor/repository/prisma/directNote.ts
+++ b/pkg/notes/adaptor/repository/prisma/directNote.ts
@@ -1,0 +1,201 @@
+import { Ether, Option, Result } from '@mikuroxina/mini-fn';
+
+import type { AccountID } from '../../../../accounts/model/account.js';
+import type { PrismaClient } from '../../../../adaptors/prisma/client.js';
+import type { prismaClient } from '../../../../adaptors/prisma.js';
+import { Medium, type MediumID } from '../../../../drive/model/medium.js';
+import { DirectNote, type DirectNoteID } from '../../../model/directNote.js';
+import {
+  type DirectNoteAttachmentRepository,
+  type DirectNoteConversationFilter,
+  type DirectNoteRepository,
+  directNoteAttachmentRepoSymbol,
+  directNoteRepoSymbol,
+} from '../../../model/repository.js';
+
+type RawDirectNote = Awaited<
+  ReturnType<typeof prismaClient.directNote.findUnique>
+>;
+
+type RawDirectNoteAttachment = Awaited<
+  ReturnType<
+    typeof prismaClient.directNoteAttachment.findMany<{
+      include: { medium: true };
+    }>
+  >
+>;
+
+export class PrismaDirectNoteRepository implements DirectNoteRepository {
+  constructor(private readonly client: PrismaClient) {}
+
+  private deserialize(data: RawDirectNote): DirectNote {
+    if (!data) {
+      throw new Error('Invalid DirectNote data');
+    }
+    return DirectNote.reconstruct({
+      id: data.id as DirectNoteID,
+      authorID: data.authorId as AccountID,
+      recipientID: data.recipientId as AccountID,
+      content: data.text,
+      // NOTE: contentsWarningComment is not stored in DB yet
+      contentsWarningComment: '',
+      attachmentFileID: [],
+      createdAt: data.createdAt,
+      deletedAt: data.deletedAt ? Option.some(data.deletedAt) : Option.none(),
+    });
+  }
+
+  async create(note: DirectNote): Promise<Result.Result<Error, void>> {
+    try {
+      await this.client.directNote.create({
+        data: {
+          id: note.getID(),
+          text: note.getContent(),
+          authorId: note.getAuthorID(),
+          recipientId: note.getRecipientID(),
+          createdAt: note.getCreatedAt(),
+          deletedAt: Option.isNone(note.getDeletedAt())
+            ? undefined
+            : Option.unwrap(note.getDeletedAt()),
+        },
+      });
+      return Result.ok(undefined);
+    } catch (e) {
+      return Result.err(e as Error);
+    }
+  }
+
+  async findByID(
+    id: DirectNoteID,
+  ): Promise<Result.Result<Error, Option.Option<DirectNote>>> {
+    try {
+      const res = await this.client.directNote.findUnique({
+        where: { id, deletedAt: null },
+      });
+      if (!res) return Result.ok(Option.none());
+      return Result.ok(Option.some(this.deserialize(res)));
+    } catch (e) {
+      return Result.err(e as Error);
+    }
+  }
+
+  async findByRecipientID(
+    recipientID: AccountID,
+  ): Promise<Result.Result<Error, DirectNote[]>> {
+    try {
+      const res = await this.client.directNote.findMany({
+        where: { recipientId: recipientID, deletedAt: null },
+        orderBy: { createdAt: 'desc' },
+      });
+      return Result.ok(res.map((v) => this.deserialize(v)));
+    } catch (e) {
+      return Result.err(e as Error);
+    }
+  }
+
+  async findConversation(
+    accountA: AccountID,
+    accountB: AccountID,
+    filter: DirectNoteConversationFilter,
+  ): Promise<Result.Result<Error, DirectNote[]>> {
+    try {
+      const res = await this.client.directNote.findMany({
+        where: {
+          deletedAt: null,
+          OR: [
+            { authorId: accountA, recipientId: accountB },
+            { authorId: accountB, recipientId: accountA },
+          ],
+        },
+        orderBy: { createdAt: 'desc' },
+        take: filter.limit,
+        ...(filter.cursor
+          ? {
+              cursor: { id: filter.cursor.id },
+              skip: 1,
+            }
+          : {}),
+      });
+      return Result.ok(res.map((v) => this.deserialize(v)));
+    } catch (e) {
+      return Result.err(e as Error);
+    }
+  }
+
+  async deleteByID(id: DirectNoteID): Promise<Result.Result<Error, void>> {
+    try {
+      await this.client.directNote.update({
+        where: { id },
+        data: { deletedAt: new Date() },
+      });
+      return Result.ok(undefined);
+    } catch (e) {
+      return Result.err(e as Error);
+    }
+  }
+}
+
+export const prismaDirectNoteRepo = (client: PrismaClient) =>
+  Ether.newEther(
+    directNoteRepoSymbol,
+    () => new PrismaDirectNoteRepository(client),
+  );
+
+export class PrismaDirectNoteAttachmentRepository
+  implements DirectNoteAttachmentRepository
+{
+  constructor(private readonly client: PrismaClient) {}
+
+  private deserialize(data: RawDirectNoteAttachment): Medium[] {
+    return data.map((v) => {
+      const medium = v.medium;
+      return Medium.reconstruct({
+        authorId: medium.authorId as AccountID,
+        hash: medium.hash,
+        id: medium.id as MediumID,
+        mime: medium.mime,
+        name: medium.name,
+        nsfw: medium.nsfw,
+        thumbnailUrl: medium.thumbnailUrl,
+        url: medium.url,
+      });
+    });
+  }
+
+  async create(
+    directNoteID: DirectNoteID,
+    attachmentFileID: readonly MediumID[],
+  ): Promise<Result.Result<Error, void>> {
+    const data = [...attachmentFileID].map((v) => ({
+      directNoteId: directNoteID,
+      mediumId: v,
+      alt: '',
+    }));
+    try {
+      await this.client.directNoteAttachment.createMany({ data });
+      return Result.ok(undefined);
+    } catch (e) {
+      return Result.err(e as Error);
+    }
+  }
+
+  async findByDirectNoteID(
+    directNoteID: DirectNoteID,
+  ): Promise<Result.Result<Error, Medium[]>> {
+    try {
+      const res = await this.client.directNoteAttachment.findMany({
+        where: { directNoteId: directNoteID },
+        include: { medium: true },
+      });
+      return Result.ok(this.deserialize(res));
+    } catch (e) {
+      return Result.err(e as Error);
+    }
+  }
+}
+
+export const prismaDirectNoteAttachmentRepo = (client: PrismaClient) =>
+  Ether.newEther(
+    directNoteAttachmentRepoSymbol,
+    () => new PrismaDirectNoteAttachmentRepository(client),
+  );

--- a/pkg/notes/adaptor/repository/prisma/directNote.ts
+++ b/pkg/notes/adaptor/repository/prisma/directNote.ts
@@ -7,7 +7,6 @@ import { Medium, type MediumID } from '../../../../drive/model/medium.js';
 import { DirectNote, type DirectNoteID } from '../../../model/directNote.js';
 import {
   type DirectNoteAttachmentRepository,
-  type DirectNoteConversationFilter,
   type DirectNoteRepository,
   directNoteAttachmentRepoSymbol,
   directNoteRepoSymbol,
@@ -88,39 +87,6 @@ export class PrismaDirectNoteRepository implements DirectNoteRepository {
         orderBy: { createdAt: 'desc' },
       });
       return Result.ok(res.map((v) => this.deserialize(v)));
-    } catch (e) {
-      return Result.err(e as Error);
-    }
-  }
-
-  async findConversation(
-    accountA: AccountID,
-    accountB: AccountID,
-    filter: DirectNoteConversationFilter,
-  ): Promise<Result.Result<Error, DirectNote[]>> {
-    // For 'after' cursor (get notes newer than cursor): query asc then reverse to keep desc order.
-    // For 'before' cursor or no cursor: query desc directly.
-    const isAfter = filter.cursor?.type === 'after';
-    try {
-      const res = await this.client.directNote.findMany({
-        where: {
-          deletedAt: null,
-          OR: [
-            { authorId: accountA, recipientId: accountB },
-            { authorId: accountB, recipientId: accountA },
-          ],
-        },
-        orderBy: { createdAt: isAfter ? 'asc' : 'desc' },
-        take: filter.limit,
-        ...(filter.cursor
-          ? {
-              cursor: { id: filter.cursor.id },
-              skip: 1,
-            }
-          : {}),
-      });
-      const notes = res.map((v) => this.deserialize(v));
-      return Result.ok(isAfter ? notes.reverse() : notes);
     } catch (e) {
       return Result.err(e as Error);
     }

--- a/pkg/notes/adaptor/repository/prisma/directNote.ts
+++ b/pkg/notes/adaptor/repository/prisma/directNote.ts
@@ -98,6 +98,9 @@ export class PrismaDirectNoteRepository implements DirectNoteRepository {
     accountB: AccountID,
     filter: DirectNoteConversationFilter,
   ): Promise<Result.Result<Error, DirectNote[]>> {
+    // For 'after' cursor (get notes newer than cursor): query asc then reverse to keep desc order.
+    // For 'before' cursor or no cursor: query desc directly.
+    const isAfter = filter.cursor?.type === 'after';
     try {
       const res = await this.client.directNote.findMany({
         where: {
@@ -107,7 +110,7 @@ export class PrismaDirectNoteRepository implements DirectNoteRepository {
             { authorId: accountB, recipientId: accountA },
           ],
         },
-        orderBy: { createdAt: 'desc' },
+        orderBy: { createdAt: isAfter ? 'asc' : 'desc' },
         take: filter.limit,
         ...(filter.cursor
           ? {
@@ -116,7 +119,8 @@ export class PrismaDirectNoteRepository implements DirectNoteRepository {
             }
           : {}),
       });
-      return Result.ok(res.map((v) => this.deserialize(v)));
+      const notes = res.map((v) => this.deserialize(v));
+      return Result.ok(isAfter ? notes.reverse() : notes);
     } catch (e) {
       return Result.err(e as Error);
     }

--- a/pkg/notes/adaptor/repository/prisma/note.ts
+++ b/pkg/notes/adaptor/repository/prisma/note.ts
@@ -1,12 +1,15 @@
 import { Ether, Option, Result } from '@mikuroxina/mini-fn';
-import type { AccountID } from '../../../accounts/model/account.js';
-import type { Prisma, PrismaClient } from '../../../adaptors/prisma/client.js';
-import type { prismaClient } from '../../../adaptors/prisma.js';
-import { Medium, type MediumID } from '../../../drive/model/medium.js';
-import { Bookmark } from '../../model/bookmark.js';
-import { Note, type NoteID, type NoteVisibility } from '../../model/note.js';
-import { Reaction, type ReactionID } from '../../model/reaction.js';
-import { RenoteStatus } from '../../model/renoteStatus.js';
+import type { AccountID } from '../../../../accounts/model/account.js';
+import type {
+  Prisma,
+  PrismaClient,
+} from '../../../../adaptors/prisma/client.js';
+import type { prismaClient } from '../../../../adaptors/prisma.js';
+import { Medium, type MediumID } from '../../../../drive/model/medium.js';
+import { Bookmark } from '../../../model/bookmark.js';
+import { Note, type NoteID, type NoteVisibility } from '../../../model/note.js';
+import { Reaction, type ReactionID } from '../../../model/reaction.js';
+import { RenoteStatus } from '../../../model/renoteStatus.js';
 import {
   type BookmarkRepository,
   bookmarkRepoSymbol,
@@ -16,8 +19,8 @@ import {
   noteRepoSymbol,
   type ReactionRepository,
   reactionRepoSymbol,
-} from '../../model/repository.js';
-import { noteModuleLogger } from '../logger.js';
+} from '../../../model/repository.js';
+import { noteModuleLogger } from '../../logger.js';
 
 type DeserializeNoteArgs = Awaited<
   ReturnType<typeof prismaClient.note.findUnique>

--- a/pkg/notes/mod.ts
+++ b/pkg/notes/mod.ts
@@ -27,6 +27,7 @@ import {
   inMemoryNoteRepo,
   inMemoryReactionRepo,
 } from './adaptor/repository/dummy.js';
+import { prismaDirectNoteRepo } from './adaptor/repository/prisma/directNote.js';
 import {
   prismaBookmarkRepo,
   prismaNoteAttachmentRepo,
@@ -39,7 +40,6 @@ import {
   NoteAttachmentNotFoundError,
   NoteContentLengthError,
   NoteEmojiNotFoundError,
-  NoteNoDestinationError,
   NoteNotFoundError,
   NoteNotReactedYetError,
   NoteTooManyAttachmentsError,
@@ -63,6 +63,8 @@ import { fetch } from './service/fetch.js';
 import { renote } from './service/renote.js';
 
 // NOTE: These dependency Ethers are shared between intermodule and notes module to ensure the same instances are used
+// NOTE: No in-memory fallback — DirectNote repo is Prisma-only until a dev-mode stub is introduced
+export const directNoteRepoEther = prismaDirectNoteRepo(prismaClient);
 export const noteAttachmentRepoEther = isProduction
   ? prismaNoteAttachmentRepo(prismaClient)
   : inMemoryNoteAttachmentRepo([], []);
@@ -182,13 +184,8 @@ noteHandlers[CreateNoteRoute.method](
   AuthMiddleware.handle({ forceAuthorized: true }),
 );
 noteHandlers.openapi(CreateNoteRoute, async (c) => {
-  const {
-    content,
-    visibility,
-    contents_warning_comment,
-    send_to,
-    attachment_file_ids,
-  } = c.req.valid('json');
+  const { content, visibility, contents_warning_comment, attachment_file_ids } =
+    c.req.valid('json');
   const accountID = Option.unwrap(c.get('accountID'));
 
   const res = await controller.createNote({
@@ -197,7 +194,6 @@ noteHandlers.openapi(CreateNoteRoute, async (c) => {
     visibility,
     contentsWarningComment: contents_warning_comment,
     attachmentFileID: attachment_file_ids,
-    sendTo: send_to,
   });
   if (Result.isErr(res)) {
     const error = Result.unwrapErr(res);
@@ -207,9 +203,6 @@ noteHandlers.openapi(CreateNoteRoute, async (c) => {
     }
     if (error instanceof NoteContentLengthError) {
       return c.json({ error: 'TOO_MANY_CONTENT' as const }, 400);
-    }
-    if (error instanceof NoteNoDestinationError) {
-      return c.json({ error: 'NO_DESTINATION' as const }, 400);
     }
     if (error instanceof NoteVisibilityInvalidError) {
       return c.json({ error: 'INVALID_VISIBILITY' as const }, 400);
@@ -280,9 +273,6 @@ noteHandlers.openapi(RenoteRoute, async (c) => {
     }
     if (error instanceof NoteContentLengthError) {
       return c.json({ error: 'TOO_MANY_CONTENT' as const }, 400);
-    }
-    if (error instanceof NoteNoDestinationError) {
-      return c.json({ error: 'NO_DESTINATION' as const }, 400);
     }
     if (error instanceof NoteVisibilityInvalidError) {
       return c.json({ error: 'INVALID_VISIBILITY' as const }, 400);

--- a/pkg/notes/mod.ts
+++ b/pkg/notes/mod.ts
@@ -32,7 +32,7 @@ import {
   prismaNoteAttachmentRepo,
   prismaNoteRepo,
   prismaReactionRepo,
-} from './adaptor/repository/prisma.js';
+} from './adaptor/repository/prisma/note.js';
 import {
   NoteAccountSilencedError,
   NoteAlreadyReactedError,

--- a/pkg/notes/model/directNote.test.ts
+++ b/pkg/notes/model/directNote.test.ts
@@ -1,0 +1,132 @@
+import { Option, Result } from '@mikuroxina/mini-fn';
+import { describe, expect, it } from 'vitest';
+
+import type { AccountID } from '../../accounts/model/account.js';
+import type { MediumID } from '../../drive/model/medium.js';
+import {
+  type CreateDirectNoteArgs,
+  DirectNote,
+  type DirectNoteID,
+} from './directNote.js';
+import {
+  DirectNoteContentLengthError,
+  DirectNoteTooManyAttachmentsError,
+} from './errors.js';
+
+const exampleInput: Omit<CreateDirectNoteArgs, 'deletedAt'> = {
+  id: '1' as DirectNoteID,
+  authorID: '2' as AccountID,
+  recipientID: '3' as AccountID,
+  content: 'hello world!',
+  contentsWarningComment: '',
+  attachmentFileID: [],
+  createdAt: new Date('2023-09-10T00:00:00.000Z'),
+};
+
+describe('DirectNote', () => {
+  it('generate new instance', () => {
+    const note = Result.unwrap(DirectNote.new(exampleInput));
+
+    expect(note.getID()).toBe(exampleInput.id);
+    expect(note.getAuthorID()).toBe(exampleInput.authorID);
+    expect(note.getRecipientID()).toBe(exampleInput.recipientID);
+    expect(note.getContent()).toBe(exampleInput.content);
+    expect(note.getCwComment()).toBe(exampleInput.contentsWarningComment);
+    expect(note.getAttachmentFileID()).toStrictEqual([]);
+    expect(note.getCreatedAt()).toBe(exampleInput.createdAt);
+    expect(note.getDeletedAt()).toStrictEqual(Option.none());
+  });
+
+  it.each([
+    {
+      name: 'with attachments',
+      args: { attachmentFileID: ['10' as MediumID, '20' as MediumID] },
+      expected: { content: exampleInput.content, attachmentCount: 2 },
+    },
+    {
+      name: 'with only attachments (no text)',
+      args: { content: '', attachmentFileID: ['10' as MediumID] },
+      expected: { content: '', attachmentCount: 1 },
+    },
+    {
+      name: 'with only CW comment',
+      args: { content: '', contentsWarningComment: 'CW text' },
+      expected: { content: '', attachmentCount: 0 },
+    },
+  ])('generate instance $name', ({ args, expected }) => {
+    const note = Result.unwrap(DirectNote.new({ ...exampleInput, ...args }));
+
+    expect(note.getContent()).toBe(expected.content);
+    expect(note.getAttachmentFileID()).toHaveLength(expected.attachmentCount);
+  });
+
+  describe('invalid input', () => {
+    it.each([
+      {
+        name: 'content too long',
+        args: { ...exampleInput, content: 'a'.repeat(3001) },
+        expectedError: DirectNoteContentLengthError,
+      },
+      {
+        name: 'contentsWarningComment too long',
+        args: { ...exampleInput, contentsWarningComment: 'a'.repeat(257) },
+        expectedError: DirectNoteContentLengthError,
+      },
+      {
+        name: 'too many attachments',
+        args: {
+          ...exampleInput,
+          attachmentFileID: Array.from(
+            { length: 17 },
+            (_, i) => (i + 1).toString() as MediumID,
+          ),
+        },
+        expectedError: DirectNoteTooManyAttachmentsError,
+      },
+      {
+        name: 'empty content, no CW comment, and no attachments',
+        args: {
+          ...exampleInput,
+          content: '',
+          contentsWarningComment: '',
+          attachmentFileID: [],
+        },
+        expectedError: DirectNoteContentLengthError,
+      },
+    ])('$name returns error', ({ args, expectedError }) => {
+      const result = DirectNote.new(args);
+      expect(Result.isErr(result)).toBe(true);
+      expect(Result.unwrapErr(result)).toBeInstanceOf(expectedError);
+    });
+  });
+
+  describe('setDeletedAt', () => {
+    it('sets deletedAt when date is after createdAt', () => {
+      const note = Result.unwrap(DirectNote.new(exampleInput));
+      const deletedAt = new Date('2023-09-11T00:00:00.000Z');
+
+      const result = note.setDeletedAt(deletedAt);
+      expect(Result.isOk(result)).toBe(true);
+      expect(note.getDeletedAt()).toStrictEqual(Option.some(deletedAt));
+    });
+
+    it('returns error when deletedAt is before createdAt', () => {
+      const note = Result.unwrap(DirectNote.new(exampleInput));
+      const deletedAt = new Date('2023-09-09T00:00:00.000Z');
+
+      const result = note.setDeletedAt(deletedAt);
+      expect(Result.isErr(result)).toBe(true);
+    });
+  });
+
+  it('reconstruct from stored data', () => {
+    const deletedAt = new Date('2023-09-11T00:00:00.000Z');
+    const note = DirectNote.reconstruct({
+      ...exampleInput,
+      deletedAt: Option.some(deletedAt),
+    });
+
+    expect(note.getID()).toBe(exampleInput.id);
+    expect(note.getDeletedAt()).toStrictEqual(Option.some(deletedAt));
+  });
+});

--- a/pkg/notes/model/directNote.ts
+++ b/pkg/notes/model/directNote.ts
@@ -1,0 +1,158 @@
+import { Option, Result } from '@mikuroxina/mini-fn';
+import * as v from 'valibot';
+
+import type { AccountID } from '../../accounts/model/account.js';
+import type { MediumID } from '../../drive/model/medium.js';
+import type { ID } from '../../internal/id/type.js';
+import {
+  DirectNoteContentLengthError,
+  DirectNoteDateInvalidError,
+  DirectNoteTooManyAttachmentsError,
+} from './errors.js';
+import { cwCommentSchema, noteContentSchema } from './note.js';
+
+export type DirectNoteID = ID<DirectNote>;
+
+export interface CreateDirectNoteArgs {
+  id: DirectNoteID;
+  authorID: AccountID;
+  recipientID: AccountID;
+  content: string;
+  contentsWarningComment: string;
+  attachmentFileID: readonly MediumID[];
+  createdAt: Date;
+  deletedAt: Option.Option<Date>;
+}
+
+type DirectNoteValidationError =
+  | DirectNoteContentLengthError
+  | DirectNoteTooManyAttachmentsError;
+
+const segmenter = new Intl.Segmenter();
+const graphemeLength = (s: string): number => [...segmenter.segment(s)].length;
+
+export class DirectNote {
+  readonly #id: DirectNoteID;
+  readonly #authorID: AccountID;
+  readonly #recipientID: AccountID;
+  readonly #content: string;
+  readonly #contentsWarningComment: string;
+  readonly #attachmentFileID: readonly MediumID[];
+  readonly #createdAt: Date;
+  #deletedAt: Option.Option<Date>;
+
+  private constructor(arg: CreateDirectNoteArgs) {
+    this.#id = arg.id;
+    this.#authorID = arg.authorID;
+    this.#recipientID = arg.recipientID;
+    this.#content = arg.content;
+    this.#contentsWarningComment = arg.contentsWarningComment;
+    this.#attachmentFileID = arg.attachmentFileID;
+    this.#createdAt = arg.createdAt;
+    this.#deletedAt = arg.deletedAt;
+  }
+
+  static new(
+    args: Omit<CreateDirectNoteArgs, 'deletedAt'>,
+  ): Result.Result<DirectNoteValidationError, DirectNote> {
+    const err = DirectNote.#checkArgs(args);
+    if (Result.isErr(err)) return err;
+    return Result.ok(new DirectNote({ ...args, deletedAt: Option.none() }));
+  }
+
+  static reconstruct(arg: CreateDirectNoteArgs): DirectNote {
+    return new DirectNote(arg);
+  }
+
+  static #checkArgs(
+    arg: Omit<CreateDirectNoteArgs, 'deletedAt'>,
+  ): Result.Result<DirectNoteValidationError, void> {
+    if (!v.safeParse(noteContentSchema, arg.content).success) {
+      return Result.err(
+        new DirectNoteContentLengthError('Content too long', {
+          cause: { contentLength: graphemeLength(arg.content) },
+        }),
+      );
+    }
+
+    if (!v.safeParse(cwCommentSchema, arg.contentsWarningComment).success) {
+      return Result.err(
+        new DirectNoteContentLengthError('ContentsWarningComment too long', {
+          cause: {
+            contentsWarningCommentLength: graphemeLength(
+              arg.contentsWarningComment,
+            ),
+          },
+        }),
+      );
+    }
+
+    if (arg.attachmentFileID.length > 16) {
+      return Result.err(
+        new DirectNoteTooManyAttachmentsError('Too many attachments', {
+          cause: { attachmentCount: arg.attachmentFileID.length },
+        }),
+      );
+    }
+
+    if (
+      arg.content === '' &&
+      arg.contentsWarningComment === '' &&
+      arg.attachmentFileID.length === 0
+    ) {
+      return Result.err(
+        new DirectNoteContentLengthError('DirectNote must have content', {
+          cause: null,
+        }),
+      );
+    }
+
+    return Result.ok(undefined);
+  }
+
+  getID(): DirectNoteID {
+    return this.#id;
+  }
+
+  getAuthorID(): AccountID {
+    return this.#authorID;
+  }
+
+  getRecipientID(): AccountID {
+    return this.#recipientID;
+  }
+
+  getContent(): string {
+    return this.#content;
+  }
+
+  getCwComment(): string {
+    return this.#contentsWarningComment;
+  }
+
+  getAttachmentFileID(): readonly MediumID[] {
+    return this.#attachmentFileID;
+  }
+
+  getCreatedAt(): Date {
+    return this.#createdAt;
+  }
+
+  getDeletedAt(): Option.Option<Date> {
+    return this.#deletedAt;
+  }
+
+  setDeletedAt(
+    deletedAt: Date,
+  ): Result.Result<DirectNoteDateInvalidError, void> {
+    if (this.#createdAt > deletedAt) {
+      return Result.err(
+        new DirectNoteDateInvalidError('deletedAt must be after createdAt', {
+          cause: null,
+        }),
+      );
+    }
+    this.#deletedAt = Option.some(deletedAt);
+    return Result.ok(undefined);
+  }
+}

--- a/pkg/notes/model/directNote.ts
+++ b/pkg/notes/model/directNote.ts
@@ -7,6 +7,7 @@ import type { ID } from '../../internal/id/type.js';
 import {
   DirectNoteContentLengthError,
   DirectNoteDateInvalidError,
+  DirectNoteSelfSendError,
   DirectNoteTooManyAttachmentsError,
 } from './errors.js';
 import { cwCommentSchema, noteContentSchema } from './note.js';
@@ -26,7 +27,8 @@ export interface CreateDirectNoteArgs {
 
 type DirectNoteValidationError =
   | DirectNoteContentLengthError
-  | DirectNoteTooManyAttachmentsError;
+  | DirectNoteTooManyAttachmentsError
+  | DirectNoteSelfSendError;
 
 const segmenter = new Intl.Segmenter();
 const graphemeLength = (s: string): number => [...segmenter.segment(s)].length;
@@ -67,6 +69,14 @@ export class DirectNote {
   static #checkArgs(
     arg: Omit<CreateDirectNoteArgs, 'deletedAt'>,
   ): Result.Result<DirectNoteValidationError, void> {
+    if (arg.authorID === arg.recipientID) {
+      return Result.err(
+        new DirectNoteSelfSendError('Cannot send direct note to yourself', {
+          cause: null,
+        }),
+      );
+    }
+
     if (!v.safeParse(noteContentSchema, arg.content).success) {
       return Result.err(
         new DirectNoteContentLengthError('Content too long', {

--- a/pkg/notes/model/errors.ts
+++ b/pkg/notes/model/errors.ts
@@ -125,3 +125,27 @@ export class NoteDateInvalidError extends Error {
     this.cause = options.cause;
   }
 }
+
+export class DirectNoteContentLengthError extends Error {
+  constructor(message: string, options: { cause: unknown }) {
+    super(message);
+    this.name = 'DirectNoteContentLengthError';
+    this.cause = options.cause;
+  }
+}
+
+export class DirectNoteTooManyAttachmentsError extends Error {
+  constructor(message: string, options: { cause: unknown }) {
+    super(message);
+    this.name = 'DirectNoteTooManyAttachmentsError';
+    this.cause = options.cause;
+  }
+}
+
+export class DirectNoteDateInvalidError extends Error {
+  constructor(message: string, options: { cause: unknown }) {
+    super(message);
+    this.name = 'DirectNoteDateInvalidError';
+    this.cause = options.cause;
+  }
+}

--- a/pkg/notes/model/errors.ts
+++ b/pkg/notes/model/errors.ts
@@ -149,3 +149,11 @@ export class DirectNoteDateInvalidError extends Error {
     this.cause = options.cause;
   }
 }
+
+export class DirectNoteSelfSendError extends Error {
+  constructor(message: string, options: { cause: unknown }) {
+    super(message);
+    this.name = 'DirectNoteSelfSendError';
+    this.cause = options.cause;
+  }
+}

--- a/pkg/notes/model/note.ts
+++ b/pkg/notes/model/note.ts
@@ -38,12 +38,12 @@ type NoteValidationError =
 const segmenter = new Intl.Segmenter();
 const graphemeLength = (s: string): number => [...segmenter.segment(s)].length;
 
-const noteContentSchema = v.pipe(
+export const noteContentSchema = v.pipe(
   v.string(),
   v.check((s) => graphemeLength(s) <= 3000),
 );
 
-const cwCommentSchema = v.pipe(
+export const cwCommentSchema = v.pipe(
   v.string(),
   v.check((s) => graphemeLength(s) <= 256),
 );

--- a/pkg/notes/model/repository.ts
+++ b/pkg/notes/model/repository.ts
@@ -71,17 +71,6 @@ export interface ReactionRepository {
 }
 export const reactionRepoSymbol = Ether.newEtherSymbol<ReactionRepository>();
 
-export interface DirectNoteConversationCursor {
-  type: 'before' | 'after';
-  id: DirectNoteID;
-}
-
-export interface DirectNoteConversationFilter {
-  /** @default 20 */
-  limit: number;
-  cursor?: DirectNoteConversationCursor;
-}
-
 export interface DirectNoteRepository {
   create(note: DirectNote): Promise<Result.Result<Error, void>>;
   findByID(
@@ -89,11 +78,6 @@ export interface DirectNoteRepository {
   ): Promise<Result.Result<Error, Option.Option<DirectNote>>>;
   findByRecipientID(
     recipientID: AccountID,
-  ): Promise<Result.Result<Error, DirectNote[]>>;
-  findConversation(
-    accountA: AccountID,
-    accountB: AccountID,
-    filter: DirectNoteConversationFilter,
   ): Promise<Result.Result<Error, DirectNote[]>>;
   deleteByID(id: DirectNoteID): Promise<Result.Result<Error, void>>;
 }

--- a/pkg/notes/model/repository.ts
+++ b/pkg/notes/model/repository.ts
@@ -3,6 +3,7 @@ import { Ether, type Option, type Result } from '@mikuroxina/mini-fn';
 import type { AccountID } from '../../accounts/model/account.js';
 import type { Medium, MediumID } from '../../drive/model/medium.js';
 import type { Bookmark } from './bookmark.js';
+import type { DirectNote, DirectNoteID } from './directNote.js';
 import type { Note, NoteID } from './note.js';
 import type { Reaction, ReactionID } from './reaction.js';
 import type { RenoteStatus } from './renoteStatus.js';
@@ -69,3 +70,44 @@ export interface ReactionRepository {
   deleteByID(id: ReactionID): Promise<Result.Result<Error, void>>;
 }
 export const reactionRepoSymbol = Ether.newEtherSymbol<ReactionRepository>();
+
+export interface DirectNoteConversationCursor {
+  type: 'before' | 'after';
+  id: DirectNoteID;
+}
+
+export interface DirectNoteConversationFilter {
+  /** @default 20 */
+  limit: number;
+  cursor?: DirectNoteConversationCursor;
+}
+
+export interface DirectNoteRepository {
+  create(note: DirectNote): Promise<Result.Result<Error, void>>;
+  findByID(
+    id: DirectNoteID,
+  ): Promise<Result.Result<Error, Option.Option<DirectNote>>>;
+  findByRecipientID(
+    recipientID: AccountID,
+  ): Promise<Result.Result<Error, DirectNote[]>>;
+  findConversation(
+    accountA: AccountID,
+    accountB: AccountID,
+    filter: DirectNoteConversationFilter,
+  ): Promise<Result.Result<Error, DirectNote[]>>;
+  deleteByID(id: DirectNoteID): Promise<Result.Result<Error, void>>;
+}
+export const directNoteRepoSymbol =
+  Ether.newEtherSymbol<DirectNoteRepository>();
+
+export interface DirectNoteAttachmentRepository {
+  create(
+    directNoteID: DirectNoteID,
+    attachmentFileID: readonly MediumID[],
+  ): Promise<Result.Result<Error, void>>;
+  findByDirectNoteID(
+    directNoteID: DirectNoteID,
+  ): Promise<Result.Result<Error, Medium[]>>;
+}
+export const directNoteAttachmentRepoSymbol =
+  Ether.newEtherSymbol<DirectNoteAttachmentRepository>();

--- a/pkg/notes/service/create.test.ts
+++ b/pkg/notes/service/create.test.ts
@@ -1,4 +1,4 @@
-import { Option, Result } from '@mikuroxina/mini-fn';
+import { Result } from '@mikuroxina/mini-fn';
 import { describe, expect, it } from 'vitest';
 
 import type { AccountID } from '../../accounts/model/account.js';
@@ -49,7 +49,6 @@ describe('CreateService', () => {
     const res = await createService.handle(
       'Hello world',
       '',
-      Option.none(),
       '1' as AccountID,
       [],
       'PUBLIC',
@@ -62,7 +61,6 @@ describe('CreateService', () => {
     const res = await createService.handle(
       'Hello world',
       '',
-      Option.none(),
       '1' as AccountID,
       ['10' as MediumID, '11' as MediumID],
       'PUBLIC',
@@ -75,7 +73,6 @@ describe('CreateService', () => {
     const res = await createService.handle(
       'Hello world',
       '',
-      Option.none(),
       '1' as AccountID,
       Array.from({ length: 17 }, (_, i) => i.toString() as MediumID),
       'PUBLIC',
@@ -88,7 +85,6 @@ describe('CreateService', () => {
     const res = await createService.handle(
       'a'.repeat(3001),
       '',
-      Option.none(),
       '1' as AccountID,
       [],
       'PUBLIC',
@@ -97,11 +93,10 @@ describe('CreateService', () => {
     expect(Result.isErr(res)).toBe(true);
   });
 
-  it('note visibility DIRECT must have a destination', async () => {
+  it('visibility DIRECT is rejected', async () => {
     const res = await createService.handle(
       'Hello world',
       '',
-      Option.none(),
       '1' as AccountID,
       [],
       'DIRECT',
@@ -114,7 +109,6 @@ describe('CreateService', () => {
     await createService.handle(
       'Hello world',
       '',
-      Option.none(),
       '101' as AccountID,
       [],
       'PUBLIC',

--- a/pkg/notes/service/create.ts
+++ b/pkg/notes/service/create.ts
@@ -12,7 +12,10 @@ import {
   type SnowflakeIDGenerator,
   snowflakeIDGeneratorSymbol,
 } from '../../internal/id/mod.js';
-import { NoteInternalError } from '../model/errors.js';
+import {
+  NoteInternalError,
+  NoteVisibilityInvalidError,
+} from '../model/errors.js';
 import { Note, type NoteID, type NoteVisibility } from '../model/note.js';
 import {
   type NoteAttachmentRepository,
@@ -25,11 +28,18 @@ export class CreateService {
   async handle(
     content: string,
     contentsWarningComment: string,
-    sendTo: Option.Option<AccountID>,
     authorID: AccountID,
     attachmentFileID: MediumID[],
     visibility: NoteVisibility,
   ): Promise<Result.Result<Error, Note>> {
+    if (visibility === 'DIRECT') {
+      return Result.err(
+        new NoteVisibilityInvalidError(
+          'Direct notes must use CreateDirectNoteService',
+          { cause: null },
+        ),
+      );
+    }
     const id = this.deps.idGenerator.generate<Note>();
     if (Result.isErr(id)) {
       return Result.err(
@@ -44,7 +54,7 @@ export class CreateService {
       content: content,
       contentsWarningComment: contentsWarningComment,
       createdAt: new Date(Number(now)),
-      sendTo: sendTo,
+      sendTo: Option.none(),
       originalNoteID: Option.none(),
       attachmentFileID: attachmentFileID,
       visibility: visibility,

--- a/pkg/notes/service/createDirect.test.ts
+++ b/pkg/notes/service/createDirect.test.ts
@@ -36,7 +36,6 @@ const mockDirectNoteRepo: DirectNoteRepository = {
   create: vi.fn().mockResolvedValue(Result.ok(undefined)),
   findByID: vi.fn(),
   findByRecipientID: vi.fn(),
-  findConversation: vi.fn(),
   deleteByID: vi.fn(),
 };
 

--- a/pkg/notes/service/createDirect.test.ts
+++ b/pkg/notes/service/createDirect.test.ts
@@ -1,0 +1,209 @@
+import { Result } from '@mikuroxina/mini-fn';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Account, AccountID } from '../../accounts/model/account.js';
+import { generateDummyAccount } from '../../accounts/testData/testData.js';
+import type { MediumID } from '../../drive/model/medium.js';
+import type { AccountModuleFacade } from '../../intermodule/account.js';
+import { MockClock, SnowflakeIDGenerator } from '../../internal/id/mod.js';
+import type {
+  DirectNoteAttachmentRepository,
+  DirectNoteRepository,
+} from '../model/repository.js';
+import { CreateDirectNoteService } from './createDirect.js';
+
+const author: Account = generateDummyAccount({
+  id: '1' as AccountID,
+  name: '@author@example.com',
+  role: 'normal',
+  silenced: 'normal',
+  status: 'active',
+  frozen: 'normal',
+  createdAt: new Date('2023-09-10T00:00:00Z'),
+});
+
+const recipient: Account = generateDummyAccount({
+  id: '2' as AccountID,
+  name: '@recipient@example.com',
+  role: 'normal',
+  silenced: 'normal',
+  status: 'active',
+  frozen: 'normal',
+  createdAt: new Date('2023-09-10T00:00:00Z'),
+});
+
+const mockDirectNoteRepo: DirectNoteRepository = {
+  create: vi.fn().mockResolvedValue(Result.ok(undefined)),
+  findByID: vi.fn(),
+  findByRecipientID: vi.fn(),
+  findConversation: vi.fn(),
+  deleteByID: vi.fn(),
+};
+
+const mockDirectNoteAttachmentRepo: DirectNoteAttachmentRepository = {
+  create: vi.fn().mockResolvedValue(Result.ok(undefined)),
+  findByDirectNoteID: vi.fn(),
+};
+
+const mockAccountModule = {
+  fetchAccount: vi.fn(),
+} as unknown as AccountModuleFacade;
+
+const service = new CreateDirectNoteService({
+  directNoteRepository: mockDirectNoteRepo,
+  directNoteAttachmentRepository: mockDirectNoteAttachmentRepo,
+  idGenerator: new SnowflakeIDGenerator(0, {
+    now: () => BigInt(Date.UTC(2023, 9, 10, 0, 0)),
+  }),
+  clock: new MockClock(new Date('2023-09-10T00:00:00Z')),
+  accountModule: mockAccountModule,
+});
+
+describe('CreateDirectNoteService', () => {
+  beforeEach(() => {
+    vi.mocked(mockAccountModule.fetchAccount).mockResolvedValue(
+      Result.ok(author),
+    );
+    vi.mocked(mockDirectNoteRepo.create).mockResolvedValue(
+      Result.ok(undefined),
+    );
+    vi.mocked(mockDirectNoteAttachmentRepo.create).mockResolvedValue(
+      Result.ok(undefined),
+    );
+  });
+
+  it('should create a direct note', async () => {
+    vi.mocked(mockAccountModule.fetchAccount)
+      .mockResolvedValueOnce(Result.ok(author))
+      .mockResolvedValueOnce(Result.ok(recipient));
+
+    const res = await service.handle(
+      'Hello',
+      '',
+      '1' as AccountID,
+      '2' as AccountID,
+      [],
+    );
+
+    expect(Result.isOk(res)).toBe(true);
+    expect(Result.unwrap(res).getContent()).toBe('Hello');
+    expect(Result.unwrap(res).getAuthorID()).toBe('1');
+    expect(Result.unwrap(res).getRecipientID()).toBe('2');
+  });
+
+  it('should return error when author not found', async () => {
+    vi.mocked(mockAccountModule.fetchAccount).mockResolvedValueOnce(
+      Result.err(new Error('not found')),
+    );
+
+    const res = await service.handle(
+      'Hello',
+      '',
+      '999' as AccountID,
+      '2' as AccountID,
+      [],
+    );
+
+    expect(Result.isErr(res)).toBe(true);
+    expect(Result.unwrapErr(res).message).toBe('Author not found');
+  });
+
+  it('should return error when recipient not found', async () => {
+    vi.mocked(mockAccountModule.fetchAccount)
+      .mockResolvedValueOnce(Result.ok(author))
+      .mockResolvedValueOnce(Result.err(new Error('not found')));
+
+    const res = await service.handle(
+      'Hello',
+      '',
+      '1' as AccountID,
+      '999' as AccountID,
+      [],
+    );
+
+    expect(Result.isErr(res)).toBe(true);
+    expect(Result.unwrapErr(res).message).toBe('Recipient not found');
+  });
+
+  it('should return error when content exceeds 3000 chars', async () => {
+    vi.mocked(mockAccountModule.fetchAccount)
+      .mockResolvedValueOnce(Result.ok(author))
+      .mockResolvedValueOnce(Result.ok(recipient));
+
+    const res = await service.handle(
+      'a'.repeat(3001),
+      '',
+      '1' as AccountID,
+      '2' as AccountID,
+      [],
+    );
+
+    expect(Result.isErr(res)).toBe(true);
+    expect(Result.unwrapErr(res).name).toBe('DirectNoteContentLengthError');
+  });
+
+  it('should return error when too many attachments (>16)', async () => {
+    vi.mocked(mockAccountModule.fetchAccount)
+      .mockResolvedValueOnce(Result.ok(author))
+      .mockResolvedValueOnce(Result.ok(recipient));
+
+    const res = await service.handle(
+      'Hello',
+      '',
+      '1' as AccountID,
+      '2' as AccountID,
+      Array.from({ length: 17 }, (_, i) => i.toString() as MediumID),
+    );
+
+    expect(Result.isErr(res)).toBe(true);
+    expect(Result.unwrapErr(res).name).toBe(
+      'DirectNoteTooManyAttachmentsError',
+    );
+  });
+
+  it('should return error when content, cw comment, and attachments are all empty', async () => {
+    vi.mocked(mockAccountModule.fetchAccount)
+      .mockResolvedValueOnce(Result.ok(author))
+      .mockResolvedValueOnce(Result.ok(recipient));
+
+    const res = await service.handle(
+      '',
+      '',
+      '1' as AccountID,
+      '2' as AccountID,
+      [],
+    );
+
+    expect(Result.isErr(res)).toBe(true);
+    expect(Result.unwrapErr(res).name).toBe('DirectNoteContentLengthError');
+  });
+
+  it('should not call attachment repo when attachmentFileID is empty', async () => {
+    vi.mocked(mockAccountModule.fetchAccount)
+      .mockResolvedValueOnce(Result.ok(author))
+      .mockResolvedValueOnce(Result.ok(recipient));
+    vi.mocked(mockDirectNoteAttachmentRepo.create).mockClear();
+
+    await service.handle('Hello', '', '1' as AccountID, '2' as AccountID, []);
+
+    expect(mockDirectNoteAttachmentRepo.create).not.toHaveBeenCalled();
+  });
+
+  it('should call attachment repo when attachments are provided', async () => {
+    vi.mocked(mockAccountModule.fetchAccount)
+      .mockResolvedValueOnce(Result.ok(author))
+      .mockResolvedValueOnce(Result.ok(recipient));
+
+    const attachments = ['10' as MediumID, '11' as MediumID];
+    const res = await service.handle(
+      'Hello',
+      '',
+      '1' as AccountID,
+      '2' as AccountID,
+      attachments,
+    );
+
+    expect(Result.isOk(res)).toBe(true);
+    expect(mockDirectNoteAttachmentRepo.create).toHaveBeenCalled();
+  });
+});

--- a/pkg/notes/service/createDirect.ts
+++ b/pkg/notes/service/createDirect.ts
@@ -1,0 +1,114 @@
+import { Ether, Result } from '@mikuroxina/mini-fn';
+
+import type { AccountID } from '../../accounts/model/account.js';
+import { AccountNotFoundError } from '../../accounts/model/errors.js';
+import type { MediumID } from '../../drive/model/medium.js';
+import {
+  type AccountModuleFacade,
+  accountModuleFacadeSymbol,
+} from '../../intermodule/account.js';
+import {
+  type Clock,
+  clockSymbol,
+  type SnowflakeIDGenerator,
+  snowflakeIDGeneratorSymbol,
+} from '../../internal/id/mod.js';
+import { DirectNote, type DirectNoteID } from '../model/directNote.js';
+import { NoteInternalError } from '../model/errors.js';
+import {
+  type DirectNoteAttachmentRepository,
+  type DirectNoteRepository,
+  directNoteAttachmentRepoSymbol,
+  directNoteRepoSymbol,
+} from '../model/repository.js';
+
+export class CreateDirectNoteService {
+  constructor(
+    private readonly deps: {
+      directNoteRepository: DirectNoteRepository;
+      directNoteAttachmentRepository: DirectNoteAttachmentRepository;
+      idGenerator: SnowflakeIDGenerator;
+      clock: Clock;
+      accountModule: AccountModuleFacade;
+    },
+  ) {}
+
+  async handle(
+    content: string,
+    contentsWarningComment: string,
+    authorID: AccountID,
+    recipientID: AccountID,
+    attachmentFileID: MediumID[],
+  ): Promise<Result.Result<Error, DirectNote>> {
+    const authorRes = await this.deps.accountModule.fetchAccount(authorID);
+    if (Result.isErr(authorRes)) {
+      return Result.err(
+        new AccountNotFoundError('Author not found', { cause: null }),
+      );
+    }
+
+    const recipientRes =
+      await this.deps.accountModule.fetchAccount(recipientID);
+    if (Result.isErr(recipientRes)) {
+      return Result.err(
+        new AccountNotFoundError('Recipient not found', { cause: null }),
+      );
+    }
+
+    const idRes = this.deps.idGenerator.generate<DirectNote>();
+    if (Result.isErr(idRes)) {
+      return Result.err(
+        new NoteInternalError('id generation failed', {
+          cause: Result.unwrapErr(idRes),
+        }),
+      );
+    }
+
+    const now = this.deps.clock.now();
+    const noteRes = DirectNote.new({
+      id: idRes[1] as DirectNoteID,
+      authorID,
+      recipientID,
+      content,
+      contentsWarningComment,
+      attachmentFileID,
+      createdAt: new Date(Number(now)),
+    });
+    if (Result.isErr(noteRes)) {
+      return noteRes;
+    }
+    const note = Result.unwrap(noteRes);
+
+    const createRes = await this.deps.directNoteRepository.create(note);
+    if (Result.isErr(createRes)) {
+      return createRes;
+    }
+
+    if (attachmentFileID.length !== 0) {
+      const attachmentRes =
+        await this.deps.directNoteAttachmentRepository.create(
+          note.getID(),
+          note.getAttachmentFileID(),
+        );
+      if (Result.isErr(attachmentRes)) {
+        return attachmentRes;
+      }
+    }
+
+    return Result.ok(note);
+  }
+}
+
+export const createDirectNoteServiceSymbol =
+  Ether.newEtherSymbol<CreateDirectNoteService>();
+export const createDirectNoteService = Ether.newEther(
+  createDirectNoteServiceSymbol,
+  (deps) => new CreateDirectNoteService(deps),
+  {
+    directNoteRepository: directNoteRepoSymbol,
+    directNoteAttachmentRepository: directNoteAttachmentRepoSymbol,
+    idGenerator: snowflakeIDGeneratorSymbol,
+    clock: clockSymbol,
+    accountModule: accountModuleFacadeSymbol,
+  },
+);

--- a/pkg/notes/service/renote.test.ts
+++ b/pkg/notes/service/renote.test.ts
@@ -182,38 +182,6 @@ describe('RenoteService', () => {
     expect(Result.isErr(res)).toBe(true);
   });
 
-  it('should not be able to renote DIRECT notes', async () => {
-    const originalDIRECTNote = Note.reconstruct({
-      id: '3' as NoteID,
-      authorID: '101' as AccountID,
-      content: 'original note',
-      contentsWarningComment: '',
-      createdAt: new Date(),
-      originalNoteID: Option.none(),
-      attachmentFileID: [],
-      sendTo: Option.some('102' as AccountID),
-      visibility: 'DIRECT',
-      updatedAt: Option.none(),
-      deletedAt: Option.none(),
-    });
-    await repository.create(originalDIRECTNote);
-    const res = await service.handle(
-      originalDIRECTNote.getID(),
-      '',
-      '',
-      '101' as AccountID,
-      [],
-      'PUBLIC',
-    );
-
-    expect(Result.isErr(res)).toBe(true);
-    expect(Result.unwrapErr(res)).toStrictEqual(
-      new NoteVisibilityInvalidError('Can not renote direct note', {
-        cause: null,
-      }),
-    );
-  });
-
   it('should not be able to renote others FOLLOWERS notes', async () => {
     const originalFOLLOWRSNote = Note.reconstruct({
       id: '4' as NoteID,

--- a/pkg/notes/service/renote.ts
+++ b/pkg/notes/service/renote.ts
@@ -185,9 +185,9 @@ export class RenoteService {
           );
         }
         return Result.ok(undefined);
-      case 'DIRECT':
+      default:
         return Result.err(
-          new NoteVisibilityInvalidError('Can not renote direct note', {
+          new NoteVisibilityInvalidError('Cannot renote this note', {
             cause: null,
           }),
         );

--- a/pkg/timeline/adaptor/repository/dummy.test.ts
+++ b/pkg/timeline/adaptor/repository/dummy.test.ts
@@ -2,6 +2,10 @@ import { Option, Result } from '@mikuroxina/mini-fn';
 import { afterEach, describe, expect, it } from 'vitest';
 
 import type { AccountID } from '../../../accounts/model/account.js';
+import {
+  DirectNote,
+  type DirectNoteID,
+} from '../../../notes/model/directNote.js';
 import { Note, type NoteID } from '../../../notes/model/note.js';
 import { TimelineInvalidFilterRangeError } from '../../model/errors.js';
 import { List, type ListID } from '../../model/list.js';
@@ -335,53 +339,51 @@ describe('InMemoryListRepository', () => {
 });
 
 describe('InMemoryConversationRepository', () => {
-  const noteFactory = (
-    id: NoteID,
+  const directNoteFactory = (
+    id: DirectNoteID,
     authorID: AccountID,
-    sendToID: Option.Option<AccountID>,
+    recipientID: AccountID,
     createdAt: Date,
   ) =>
     Result.unwrap(
-      Note.new({
-        attachmentFileID: [],
-        authorID,
-        contentsWarningComment: '',
-        createdAt,
+      DirectNote.new({
         id,
-        originalNoteID: Option.none(),
-        sendTo: sendToID,
-        visibility: 'DIRECT',
+        authorID,
+        recipientID,
         content: 'this is a test note',
+        contentsWarningComment: '',
+        attachmentFileID: [],
+        createdAt,
       }),
     );
 
   const testMap = [
     // 1-->2
-    noteFactory(
-      '100' as NoteID,
+    directNoteFactory(
+      '100' as DirectNoteID,
       '1' as AccountID,
-      Option.some('2' as AccountID),
+      '2' as AccountID,
       new Date('2023-09-10T00:00:00Z'),
     ),
     // 1-->2
-    noteFactory(
-      '101' as NoteID,
+    directNoteFactory(
+      '101' as DirectNoteID,
       '1' as AccountID,
-      Option.some('2' as AccountID),
+      '2' as AccountID,
       new Date('2023-09-11T00:00:00Z'),
     ),
     // 2-->1
-    noteFactory(
-      '200' as NoteID,
+    directNoteFactory(
+      '200' as DirectNoteID,
       '2' as AccountID,
-      Option.some('1' as AccountID),
+      '1' as AccountID,
       new Date('2023-09-12T00:00:00Z'),
     ),
     // 2-->1
-    noteFactory(
-      '201' as NoteID,
+    directNoteFactory(
+      '201' as DirectNoteID,
       '2' as AccountID,
-      Option.some('1' as AccountID),
+      '1' as AccountID,
       new Date('2023-09-13T00:00:00Z'),
     ),
   ];
@@ -395,7 +397,7 @@ describe('InMemoryConversationRepository', () => {
       {
         id: '2' as AccountID,
         lastSentAt: new Date('2023-09-13T00:00:00Z'),
-        latestNoteID: '201' as NoteID,
+        latestNoteID: '201' as DirectNoteID,
         latestNoteAuthor: '2' as AccountID,
       },
     ]);
@@ -409,7 +411,7 @@ describe('InMemoryConversationRepository', () => {
       {
         id: '1' as AccountID,
         lastSentAt: new Date('2023-09-13T00:00:00Z'),
-        latestNoteID: '201' as NoteID,
+        latestNoteID: '201' as DirectNoteID,
         latestNoteAuthor: '2' as AccountID,
       },
     ]);

--- a/pkg/timeline/adaptor/repository/dummy.ts
+++ b/pkg/timeline/adaptor/repository/dummy.ts
@@ -19,7 +19,6 @@ import {
   type ConversationRepository,
   conversationRepoSymbol,
   type FetchAccountTimelineFilter,
-  type FetchConversationNotesFilter,
   type FetchHomeTimelineFilter,
   type FetchListTimelineFilter,
   type ListRepository,
@@ -491,54 +490,6 @@ export class InMemoryConversationRepository implements ConversationRepository {
       };
     });
     return Result.ok(res);
-  }
-
-  async fetchConversationNotes(
-    accountID: AccountID,
-    recipientID: AccountID,
-    filter: FetchConversationNotesFilter,
-  ): Promise<Result.Result<Error, Note[]>> {
-    const notes = this.data.filter(
-      (v) =>
-        v.getVisibility() === 'DIRECT' &&
-        ((v.getAuthorID() === accountID &&
-          Option.unwrap(v.getSendTo()) === recipientID) ||
-          (v.getAuthorID() === recipientID &&
-            Option.unwrap(v.getSendTo()) === accountID)),
-    );
-
-    if (!filter.cursor) {
-      const sortedNotes = notes.toSorted(sortByCreatedAtDesc);
-      return Result.ok(sortedNotes.slice(0, filter.limit));
-    }
-
-    if (filter.cursor.type === 'before') {
-      const beforeIndex = notes.findIndex(
-        (n) => n.getID() === filter.cursor?.id,
-      );
-      if (beforeIndex === -1) {
-        return Result.ok([]);
-      }
-      const slicedNotes = notes
-        .slice(0, beforeIndex)
-        .toSorted(sortByCreatedAtDesc);
-      return Result.ok(slicedNotes.slice(0, filter.limit));
-    }
-
-    if (filter.cursor.type === 'after') {
-      const afterIndex = notes.findIndex(
-        (n) => n.getID() === filter.cursor?.id,
-      );
-      if (afterIndex === -1) {
-        return Result.ok([]);
-      }
-      const slicedNotes = notes
-        .slice(afterIndex + 1)
-        .toSorted(sortByCreatedAtDesc);
-      return Result.ok(slicedNotes.slice(0, filter.limit));
-    }
-
-    return Result.ok([]);
   }
 }
 export const inMemoryConversationRepo = (data?: Note[]) =>

--- a/pkg/timeline/adaptor/repository/dummy.ts
+++ b/pkg/timeline/adaptor/repository/dummy.ts
@@ -1,9 +1,10 @@
-import { Ether, Option, Result } from '@mikuroxina/mini-fn';
+import { Ether, Result } from '@mikuroxina/mini-fn';
 
 import type { AccountID } from '../../../accounts/model/account.js';
 import { AccountNotFoundError } from '../../../accounts/model/errors.js';
 import type { NoteModuleFacade } from '../../../intermodule/note.js';
 import type { Bookmark } from '../../../notes/model/bookmark.js';
+import type { DirectNote } from '../../../notes/model/directNote.js';
 import type { Note, NoteID } from '../../../notes/model/note.js';
 import {
   ListInternalError,
@@ -15,6 +16,7 @@ import {
   type BookmarkTimelineFilter,
   type BookmarkTimelineRepository,
   bookmarkTimelineRepoSymbol,
+  type ConversationNotesFilter,
   type ConversationRecipient,
   type ConversationRepository,
   conversationRepoSymbol,
@@ -426,60 +428,38 @@ export const inMemoryBookmarkTimelineRepo = (data?: Bookmark[]) =>
     () => new InMemoryBookmarkTimelineRepository(data),
   );
 
-/**
- * @description Sort notes by creation date (newest first)
- * @param a First note
- * @param b Second note
- * @returns Comparison result for sorting
- */
-const sortByCreatedAtDesc = (a: Note, b: Note): number =>
+const sortDirectNoteByCreatedAtDesc = (a: DirectNote, b: DirectNote): number =>
   b.getCreatedAt().getTime() - a.getCreatedAt().getTime();
 
 export class InMemoryConversationRepository implements ConversationRepository {
-  private data: Note[];
+  private data: DirectNote[];
 
-  constructor(data?: Note[]) {
+  constructor(data?: DirectNote[]) {
     this.data = data ?? [];
-    // FIXME: Consider pre-sorting data at construction/insertion time to avoid O(N log N) sorting
-    // on every query, which can be expensive during debugging with large datasets.
-    // This would require maintaining sorted order when inserting new notes.
   }
 
   async findByAccountID(
     id: AccountID,
   ): Promise<Result.Result<Error, ConversationRecipient[]>> {
     const notes = this.data.filter(
-      (v) => v.getAuthorID() === id || Option.unwrap(v.getSendTo()) === id,
+      (v) => v.getAuthorID() === id || v.getRecipientID() === id,
     );
 
-    // K: Recipient ID/ V: Conversation Notes
-    const recipientMap = new Map<AccountID, Note[]>();
+    // K: counterpart account ID / V: conversation notes
+    const recipientMap = new Map<AccountID, DirectNote[]>();
     for (const note of notes) {
-      if (note.getAuthorID() === id) {
-        // Sent
-        if (recipientMap.has(Option.unwrap(note.getSendTo()))) {
-          const tmp = recipientMap.get(Option.unwrap(note.getSendTo()));
-          if (!tmp) throw new Error('Note not found');
-          tmp.push(note);
-          recipientMap.set(Option.unwrap(note.getSendTo()), tmp);
-          continue;
-        }
-        recipientMap.set(Option.unwrap(note.getSendTo()), [note]);
-        continue;
+      const counterpart =
+        note.getAuthorID() === id ? note.getRecipientID() : note.getAuthorID();
+      const existing = recipientMap.get(counterpart);
+      if (existing) {
+        existing.push(note);
+      } else {
+        recipientMap.set(counterpart, [note]);
       }
-      // Received
-      if (recipientMap.has(note.getAuthorID())) {
-        const tmp = recipientMap.get(note.getAuthorID());
-        if (!tmp) throw new Error('Note not found');
-        tmp.push(note);
-        recipientMap.set(note.getAuthorID(), tmp);
-        continue;
-      }
-      recipientMap.set(note.getAuthorID(), [note]);
     }
 
     const res: ConversationRecipient[] = [...recipientMap].map(([k, v]) => {
-      const latestNote = v.toSorted(sortByCreatedAtDesc)[0];
+      const latestNote = v.toSorted(sortDirectNoteByCreatedAtDesc)[0];
       if (!latestNote) throw new Error('Note not found');
 
       return {
@@ -491,8 +471,41 @@ export class InMemoryConversationRepository implements ConversationRepository {
     });
     return Result.ok(res);
   }
+
+  async findConversationNotes(
+    accountID: AccountID,
+    recipientID: AccountID,
+    filter: ConversationNotesFilter,
+  ): Promise<Result.Result<Error, DirectNote[]>> {
+    const notes = this.data
+      .filter(
+        (v) =>
+          (v.getAuthorID() === accountID &&
+            v.getRecipientID() === recipientID) ||
+          (v.getAuthorID() === recipientID && v.getRecipientID() === accountID),
+      )
+      .toSorted(sortDirectNoteByCreatedAtDesc);
+
+    if (!filter.cursor) {
+      return Result.ok(notes.slice(0, filter.limit));
+    }
+
+    const cursorIndex = notes.findIndex((v) => v.getID() === filter.cursor?.id);
+    if (cursorIndex === -1) return Result.ok([]);
+
+    if (filter.cursor.type === 'before') {
+      // Return notes older than cursor (later in desc-sorted array)
+      return Result.ok(
+        notes.slice(cursorIndex + 1, cursorIndex + 1 + filter.limit),
+      );
+    }
+
+    // after: return notes newer than cursor (earlier in desc-sorted array)
+    const start = Math.max(0, cursorIndex - filter.limit);
+    return Result.ok(notes.slice(start, cursorIndex));
+  }
 }
-export const inMemoryConversationRepo = (data?: Note[]) =>
+export const inMemoryConversationRepo = (data?: DirectNote[]) =>
   Ether.newEther(
     conversationRepoSymbol,
     () => new InMemoryConversationRepository(data),

--- a/pkg/timeline/adaptor/repository/prisma.ts
+++ b/pkg/timeline/adaptor/repository/prisma.ts
@@ -21,7 +21,6 @@ import {
   type ConversationRepository,
   conversationRepoSymbol,
   type FetchAccountTimelineFilter,
-  type FetchConversationNotesFilter,
   type FetchHomeTimelineFilter,
   type FetchListTimelineFilter,
   type ListRepository,
@@ -550,15 +549,6 @@ export class PrismaConversationRepository implements ConversationRepository {
   async findByAccountID(
     _accountId: AccountID,
   ): Promise<Result.Result<Error, ConversationRecipient[]>> {
-    // TODO(phase5): implement using DirectNote table
-    return Result.ok([]);
-  }
-
-  async fetchConversationNotes(
-    _accountID: AccountID,
-    _recipientID: AccountID,
-    _filter: FetchConversationNotesFilter,
-  ): Promise<Result.Result<Error, Note[]>> {
     // TODO(phase5): implement using DirectNote table
     return Result.ok([]);
   }

--- a/pkg/timeline/adaptor/repository/prisma.ts
+++ b/pkg/timeline/adaptor/repository/prisma.ts
@@ -547,127 +547,25 @@ export const prismaBookmarkTimelineRepo = (client: PrismaClient) =>
   );
 
 export class PrismaConversationRepository implements ConversationRepository {
-  private readonly VISIBILITY_DIRECT = 3;
-
-  constructor(private readonly prisma: PrismaClient) {}
-
   async findByAccountID(
-    accountId: AccountID,
+    _accountId: AccountID,
   ): Promise<Result.Result<Error, ConversationRecipient[]>> {
-    try {
-      const conversations = await this.prisma.note.findMany({
-        where: {
-          visibility: this.VISIBILITY_DIRECT,
-          deletedAt: null,
-          sendToId: accountId,
-        },
-        orderBy: {
-          createdAt: 'desc',
-        },
-        distinct: ['authorId', 'sendToId'],
-      });
-
-      return Result.ok(
-        conversations.map(
-          (v): ConversationRecipient => ({
-            id: accountId,
-            latestNoteAuthor: v.authorId as AccountID,
-            latestNoteID: v.id as NoteID,
-            lastSentAt: v.createdAt,
-          }),
-        ),
-      );
-    } catch (e) {
-      return Result.err(
-        new TimelineInternalError('unknown error', { cause: e }),
-      );
-    }
+    // TODO(phase5): implement using DirectNote table
+    return Result.ok([]);
   }
 
   async fetchConversationNotes(
-    accountID: AccountID,
-    recipientID: AccountID,
-    filter: FetchConversationNotesFilter,
+    _accountID: AccountID,
+    _recipientID: AccountID,
+    _filter: FetchConversationNotesFilter,
   ): Promise<Result.Result<Error, Note[]>> {
-    try {
-      const notes = await this.prisma.note.findMany({
-        where: {
-          visibility: this.VISIBILITY_DIRECT,
-          deletedAt: null,
-          OR: [
-            {
-              authorId: accountID,
-              sendToId: recipientID,
-            },
-            {
-              authorId: recipientID,
-              sendToId: accountID,
-            },
-          ],
-        },
-        orderBy: {
-          createdAt: filter.cursor?.type === 'after' ? 'asc' : 'desc',
-        },
-        ...(filter.cursor
-          ? {
-              cursor: {
-                id: filter.cursor.id,
-              },
-              skip: 1,
-            }
-          : {}),
-        take: filter.limit,
-      });
-
-      return Result.ok(this.deserialize(notes));
-    } catch (e) {
-      return Result.err(
-        new TimelineInternalError('unknown error', { cause: e }),
-      );
-    }
-  }
-
-  private deserialize(
-    data: Awaited<ReturnType<typeof this.prisma.note.findMany & {}>>,
-  ): Note[] {
-    return data.map((v) => {
-      const visibility = (): NoteVisibility => {
-        switch (v.visibility) {
-          case 0:
-            return 'PUBLIC';
-          case 1:
-            return 'HOME';
-          case 2:
-            return 'FOLLOWERS';
-          case 3:
-            return 'DIRECT';
-          default:
-            throw new Error('Invalid Visibility');
-        }
-      };
-      return Note.reconstruct({
-        id: v.id as NoteID,
-        content: v.text,
-        authorID: v.authorId as AccountID,
-        createdAt: v.createdAt,
-        deletedAt: !v.deletedAt ? Option.none() : Option.some(v.deletedAt),
-        contentsWarningComment: '',
-        originalNoteID: !v.renoteId
-          ? Option.none()
-          : Option.some(v.renoteId as NoteID),
-        attachmentFileID: [],
-        sendTo: !v.sendToId
-          ? Option.none()
-          : Option.some(v.sendToId as AccountID),
-        updatedAt: Option.none(),
-        visibility: visibility() as NoteVisibility,
-      });
-    });
+    // TODO(phase5): implement using DirectNote table
+    return Result.ok([]);
   }
 }
 
-export const prismaConversationRepo = (client: PrismaClient) =>
+export const prismaConversationRepo = () =>
   Ether.newEther(
     conversationRepoSymbol,
-    () => new PrismaConversationRepository(client),
+    () => new PrismaConversationRepository(),
   );

--- a/pkg/timeline/adaptor/repository/prisma.ts
+++ b/pkg/timeline/adaptor/repository/prisma.ts
@@ -3,6 +3,10 @@ import type { AccountID } from '../../../accounts/model/account.js';
 import { Prisma, type PrismaClient } from '../../../adaptors/prisma/client.js';
 import type { prismaClient } from '../../../adaptors/prisma.js';
 import {
+  DirectNote,
+  type DirectNoteID,
+} from '../../../notes/model/directNote.js';
+import {
   Note,
   type NoteID,
   type NoteVisibility,
@@ -17,6 +21,7 @@ import {
   type BookmarkTimelineFilter,
   type BookmarkTimelineRepository,
   bookmarkTimelineRepoSymbol,
+  type ConversationNotesFilter,
   type ConversationRecipient,
   type ConversationRepository,
   conversationRepoSymbol,
@@ -545,17 +550,64 @@ export const prismaBookmarkTimelineRepo = (client: PrismaClient) =>
     () => new PrismaBookmarkTimelineRepository(client),
   );
 
+type RawConversationDirectNote = Awaited<
+  ReturnType<typeof prismaClient.directNote.findMany>
+>[number];
+
 export class PrismaConversationRepository implements ConversationRepository {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  private deserializeDirectNote(data: RawConversationDirectNote): DirectNote {
+    return DirectNote.reconstruct({
+      id: data.id as DirectNoteID,
+      authorID: data.authorId as AccountID,
+      recipientID: data.recipientId as AccountID,
+      content: data.text,
+      contentsWarningComment: '',
+      attachmentFileID: [],
+      createdAt: data.createdAt,
+      deletedAt: data.deletedAt ? Option.some(data.deletedAt) : Option.none(),
+    });
+  }
+
   async findByAccountID(
     _accountId: AccountID,
   ): Promise<Result.Result<Error, ConversationRecipient[]>> {
-    // TODO(phase5): implement using DirectNote table
+    // TODO: implement using DirectNote table
     return Result.ok([]);
+  }
+
+  async findConversationNotes(
+    accountID: AccountID,
+    recipientID: AccountID,
+    filter: ConversationNotesFilter,
+  ): Promise<Result.Result<Error, DirectNote[]>> {
+    // For 'after' cursor (get notes newer than cursor): query asc then reverse to keep desc order.
+    // For 'before' cursor or no cursor: query desc directly.
+    const isAfter = filter.cursor?.type === 'after';
+    try {
+      const res = await this.prisma.directNote.findMany({
+        where: {
+          deletedAt: null,
+          OR: [
+            { authorId: accountID, recipientId: recipientID },
+            { authorId: recipientID, recipientId: accountID },
+          ],
+        },
+        orderBy: { createdAt: isAfter ? 'asc' : 'desc' },
+        take: filter.limit,
+        ...(filter.cursor ? { cursor: { id: filter.cursor.id }, skip: 1 } : {}),
+      });
+      const notes = res.map((v) => this.deserializeDirectNote(v));
+      return Result.ok(isAfter ? notes.reverse() : notes);
+    } catch (e) {
+      return Result.err(e as Error);
+    }
   }
 }
 
-export const prismaConversationRepo = () =>
+export const prismaConversationRepo = (client: PrismaClient) =>
   Ether.newEther(
     conversationRepoSymbol,
-    () => new PrismaConversationRepository(),
+    () => new PrismaConversationRepository(client),
   );

--- a/pkg/timeline/mod.ts
+++ b/pkg/timeline/mod.ts
@@ -19,6 +19,7 @@ import {
   timelineCacheRepositoryInstance,
 } from '../intermodule/timeline.js';
 import { clockSymbol, snowflakeIDGenerator } from '../internal/id/mod.js';
+import { directNoteRepoEther } from '../notes/mod.js';
 import { TimelineController } from './adaptor/controller/timeline.js';
 import { timelineModuleLogger } from './adaptor/logger.js';
 import {
@@ -173,8 +174,9 @@ const controller = new TimelineController({
       .feed(Ether.compose(bookmarkTimelineRepository)).value,
   ),
   fetchConversationService: Ether.runEther(
-    Cat.cat(fetchConversation).feed(Ether.compose(conversationRepository))
-      .value,
+    Cat.cat(fetchConversation)
+      .feed(Ether.compose(conversationRepository))
+      .feed(Ether.compose(directNoteRepoEther)).value,
   ),
   publicTimelineService: Ether.runEther(
     Cat.cat(publicTimeline).feed(Ether.compose(timelineRepository)).value,

--- a/pkg/timeline/mod.ts
+++ b/pkg/timeline/mod.ts
@@ -19,7 +19,6 @@ import {
   timelineCacheRepositoryInstance,
 } from '../intermodule/timeline.js';
 import { clockSymbol, snowflakeIDGenerator } from '../internal/id/mod.js';
-import { directNoteRepoEther } from '../notes/mod.js';
 import { TimelineController } from './adaptor/controller/timeline.js';
 import { timelineModuleLogger } from './adaptor/logger.js';
 import {
@@ -121,7 +120,7 @@ const bookmarkTimelineRepository = isProduction
   : inMemoryBookmarkTimelineRepo();
 
 const conversationRepository = isProduction
-  ? prismaConversationRepo()
+  ? prismaConversationRepo(prismaClient)
   : inMemoryConversationRepo();
 
 const controller = new TimelineController({
@@ -174,9 +173,8 @@ const controller = new TimelineController({
       .feed(Ether.compose(bookmarkTimelineRepository)).value,
   ),
   fetchConversationService: Ether.runEther(
-    Cat.cat(fetchConversation)
-      .feed(Ether.compose(conversationRepository))
-      .feed(Ether.compose(directNoteRepoEther)).value,
+    Cat.cat(fetchConversation).feed(Ether.compose(conversationRepository))
+      .value,
   ),
   publicTimelineService: Ether.runEther(
     Cat.cat(publicTimeline).feed(Ether.compose(timelineRepository)).value,

--- a/pkg/timeline/mod.ts
+++ b/pkg/timeline/mod.ts
@@ -120,7 +120,7 @@ const bookmarkTimelineRepository = isProduction
   : inMemoryBookmarkTimelineRepo();
 
 const conversationRepository = isProduction
-  ? prismaConversationRepo(prismaClient)
+  ? prismaConversationRepo()
   : inMemoryConversationRepo();
 
 const controller = new TimelineController({

--- a/pkg/timeline/model/repository.ts
+++ b/pkg/timeline/model/repository.ts
@@ -1,6 +1,7 @@
 import { Ether, type Result } from '@mikuroxina/mini-fn';
 
 import type { AccountID } from '../../accounts/model/account.js';
+import type { DirectNote, DirectNoteID } from '../../notes/model/directNote.js';
 import type { Note, NoteID } from '../../notes/model/note.js';
 import type { List, ListID } from './list.js';
 
@@ -168,8 +169,25 @@ export interface ConversationRecipient {
    * @desc Time the last message was sent
    */
   lastSentAt: Date;
-  latestNoteID: NoteID;
+  latestNoteID: DirectNoteID;
   latestNoteAuthor: AccountID;
+}
+
+export interface ConversationNotesCursor {
+  type: 'before' | 'after';
+  id: DirectNoteID;
+}
+
+export interface ConversationNotesFilter {
+  /** @default 20 */
+  limit: number;
+  /**
+   * @description Cursor for pagination
+   * - before: Retrieved from notes before this ID
+   * - after: Retrieved from notes after this ID
+   * - undefined: Retrieved from latest notes
+   */
+  cursor?: ConversationNotesCursor;
 }
 
 export interface ConversationRepository {
@@ -184,6 +202,19 @@ export interface ConversationRepository {
   findByAccountID(
     id: AccountID,
   ): Promise<Result.Result<Error, ConversationRecipient[]>>;
+
+  /**
+   * @description Fetch direct notes exchanged between two accounts.
+   * @param accountID The account ID of the current user
+   * @param recipientID The account ID of the conversation partner
+   * @param filter Pagination options
+   * @returns {@link DirectNote}[] sorted by createdAt descending
+   */
+  findConversationNotes(
+    accountID: AccountID,
+    recipientID: AccountID,
+    filter: ConversationNotesFilter,
+  ): Promise<Result.Result<Error, DirectNote[]>>;
 }
 export const conversationRepoSymbol =
   Ether.newEtherSymbol<ConversationRepository>();

--- a/pkg/timeline/model/repository.ts
+++ b/pkg/timeline/model/repository.ts
@@ -172,28 +172,6 @@ export interface ConversationRecipient {
   latestNoteAuthor: AccountID;
 }
 
-export interface ConversationCursor {
-  /**
-   * Cursor type
-   */
-  type: 'before' | 'after';
-  id: NoteID;
-}
-
-export interface FetchConversationNotesFilter {
-  /**
-   * @default 20
-   */
-  limit: number;
-  /**
-   * @description Cursor for pagination
-   * - before: Retrieved from notes before this ID
-   * - after: Retrieved from notes after this ID
-   * - undefined: Retrieved from latest notes
-   */
-  cursor?: ConversationCursor;
-}
-
 export interface ConversationRepository {
   /**
    *  @description
@@ -206,23 +184,6 @@ export interface ConversationRepository {
   findByAccountID(
     id: AccountID,
   ): Promise<Result.Result<Error, ConversationRecipient[]>>;
-
-  /**
-   * @description
-   * Fetch conversation notes between two accounts.
-   * Returns direct notes (visibility = DIRECT) between the specified accounts.
-   * The sorting order is chronological (newest to oldest).
-   *
-   * @param accountID The account ID of the current user
-   * @param recipientID The account ID of the conversation partner
-   * @param filter Filter options for pagination
-   * @returns Array of direct notes in the conversation
-   */
-  fetchConversationNotes(
-    accountID: AccountID,
-    recipientID: AccountID,
-    filter: FetchConversationNotesFilter,
-  ): Promise<Result.Result<Error, Note[]>>;
 }
 export const conversationRepoSymbol =
   Ether.newEtherSymbol<ConversationRepository>();

--- a/pkg/timeline/service/fetchConversation.test.ts
+++ b/pkg/timeline/service/fetchConversation.test.ts
@@ -1,32 +1,10 @@
 import { Option, Result } from '@mikuroxina/mini-fn';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import type { AccountID } from '../../accounts/model/account.js';
 import { DirectNote, type DirectNoteID } from '../../notes/model/directNote.js';
-import { Note, type NoteID } from '../../notes/model/note.js';
-import type { DirectNoteRepository } from '../../notes/model/repository.js';
 import { InMemoryConversationRepository } from '../adaptor/repository/dummy.js';
 import { FetchConversationService } from './fetchConversation.js';
-
-const noteFactory = (
-  id: NoteID,
-  authorID: AccountID,
-  sendToID: Option.Option<AccountID>,
-  createdAt: Date,
-) =>
-  Result.unwrap(
-    Note.new({
-      attachmentFileID: [],
-      authorID,
-      contentsWarningComment: '',
-      createdAt,
-      id,
-      originalNoteID: Option.none(),
-      sendTo: sendToID,
-      visibility: 'DIRECT',
-      content: 'This is a test note',
-    }),
-  );
 
 const directNoteFactory = (
   id: DirectNoteID,
@@ -51,87 +29,49 @@ const directNoteFactory = (
  *   1 sent 2 notes to 2
  * 2 received 2 notes from 1
  *   2 sent 2 notes to 1
- *   2 sent 1 note to 4
+ *   2 sent 1 note to 4 (via 4-->2 below)
  * 4 received 1 note from 2
  */
-const noteTestMap = [
-  // 1-->2
-  noteFactory(
-    '100' as NoteID,
-    '1' as AccountID,
-    Option.some('2' as AccountID),
-    new Date('2023-09-10T00:00:00Z'),
-  ),
-  // 1-->2
-  noteFactory(
-    '101' as NoteID,
-    '1' as AccountID,
-    Option.some('2' as AccountID),
-    new Date('2023-09-11T00:00:00Z'),
-  ),
-  // 2-->1
-  noteFactory(
-    '200' as NoteID,
-    '2' as AccountID,
-    Option.some('1' as AccountID),
-    new Date('2023-09-12T00:00:00Z'),
-  ),
-  // 2-->1
-  noteFactory(
-    '201' as NoteID,
-    '2' as AccountID,
-    Option.some('1' as AccountID),
-    new Date('2023-09-13T00:00:00Z'),
-  ),
-  // 4-->2
-  noteFactory(
-    '400' as NoteID,
-    '4' as AccountID,
-    Option.some('2' as AccountID),
-    new Date('2024-01-01T00:00:00Z'),
-  ),
-];
-
 const dummyDirectNotes = [
+  // 1-->2
   directNoteFactory(
     '100' as DirectNoteID,
     '1' as AccountID,
     '2' as AccountID,
     new Date('2023-09-10T00:00:00Z'),
   ),
+  // 1-->2
   directNoteFactory(
     '101' as DirectNoteID,
     '1' as AccountID,
     '2' as AccountID,
     new Date('2023-09-11T00:00:00Z'),
   ),
+  // 2-->1
   directNoteFactory(
     '200' as DirectNoteID,
     '2' as AccountID,
     '1' as AccountID,
     new Date('2023-09-12T00:00:00Z'),
   ),
+  // 2-->1
   directNoteFactory(
     '201' as DirectNoteID,
     '2' as AccountID,
     '1' as AccountID,
     new Date('2023-09-13T00:00:00Z'),
   ),
+  // 4-->2
+  directNoteFactory(
+    '400' as DirectNoteID,
+    '4' as AccountID,
+    '2' as AccountID,
+    new Date('2024-01-01T00:00:00Z'),
+  ),
 ];
 
-const mockDirectNoteRepo: DirectNoteRepository = {
-  create: vi.fn(),
-  findByID: vi.fn(),
-  findByRecipientID: vi.fn(),
-  findConversation: vi.fn(),
-  deleteByID: vi.fn(),
-};
-
-const conversationRepo = new InMemoryConversationRepository(noteTestMap);
-const service = new FetchConversationService(
-  conversationRepo,
-  mockDirectNoteRepo,
-);
+const conversationRepo = new InMemoryConversationRepository(dummyDirectNotes);
+const service = new FetchConversationService(conversationRepo);
 
 describe('FetchConversationService', () => {
   it('should fetch conversations', async () => {
@@ -140,10 +80,10 @@ describe('FetchConversationService', () => {
     expect(Result.isOk(result)).toBe(true);
     expect(Result.unwrap(result)).toStrictEqual([
       {
-        id: noteTestMap[3]?.getAuthorID(),
-        lastSentAt: noteTestMap[3]?.getCreatedAt(),
-        latestNoteID: noteTestMap[3]?.getID(),
-        latestNoteAuthor: noteTestMap[3]?.getAuthorID(),
+        id: dummyDirectNotes[3]?.getAuthorID(),
+        lastSentAt: dummyDirectNotes[3]?.getCreatedAt(),
+        latestNoteID: dummyDirectNotes[3]?.getID(),
+        latestNoteAuthor: dummyDirectNotes[3]?.getAuthorID(),
       },
     ]);
   });
@@ -155,15 +95,15 @@ describe('FetchConversationService', () => {
     const recipients = Result.unwrap(result);
     expect(recipients).toStrictEqual([
       {
-        id: noteTestMap[4]?.getAuthorID(),
-        lastSentAt: noteTestMap[4]?.getCreatedAt(),
-        latestNoteID: noteTestMap[4]?.getID(),
-        latestNoteAuthor: noteTestMap[4]?.getAuthorID(),
+        id: dummyDirectNotes[4]?.getAuthorID(),
+        lastSentAt: dummyDirectNotes[4]?.getCreatedAt(),
+        latestNoteID: dummyDirectNotes[4]?.getID(),
+        latestNoteAuthor: dummyDirectNotes[4]?.getAuthorID(),
       },
       {
         id: '1' as AccountID,
         lastSentAt: new Date('2023-09-13T00:00:00Z'),
-        latestNoteID: '201' as NoteID,
+        latestNoteID: '201' as DirectNoteID,
         latestNoteAuthor: '2' as AccountID,
       },
     ]);
@@ -177,78 +117,72 @@ describe('FetchConversationService', () => {
   });
 
   describe('fetchConversationNotes', () => {
-    beforeEach(() => {
-      vi.mocked(mockDirectNoteRepo.findConversation).mockResolvedValue(
-        Result.ok(dummyDirectNotes),
-      );
-    });
-
     it('should pass default limit of 20 when no limit provided', async () => {
-      await service.fetchConversationNotes('1' as AccountID, '2' as AccountID);
-
-      expect(mockDirectNoteRepo.findConversation).toHaveBeenCalledWith(
-        '1' as AccountID,
-        '2' as AccountID,
-        { limit: 20, cursor: undefined },
-      );
-    });
-
-    it('should pass custom limit to repository', async () => {
-      await service.fetchConversationNotes('1' as AccountID, '2' as AccountID, {
-        limit: Option.some(5),
-        beforeID: Option.none(),
-        afterID: Option.none(),
-      });
-
-      expect(mockDirectNoteRepo.findConversation).toHaveBeenCalledWith(
-        '1' as AccountID,
-        '2' as AccountID,
-        { limit: 5, cursor: undefined },
-      );
-    });
-
-    it('should pass beforeID cursor to repository', async () => {
-      await service.fetchConversationNotes('1' as AccountID, '2' as AccountID, {
-        limit: Option.none(),
-        beforeID: Option.some('201' as DirectNoteID),
-        afterID: Option.none(),
-      });
-
-      expect(mockDirectNoteRepo.findConversation).toHaveBeenCalledWith(
-        '1' as AccountID,
-        '2' as AccountID,
-        { limit: 20, cursor: { type: 'before', id: '201' as DirectNoteID } },
-      );
-    });
-
-    it('should pass afterID cursor to repository', async () => {
-      await service.fetchConversationNotes('1' as AccountID, '2' as AccountID, {
-        limit: Option.none(),
-        beforeID: Option.none(),
-        afterID: Option.some('100' as DirectNoteID),
-      });
-
-      expect(mockDirectNoteRepo.findConversation).toHaveBeenCalledWith(
-        '1' as AccountID,
-        '2' as AccountID,
-        { limit: 20, cursor: { type: 'after', id: '100' as DirectNoteID } },
-      );
-    });
-
-    it('should return what the repository returns', async () => {
-      const note = dummyDirectNotes[0];
-      if (!note) throw new Error('test data missing');
-      vi.mocked(mockDirectNoteRepo.findConversation).mockResolvedValue(
-        Result.ok([note]),
-      );
-
       const result = await service.fetchConversationNotes(
         '1' as AccountID,
         '2' as AccountID,
       );
 
       expect(Result.isOk(result)).toBe(true);
-      expect(Result.unwrap(result)).toStrictEqual([note]);
+      // dataset has 4 notes between 1 and 2; all returned since limit=20
+      expect(Result.unwrap(result)).toHaveLength(4);
+    });
+
+    it('should pass custom limit to repository', async () => {
+      const result = await service.fetchConversationNotes(
+        '1' as AccountID,
+        '2' as AccountID,
+        {
+          limit: Option.some(2),
+          beforeID: Option.none(),
+          afterID: Option.none(),
+        },
+      );
+
+      expect(Result.isOk(result)).toBe(true);
+      expect(Result.unwrap(result)).toHaveLength(2);
+      // newest two notes between 1 and 2
+      expect(Result.unwrap(result).map((n) => n.getID())).toStrictEqual([
+        '201',
+        '200',
+      ]);
+    });
+
+    it('should apply beforeID cursor correctly', async () => {
+      const result = await service.fetchConversationNotes(
+        '1' as AccountID,
+        '2' as AccountID,
+        {
+          limit: Option.none(),
+          beforeID: Option.some('200' as DirectNoteID),
+          afterID: Option.none(),
+        },
+      );
+
+      expect(Result.isOk(result)).toBe(true);
+      // notes older than '200' (2023-09-12): '101' and '100'
+      expect(Result.unwrap(result).map((n) => n.getID())).toStrictEqual([
+        '101',
+        '100',
+      ]);
+    });
+
+    it('should apply afterID cursor correctly', async () => {
+      const result = await service.fetchConversationNotes(
+        '1' as AccountID,
+        '2' as AccountID,
+        {
+          limit: Option.none(),
+          beforeID: Option.none(),
+          afterID: Option.some('200' as DirectNoteID),
+        },
+      );
+
+      expect(Result.isOk(result)).toBe(true);
+      // notes newer than '200' (2023-09-12): '201'
+      expect(Result.unwrap(result).map((n) => n.getID())).toStrictEqual([
+        '201',
+      ]);
     });
 
     it('should return error when both beforeID and afterID are specified', async () => {

--- a/pkg/timeline/service/fetchConversation.test.ts
+++ b/pkg/timeline/service/fetchConversation.test.ts
@@ -1,89 +1,149 @@
 import { Option, Result } from '@mikuroxina/mini-fn';
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
 import type { AccountID } from '../../accounts/model/account.js';
+import { DirectNote, type DirectNoteID } from '../../notes/model/directNote.js';
 import { Note, type NoteID } from '../../notes/model/note.js';
+import type { DirectNoteRepository } from '../../notes/model/repository.js';
 import { InMemoryConversationRepository } from '../adaptor/repository/dummy.js';
 import { FetchConversationService } from './fetchConversation.js';
 
+const noteFactory = (
+  id: NoteID,
+  authorID: AccountID,
+  sendToID: Option.Option<AccountID>,
+  createdAt: Date,
+) =>
+  Result.unwrap(
+    Note.new({
+      attachmentFileID: [],
+      authorID,
+      contentsWarningComment: '',
+      createdAt,
+      id,
+      originalNoteID: Option.none(),
+      sendTo: sendToID,
+      visibility: 'DIRECT',
+      content: 'This is a test note',
+    }),
+  );
+
+const directNoteFactory = (
+  id: DirectNoteID,
+  authorID: AccountID,
+  recipientID: AccountID,
+  createdAt: Date,
+) =>
+  Result.unwrap(
+    DirectNote.new({
+      id,
+      authorID,
+      recipientID,
+      content: 'This is a test note',
+      contentsWarningComment: '',
+      attachmentFileID: [],
+      createdAt,
+    }),
+  );
+
+/**
+ * 1 received 2 notes from 2
+ *   1 sent 2 notes to 2
+ * 2 received 2 notes from 1
+ *   2 sent 2 notes to 1
+ *   2 sent 1 note to 4
+ * 4 received 1 note from 2
+ */
+const noteTestMap = [
+  // 1-->2
+  noteFactory(
+    '100' as NoteID,
+    '1' as AccountID,
+    Option.some('2' as AccountID),
+    new Date('2023-09-10T00:00:00Z'),
+  ),
+  // 1-->2
+  noteFactory(
+    '101' as NoteID,
+    '1' as AccountID,
+    Option.some('2' as AccountID),
+    new Date('2023-09-11T00:00:00Z'),
+  ),
+  // 2-->1
+  noteFactory(
+    '200' as NoteID,
+    '2' as AccountID,
+    Option.some('1' as AccountID),
+    new Date('2023-09-12T00:00:00Z'),
+  ),
+  // 2-->1
+  noteFactory(
+    '201' as NoteID,
+    '2' as AccountID,
+    Option.some('1' as AccountID),
+    new Date('2023-09-13T00:00:00Z'),
+  ),
+  // 4-->2
+  noteFactory(
+    '400' as NoteID,
+    '4' as AccountID,
+    Option.some('2' as AccountID),
+    new Date('2024-01-01T00:00:00Z'),
+  ),
+];
+
+const dummyDirectNotes = [
+  directNoteFactory(
+    '100' as DirectNoteID,
+    '1' as AccountID,
+    '2' as AccountID,
+    new Date('2023-09-10T00:00:00Z'),
+  ),
+  directNoteFactory(
+    '101' as DirectNoteID,
+    '1' as AccountID,
+    '2' as AccountID,
+    new Date('2023-09-11T00:00:00Z'),
+  ),
+  directNoteFactory(
+    '200' as DirectNoteID,
+    '2' as AccountID,
+    '1' as AccountID,
+    new Date('2023-09-12T00:00:00Z'),
+  ),
+  directNoteFactory(
+    '201' as DirectNoteID,
+    '2' as AccountID,
+    '1' as AccountID,
+    new Date('2023-09-13T00:00:00Z'),
+  ),
+];
+
+const mockDirectNoteRepo: DirectNoteRepository = {
+  create: vi.fn(),
+  findByID: vi.fn(),
+  findByRecipientID: vi.fn(),
+  findConversation: vi.fn(),
+  deleteByID: vi.fn(),
+};
+
+const conversationRepo = new InMemoryConversationRepository(noteTestMap);
+const service = new FetchConversationService(
+  conversationRepo,
+  mockDirectNoteRepo,
+);
+
 describe('FetchConversationService', () => {
-  const noteFactory = (
-    id: NoteID,
-    authorID: AccountID,
-    sendToID: Option.Option<AccountID>,
-    createdAt: Date,
-  ) =>
-    Result.unwrap(
-      Note.new({
-        attachmentFileID: [],
-        authorID,
-        contentsWarningComment: '',
-        createdAt,
-        id,
-        originalNoteID: Option.none(),
-        sendTo: sendToID,
-        visibility: 'DIRECT',
-        content: 'This is a test note',
-      }),
-    );
-
-  /**
-   * 1 received 2 notes from 2
-   *   1 sent 2 notes to 2
-   * 2 received 2 notes from 1
-   *   2 sent 2 notes to 1
-   *   2 sent 1 note to 4
-   * 4 received 1 note from 2
-   */
-  const testMap = [
-    // 1-->2
-    noteFactory(
-      '100' as NoteID,
-      '1' as AccountID,
-      Option.some('2' as AccountID),
-      new Date('2023-09-10T00:00:00Z'),
-    ),
-    // 1-->2
-    noteFactory(
-      '101' as NoteID,
-      '1' as AccountID,
-      Option.some('2' as AccountID),
-      new Date('2023-09-11T00:00:00Z'),
-    ),
-    // 2-->1
-    noteFactory(
-      '200' as NoteID,
-      '2' as AccountID,
-      Option.some('1' as AccountID),
-      new Date('2023-09-12T00:00:00Z'),
-    ),
-    // 2-->1
-    noteFactory(
-      '201' as NoteID,
-      '2' as AccountID,
-      Option.some('1' as AccountID),
-      new Date('2023-09-13T00:00:00Z'),
-    ),
-    // 4-->2
-    noteFactory(
-      '400' as NoteID,
-      '4' as AccountID,
-      Option.some('2' as AccountID),
-      new Date('2024-01-01T00:00:00Z'),
-    ),
-  ];
-  const repo = new InMemoryConversationRepository(testMap);
-  const service = new FetchConversationService(repo);
-
   it('should fetch conversations', async () => {
     const result = await service.fetchConversation('1' as AccountID);
 
     expect(Result.isOk(result)).toBe(true);
     expect(Result.unwrap(result)).toStrictEqual([
       {
-        id: testMap[3]?.getAuthorID(),
-        lastSentAt: testMap[3]?.getCreatedAt(),
-        latestNoteID: testMap[3]?.getID(),
-        latestNoteAuthor: testMap[3]?.getAuthorID(),
+        id: noteTestMap[3]?.getAuthorID(),
+        lastSentAt: noteTestMap[3]?.getCreatedAt(),
+        latestNoteID: noteTestMap[3]?.getID(),
+        latestNoteAuthor: noteTestMap[3]?.getAuthorID(),
       },
     ]);
   });
@@ -95,10 +155,10 @@ describe('FetchConversationService', () => {
     const recipients = Result.unwrap(result);
     expect(recipients).toStrictEqual([
       {
-        id: testMap[4]?.getAuthorID(),
-        lastSentAt: testMap[4]?.getCreatedAt(),
-        latestNoteID: testMap[4]?.getID(),
-        latestNoteAuthor: testMap[4]?.getAuthorID(),
+        id: noteTestMap[4]?.getAuthorID(),
+        lastSentAt: noteTestMap[4]?.getCreatedAt(),
+        latestNoteID: noteTestMap[4]?.getID(),
+        latestNoteAuthor: noteTestMap[4]?.getAuthorID(),
       },
       {
         id: '1' as AccountID,
@@ -117,126 +177,78 @@ describe('FetchConversationService', () => {
   });
 
   describe('fetchConversationNotes', () => {
-    it('should fetch conversation notes between two accounts', async () => {
+    beforeEach(() => {
+      vi.mocked(mockDirectNoteRepo.findConversation).mockResolvedValue(
+        Result.ok(dummyDirectNotes),
+      );
+    });
+
+    it('should pass default limit of 20 when no limit provided', async () => {
+      await service.fetchConversationNotes('1' as AccountID, '2' as AccountID);
+
+      expect(mockDirectNoteRepo.findConversation).toHaveBeenCalledWith(
+        '1' as AccountID,
+        '2' as AccountID,
+        { limit: 20, cursor: undefined },
+      );
+    });
+
+    it('should pass custom limit to repository', async () => {
+      await service.fetchConversationNotes('1' as AccountID, '2' as AccountID, {
+        limit: Option.some(5),
+        beforeID: Option.none(),
+        afterID: Option.none(),
+      });
+
+      expect(mockDirectNoteRepo.findConversation).toHaveBeenCalledWith(
+        '1' as AccountID,
+        '2' as AccountID,
+        { limit: 5, cursor: undefined },
+      );
+    });
+
+    it('should pass beforeID cursor to repository', async () => {
+      await service.fetchConversationNotes('1' as AccountID, '2' as AccountID, {
+        limit: Option.none(),
+        beforeID: Option.some('201' as DirectNoteID),
+        afterID: Option.none(),
+      });
+
+      expect(mockDirectNoteRepo.findConversation).toHaveBeenCalledWith(
+        '1' as AccountID,
+        '2' as AccountID,
+        { limit: 20, cursor: { type: 'before', id: '201' as DirectNoteID } },
+      );
+    });
+
+    it('should pass afterID cursor to repository', async () => {
+      await service.fetchConversationNotes('1' as AccountID, '2' as AccountID, {
+        limit: Option.none(),
+        beforeID: Option.none(),
+        afterID: Option.some('100' as DirectNoteID),
+      });
+
+      expect(mockDirectNoteRepo.findConversation).toHaveBeenCalledWith(
+        '1' as AccountID,
+        '2' as AccountID,
+        { limit: 20, cursor: { type: 'after', id: '100' as DirectNoteID } },
+      );
+    });
+
+    it('should return what the repository returns', async () => {
+      const note = dummyDirectNotes[0];
+      if (!note) throw new Error('test data missing');
+      vi.mocked(mockDirectNoteRepo.findConversation).mockResolvedValue(
+        Result.ok([note]),
+      );
+
       const result = await service.fetchConversationNotes(
         '1' as AccountID,
         '2' as AccountID,
       );
 
       expect(Result.isOk(result)).toBe(true);
-      const notes = Result.unwrap(result);
-      expect(notes).toHaveLength(4);
-      expect(notes[0]?.getID()).toBe('201');
-      expect(notes[1]?.getID()).toBe('200');
-      expect(notes[2]?.getID()).toBe('101');
-      expect(notes[3]?.getID()).toBe('100');
-    });
-
-    it('should use default limit of 20', async () => {
-      const result = await service.fetchConversationNotes(
-        '1' as AccountID,
-        '2' as AccountID,
-      );
-
-      expect(Result.isOk(result)).toBe(true);
-      const notes = Result.unwrap(result);
-      expect(notes.length).toBeLessThanOrEqual(20);
-    });
-
-    it('should respect custom limit', async () => {
-      const result = await service.fetchConversationNotes(
-        '1' as AccountID,
-        '2' as AccountID,
-        {
-          limit: Option.some(2),
-          beforeID: Option.none(),
-          afterID: Option.none(),
-        },
-      );
-
-      expect(Result.isOk(result)).toBe(true);
-      const notes = Result.unwrap(result);
-      expect(notes).toHaveLength(2);
-      expect(notes[0]?.getID()).toBe('201');
-      expect(notes[1]?.getID()).toBe('200');
-    });
-
-    it('should fetch notes before specified ID', async () => {
-      const result = await service.fetchConversationNotes(
-        '1' as AccountID,
-        '2' as AccountID,
-        {
-          limit: Option.none(),
-          beforeID: Option.some('201' as NoteID),
-          afterID: Option.none(),
-        },
-      );
-
-      expect(Result.isOk(result)).toBe(true);
-      const notes = Result.unwrap(result);
-      expect(notes).toHaveLength(3);
-      expect(notes[0]?.getID()).toBe('200');
-      expect(notes[1]?.getID()).toBe('101');
-      expect(notes[2]?.getID()).toBe('100');
-    });
-
-    it('should fetch notes after specified ID', async () => {
-      const result = await service.fetchConversationNotes(
-        '1' as AccountID,
-        '2' as AccountID,
-        {
-          limit: Option.none(),
-          beforeID: Option.none(),
-          afterID: Option.some('100' as NoteID),
-        },
-      );
-
-      expect(Result.isOk(result)).toBe(true);
-      const notes = Result.unwrap(result);
-      expect(notes).toHaveLength(3);
-      expect(notes[0]?.getID()).toBe('201');
-      expect(notes[1]?.getID()).toBe('200');
-      expect(notes[2]?.getID()).toBe('101');
-    });
-
-    it('should return empty array when no conversation exists', async () => {
-      const result = await service.fetchConversationNotes(
-        '1' as AccountID,
-        '3' as AccountID,
-      );
-
-      expect(Result.isOk(result)).toBe(true);
-      expect(Result.unwrap(result)).toStrictEqual([]);
-    });
-
-    it('should return empty array when beforeID does not exist', async () => {
-      const result = await service.fetchConversationNotes(
-        '1' as AccountID,
-        '2' as AccountID,
-        {
-          limit: Option.none(),
-          beforeID: Option.some('999' as NoteID),
-          afterID: Option.none(),
-        },
-      );
-
-      expect(Result.isOk(result)).toBe(true);
-      expect(Result.unwrap(result)).toStrictEqual([]);
-    });
-
-    it('should return empty array when afterID does not exist', async () => {
-      const result = await service.fetchConversationNotes(
-        '1' as AccountID,
-        '2' as AccountID,
-        {
-          limit: Option.none(),
-          beforeID: Option.none(),
-          afterID: Option.some('999' as NoteID),
-        },
-      );
-
-      expect(Result.isOk(result)).toBe(true);
-      expect(Result.unwrap(result)).toStrictEqual([]);
+      expect(Result.unwrap(result)).toStrictEqual([note]);
     });
 
     it('should return error when both beforeID and afterID are specified', async () => {
@@ -245,8 +257,8 @@ describe('FetchConversationService', () => {
         '2' as AccountID,
         {
           limit: Option.none(),
-          beforeID: Option.some('201' as NoteID),
-          afterID: Option.some('100' as NoteID),
+          beforeID: Option.some('201' as DirectNoteID),
+          afterID: Option.some('100' as DirectNoteID),
         },
       );
 
@@ -254,61 +266,6 @@ describe('FetchConversationService', () => {
       expect(Result.unwrapErr(result).message).toBe(
         'beforeID and afterID cannot be specified at the same time',
       );
-    });
-
-    it('should return notes sorted by creation date (newest first)', async () => {
-      const result = await service.fetchConversationNotes(
-        '1' as AccountID,
-        '2' as AccountID,
-      );
-
-      expect(Result.isOk(result)).toBe(true);
-      const notes = Result.unwrap(result);
-      for (let i = 0; i < notes.length - 1; i++) {
-        const currentNote = notes[i];
-        const nextNote = notes[i + 1];
-        if (currentNote && nextNote) {
-          expect(currentNote.getCreatedAt().getTime()).toBeGreaterThanOrEqual(
-            nextNote.getCreatedAt().getTime(),
-          );
-        }
-      }
-    });
-
-    it('should handle pagination with limit and beforeID', async () => {
-      const result = await service.fetchConversationNotes(
-        '1' as AccountID,
-        '2' as AccountID,
-        {
-          limit: Option.some(2),
-          beforeID: Option.some('201' as NoteID),
-          afterID: Option.none(),
-        },
-      );
-
-      expect(Result.isOk(result)).toBe(true);
-      const notes = Result.unwrap(result);
-      expect(notes).toHaveLength(2);
-      expect(notes[0]?.getID()).toBe('200');
-      expect(notes[1]?.getID()).toBe('101');
-    });
-
-    it('should handle pagination with limit and afterID', async () => {
-      const result = await service.fetchConversationNotes(
-        '1' as AccountID,
-        '2' as AccountID,
-        {
-          limit: Option.some(2),
-          beforeID: Option.none(),
-          afterID: Option.some('100' as NoteID),
-        },
-      );
-
-      expect(Result.isOk(result)).toBe(true);
-      const notes = Result.unwrap(result);
-      expect(notes).toHaveLength(2);
-      expect(notes[0]?.getID()).toBe('201');
-      expect(notes[1]?.getID()).toBe('200');
     });
   });
 });

--- a/pkg/timeline/service/fetchConversation.ts
+++ b/pkg/timeline/service/fetchConversation.ts
@@ -7,6 +7,7 @@ import {
   type DirectNoteRepository,
   directNoteRepoSymbol,
 } from '../../notes/model/repository.js';
+import { TimelineInvalidFilterRangeError } from '../model/errors.js';
 import {
   type ConversationRecipient,
   type ConversationRepository,
@@ -68,7 +69,10 @@ export class FetchConversationService {
   ): Promise<Result.Result<Error, DirectNote[]>> {
     if (Option.isSome(args.beforeID) && Option.isSome(args.afterID)) {
       return Result.err(
-        new Error('beforeID and afterID cannot be specified at the same time'),
+        new TimelineInvalidFilterRangeError(
+          'beforeID and afterID cannot be specified at the same time',
+          { cause: null },
+        ),
       );
     }
 

--- a/pkg/timeline/service/fetchConversation.ts
+++ b/pkg/timeline/service/fetchConversation.ts
@@ -2,13 +2,9 @@ import { Ether, Option, Result } from '@mikuroxina/mini-fn';
 
 import type { AccountID } from '../../accounts/model/account.js';
 import type { DirectNote, DirectNoteID } from '../../notes/model/directNote.js';
-import {
-  type DirectNoteConversationFilter,
-  type DirectNoteRepository,
-  directNoteRepoSymbol,
-} from '../../notes/model/repository.js';
 import { TimelineInvalidFilterRangeError } from '../model/errors.js';
 import {
+  type ConversationNotesFilter,
   type ConversationRecipient,
   type ConversationRepository,
   conversationRepoSymbol,
@@ -29,7 +25,6 @@ export interface FetchConversationNotesArgs {
 export class FetchConversationService {
   constructor(
     private readonly conversationRepository: ConversationRepository,
-    private readonly directNoteRepository: DirectNoteRepository,
   ) {}
 
   /**
@@ -78,7 +73,7 @@ export class FetchConversationService {
 
     const limit = Option.unwrapOr(20)(args.limit);
 
-    const cursor: DirectNoteConversationFilter['cursor'] = Option.isSome(
+    const cursor: ConversationNotesFilter['cursor'] = Option.isSome(
       args.beforeID,
     )
       ? {
@@ -92,12 +87,12 @@ export class FetchConversationService {
           }
         : undefined;
 
-    const filter: DirectNoteConversationFilter = {
+    const filter: ConversationNotesFilter = {
       limit,
       cursor,
     };
 
-    return await this.directNoteRepository.findConversation(
+    return await this.conversationRepository.findConversationNotes(
       accountID,
       recipientID,
       filter,
@@ -108,10 +103,9 @@ export const fetchConversationServiceSymbol =
   Ether.newEtherSymbol<FetchConversationService>();
 export const fetchConversation = Ether.newEther(
   fetchConversationServiceSymbol,
-  ({ conversationRepository, directNoteRepository }) =>
-    new FetchConversationService(conversationRepository, directNoteRepository),
+  ({ conversationRepository }) =>
+    new FetchConversationService(conversationRepository),
   {
     conversationRepository: conversationRepoSymbol,
-    directNoteRepository: directNoteRepoSymbol,
   },
 );

--- a/pkg/timeline/service/fetchConversation.ts
+++ b/pkg/timeline/service/fetchConversation.ts
@@ -1,12 +1,16 @@
 import { Ether, Option, Result } from '@mikuroxina/mini-fn';
+
 import type { AccountID } from '../../accounts/model/account.js';
-import type { Note, NoteID } from '../../notes/model/note.js';
+import type { DirectNote, DirectNoteID } from '../../notes/model/directNote.js';
 import {
-  type ConversationCursor,
+  type DirectNoteConversationFilter,
+  type DirectNoteRepository,
+  directNoteRepoSymbol,
+} from '../../notes/model/repository.js';
+import {
   type ConversationRecipient,
   type ConversationRepository,
   conversationRepoSymbol,
-  type FetchConversationNotesFilter,
 } from '../model/repository.js';
 
 export interface FetchConversationNotesArgs {
@@ -14,16 +18,17 @@ export interface FetchConversationNotesArgs {
   /**
    * @description Retrieved from notes before this ID
    */
-  beforeID: Option.Option<NoteID>;
+  beforeID: Option.Option<DirectNoteID>;
   /**
    * @description Retrieved from notes after this ID
    */
-  afterID: Option.Option<NoteID>;
+  afterID: Option.Option<DirectNoteID>;
 }
 
 export class FetchConversationService {
   constructor(
     private readonly conversationRepository: ConversationRepository,
+    private readonly directNoteRepository: DirectNoteRepository,
   ) {}
 
   /**
@@ -60,7 +65,7 @@ export class FetchConversationService {
       beforeID: Option.none(),
       afterID: Option.none(),
     },
-  ): Promise<Result.Result<Error, Note[]>> {
+  ): Promise<Result.Result<Error, DirectNote[]>> {
     if (Option.isSome(args.beforeID) && Option.isSome(args.afterID)) {
       return Result.err(
         new Error('beforeID and afterID cannot be specified at the same time'),
@@ -69,26 +74,26 @@ export class FetchConversationService {
 
     const limit = Option.unwrapOr(20)(args.limit);
 
-    const cursor: Option.Option<ConversationCursor> = Option.isSome(
+    const cursor: DirectNoteConversationFilter['cursor'] = Option.isSome(
       args.beforeID,
     )
-      ? Option.some({
+      ? {
           type: 'before',
           id: Option.unwrap(args.beforeID),
-        })
+        }
       : Option.isSome(args.afterID)
-        ? Option.some({
+        ? {
             type: 'after',
             id: Option.unwrap(args.afterID),
-          })
-        : Option.none();
+          }
+        : undefined;
 
-    const filter: FetchConversationNotesFilter = {
+    const filter: DirectNoteConversationFilter = {
       limit,
-      cursor: Option.isSome(cursor) ? Option.unwrap(cursor) : undefined,
+      cursor,
     };
 
-    return await this.conversationRepository.fetchConversationNotes(
+    return await this.directNoteRepository.findConversation(
       accountID,
       recipientID,
       filter,
@@ -99,9 +104,10 @@ export const fetchConversationServiceSymbol =
   Ether.newEtherSymbol<FetchConversationService>();
 export const fetchConversation = Ether.newEther(
   fetchConversationServiceSymbol,
-  ({ conversationRepository }) =>
-    new FetchConversationService(conversationRepository),
+  ({ conversationRepository, directNoteRepository }) =>
+    new FetchConversationService(conversationRepository, directNoteRepository),
   {
     conversationRepository: conversationRepoSymbol,
+    directNoteRepository: directNoteRepoSymbol,
   },
 );

--- a/pkg/timeline/service/noteVisibility.test.ts
+++ b/pkg/timeline/service/noteVisibility.test.ts
@@ -5,7 +5,6 @@ import type { AccountID } from '../../accounts/model/account.js';
 import { partialAccount1 } from '../../accounts/testData/testData.js';
 import { dummyAccountModuleFacade } from '../../intermodule/account.js';
 import {
-  dummyDirectNote,
   dummyFollowersNote,
   dummyHomeNote,
   dummyPublicNote,
@@ -22,12 +21,7 @@ describe('NoteVisibilityService', () => {
       },
     );
 
-    const testObjects = [
-      dummyPublicNote,
-      dummyHomeNote,
-      dummyFollowersNote,
-      dummyDirectNote,
-    ];
+    const testObjects = [dummyPublicNote, dummyHomeNote, dummyFollowersNote];
     for (const note of testObjects) {
       expect(
         await visibilityService.handle({
@@ -36,26 +30,6 @@ describe('NoteVisibilityService', () => {
         }),
       ).toBe(true);
     }
-  });
-
-  it('when direct note: return true if sendTo is accountID', async () => {
-    vi.spyOn(dummyAccountModuleFacade, 'fetchFollowers').mockImplementation(
-      async () => {
-        return Result.ok([partialAccount1]);
-      },
-    );
-
-    const res = await visibilityService.handle({
-      accountID: '101' as AccountID,
-      note: dummyDirectNote,
-    });
-    expect(res).toBe(true);
-
-    const res2 = await visibilityService.handle({
-      accountID: '0' as AccountID,
-      note: dummyDirectNote,
-    });
-    expect(res2).toBe(false);
   });
 
   it('when following: return true if public,home,followers', async () => {
@@ -129,38 +103,22 @@ describe('NoteVisibilityService', () => {
     expect(res).toBe(true);
   });
 
-  it("homeTimelineVisibilityCheck: return true if visibility is not 'DIRECT'", async () => {
+  it('homeTimelineVisibilityCheck: always return true', async () => {
     vi.spyOn(dummyAccountModuleFacade, 'fetchFollowers').mockImplementation(
       async () => Result.ok([partialAccount1]),
     );
 
-    expect(
-      await visibilityService.isVisibleNoteInHomeTimeline({
-        accountID: '0' as AccountID,
-        note: dummyPublicNote,
-      }),
-    ).toBe(true);
-    expect(
-      await visibilityService.isVisibleNoteInHomeTimeline({
-        accountID: '0' as AccountID,
-        note: dummyHomeNote,
-      }),
-    ).toBe(true);
-    expect(
-      await visibilityService.isVisibleNoteInHomeTimeline({
-        accountID: '0' as AccountID,
-        note: dummyFollowersNote,
-      }),
-    ).toBe(true);
-    expect(
-      await visibilityService.isVisibleNoteInHomeTimeline({
-        accountID: '0' as AccountID,
-        note: dummyDirectNote,
-      }),
-    ).toBe(false);
+    for (const note of [dummyPublicNote, dummyHomeNote, dummyFollowersNote]) {
+      expect(
+        await visibilityService.isVisibleNoteInHomeTimeline({
+          accountID: '0' as AccountID,
+          note,
+        }),
+      ).toBe(true);
+    }
   });
 
-  it("listVisibilityCheck: return true if visibility is not 'PUBLIC' and 'HOME'", async () => {
+  it("listVisibilityCheck: return false only for 'FOLLOWERS'", async () => {
     vi.spyOn(dummyAccountModuleFacade, 'fetchFollowers').mockImplementation(
       async () => Result.ok([partialAccount1]),
     );
@@ -181,12 +139,6 @@ describe('NoteVisibilityService', () => {
       await visibilityService.isVisibleNoteInList({
         accountID: '0' as AccountID,
         note: dummyFollowersNote,
-      }),
-    ).toBe(false);
-    expect(
-      await visibilityService.isVisibleNoteInList({
-        accountID: '0' as AccountID,
-        note: dummyDirectNote,
       }),
     ).toBe(false);
   });

--- a/pkg/timeline/service/noteVisibility.test.ts
+++ b/pkg/timeline/service/noteVisibility.test.ts
@@ -103,21 +103,6 @@ describe('NoteVisibilityService', () => {
     expect(res).toBe(true);
   });
 
-  it('homeTimelineVisibilityCheck: always return true', async () => {
-    vi.spyOn(dummyAccountModuleFacade, 'fetchFollowers').mockImplementation(
-      async () => Result.ok([partialAccount1]),
-    );
-
-    for (const note of [dummyPublicNote, dummyHomeNote, dummyFollowersNote]) {
-      expect(
-        await visibilityService.isVisibleNoteInHomeTimeline({
-          accountID: '0' as AccountID,
-          note,
-        }),
-      ).toBe(true);
-    }
-  });
-
   it("listVisibilityCheck: return false only for 'FOLLOWERS'", async () => {
     vi.spyOn(dummyAccountModuleFacade, 'fetchFollowers').mockImplementation(
       async () => Result.ok([partialAccount1]),

--- a/pkg/timeline/service/noteVisibility.ts
+++ b/pkg/timeline/service/noteVisibility.ts
@@ -27,7 +27,9 @@ export class NoteVisibilityService {
       return true;
     }
     if (args.note.getVisibility() === 'FOLLOWERS') {
-      const followers = await this.accountModule.fetchFollowers(args.accountID);
+      const followers = await this.accountModule.fetchFollowers(
+        args.note.getAuthorID(),
+      );
       if (Result.isErr(followers)) {
         return false;
       }
@@ -39,12 +41,6 @@ export class NoteVisibilityService {
     }
 
     return false;
-  }
-
-  public async isVisibleNoteInHomeTimeline(
-    _args: NoteVisibilityCheckArgs,
-  ): Promise<boolean> {
-    return true;
   }
 
   public async isVisibleNoteInList(

--- a/pkg/timeline/service/noteVisibility.ts
+++ b/pkg/timeline/service/noteVisibility.ts
@@ -1,4 +1,4 @@
-import { Ether, Option, Result } from '@mikuroxina/mini-fn';
+import { Ether, Result } from '@mikuroxina/mini-fn';
 
 import type { AccountID } from '../../accounts/model/account.js';
 import {
@@ -26,11 +26,6 @@ export class NoteVisibilityService {
     if (args.note.getVisibility() === 'HOME') {
       return true;
     }
-    if (args.note.getVisibility() === 'DIRECT') {
-      if (Option.unwrapOr('')(args.note.getSendTo()) === args.accountID) {
-        return true;
-      }
-    }
     if (args.note.getVisibility() === 'FOLLOWERS') {
       const followers = await this.accountModule.fetchFollowers(args.accountID);
       if (Result.isErr(followers)) {
@@ -47,18 +42,15 @@ export class NoteVisibilityService {
   }
 
   public async isVisibleNoteInHomeTimeline(
-    args: NoteVisibilityCheckArgs,
+    _args: NoteVisibilityCheckArgs,
   ): Promise<boolean> {
-    return args.note.getVisibility() !== 'DIRECT';
+    return true;
   }
 
   public async isVisibleNoteInList(
     args: NoteVisibilityCheckArgs,
   ): Promise<boolean> {
-    return (
-      args.note.getVisibility() !== 'DIRECT' &&
-      args.note.getVisibility() !== 'FOLLOWERS'
-    );
+    return args.note.getVisibility() !== 'FOLLOWERS';
   }
 }
 export const noteVisibilitySymbol =

--- a/pkg/timeline/service/push.test.ts
+++ b/pkg/timeline/service/push.test.ts
@@ -10,7 +10,6 @@ import { InMemoryListRepository } from '../adaptor/repository/dummy.js';
 import { InMemoryTimelineCacheRepository } from '../adaptor/repository/dummyCache.js';
 import { List, type ListID } from '../model/list.js';
 import {
-  dummyDirectNote,
   dummyFollowersNote,
   dummyHomeNote,
   dummyPublicNote,
@@ -86,17 +85,6 @@ describe('PushTimelineService', () => {
     expect(Result.unwrap(listTimeline)).toEqual(['1' as NoteID]);
   });
 
-  it("if Note.visibility is DIRECT, don't push to List", async () => {
-    const res = await pushTimelineService.handle(dummyDirectNote);
-    const listTimeline = await timelineCacheRepository.getListTimeline(
-      '10' as ListID,
-    );
-    expect(Result.isErr(res)).toBe(true);
-    expect(Result.unwrap(listTimeline).includes(dummyDirectNote.getID())).toBe(
-      false,
-    );
-  });
-
   it("if Note.visibility is FOLLOWERS, don't push to List", async () => {
     const res = await pushTimelineService.handle(dummyFollowersNote);
     const listTimeline = await timelineCacheRepository.getListTimeline(
@@ -104,9 +92,9 @@ describe('PushTimelineService', () => {
     );
 
     expect(Result.isErr(res)).toBe(true);
-    expect(Result.unwrap(listTimeline).includes(dummyDirectNote.getID())).toBe(
-      false,
-    );
+    expect(
+      Result.unwrap(listTimeline).includes(dummyFollowersNote.getID()),
+    ).toBe(false);
   });
 
   it('if Cache limit reached, delete oldest note', async () => {

--- a/pkg/timeline/service/push.ts
+++ b/pkg/timeline/service/push.ts
@@ -102,20 +102,6 @@ export class PushTimelineService {
     }
     const unwrappedFollowers = Result.unwrap(followers);
 
-    /*
-    PUBLIC, HOME, FOLLOWER: OK
-    DIRECT: reject (direct note is not pushed to home timeline)
-     */
-    const visible = await this.noteVisibility.isVisibleNoteInHomeTimeline({
-      accountID: note.getAuthorID(),
-      note,
-    });
-    if (!visible) {
-      return Result.err(
-        new NoteVisibilityInvalidError('Note invisible', { cause: null }),
-      );
-    }
-
     for (const v of unwrappedFollowers) {
       const checkRes = await this.timelineLimitCheck('home', v.id);
       if (Result.isErr(checkRes)) {
@@ -154,7 +140,7 @@ export class PushTimelineService {
 
     /*
     PUBLIC, HOME: OK
-    FOLLOWER, DIRECT: reject
+    FOLLOWERS: reject
      */
     const visible = await this.noteVisibility.isVisibleNoteInList({
       accountID: note.getAuthorID(),

--- a/prisma/migrations/20260526231912_add_direct_note_tables/migration.sql
+++ b/prisma/migrations/20260526231912_add_direct_note_tables/migration.sql
@@ -1,0 +1,61 @@
+-- DropForeignKey
+ALTER TABLE "note" DROP CONSTRAINT "note_send_to_id_fkey";
+
+-- AlterTable
+ALTER TABLE "note" DROP COLUMN "send_to_id";
+
+-- CreateTable
+CREATE TABLE "direct_note" (
+    "id" TEXT NOT NULL,
+    "text" TEXT NOT NULL,
+    "author_id" TEXT NOT NULL,
+    "recipient_id" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "deleted_at" TIMESTAMP(3),
+
+    CONSTRAINT "direct_note_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "direct_note_attachment" (
+    "medium_id" TEXT NOT NULL,
+    "direct_note_id" TEXT NOT NULL,
+    "alt" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "deleted_at" TIMESTAMP(3),
+
+    CONSTRAINT "direct_note_attachment_pkey" PRIMARY KEY ("medium_id","direct_note_id")
+);
+
+-- CreateTable
+CREATE TABLE "direct_note_reaction" (
+    "reactionId" TEXT NOT NULL,
+    "reacted_by_id" TEXT NOT NULL,
+    "reacted_to_id" TEXT NOT NULL,
+    "body" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "deleted_at" TIMESTAMP(3),
+
+    CONSTRAINT "direct_note_reaction_pkey" PRIMARY KEY ("reactionId")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "direct_note_reaction_reacted_by_id_reacted_to_id_key" ON "direct_note_reaction"("reacted_by_id", "reacted_to_id");
+
+-- AddForeignKey
+ALTER TABLE "direct_note" ADD CONSTRAINT "direct_note_author_id_fkey" FOREIGN KEY ("author_id") REFERENCES "account"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "direct_note" ADD CONSTRAINT "direct_note_recipient_id_fkey" FOREIGN KEY ("recipient_id") REFERENCES "account"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "direct_note_attachment" ADD CONSTRAINT "direct_note_attachment_medium_id_fkey" FOREIGN KEY ("medium_id") REFERENCES "medium"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "direct_note_attachment" ADD CONSTRAINT "direct_note_attachment_direct_note_id_fkey" FOREIGN KEY ("direct_note_id") REFERENCES "direct_note"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "direct_note_reaction" ADD CONSTRAINT "direct_note_reaction_reacted_by_id_fkey" FOREIGN KEY ("reacted_by_id") REFERENCES "account"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "direct_note_reaction" ADD CONSTRAINT "direct_note_reaction_reacted_to_id_fkey" FOREIGN KEY ("reacted_to_id") REFERENCES "direct_note"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -26,20 +26,22 @@ model Account {
   updatedAt DateTime? @updatedAt @map("updated_at")
   deletedAt DateTime? @map("deleted_at")
 
-  following          Following[]          @relation("following")
-  followed           Following[]          @relation("followed")
-  avatar             AccountAvatar[]      @relation("avatar")
-  header             AccountHeader[]      @relation("header")
-  note               Note[]               @relation("author")
-  reaction           Reaction[]
-  bookmark           Bookmark[]
-  listMember         ListMember[]
-  medium Medium[]
-  list   List[]
+  following  Following[]     @relation("following")
+  followed   Following[]     @relation("followed")
+  avatar     AccountAvatar[] @relation("avatar")
+  header     AccountHeader[] @relation("header")
+  note       Note[]          @relation("author")
+  reaction   Reaction[]
+  bookmark   Bookmark[]
+  listMember ListMember[]
+  medium     Medium[]
+  list       List[]
 
-  recievedNotification Notification[] @relation("recipient")
-  sentNotification     Notification[] @relation("actor")
-  conversation         Note[]         @relation("conversation")
+  recievedNotification Notification[]       @relation("recipient")
+  sentNotification     Notification[]       @relation("actor")
+  sentDirectNotes      DirectNote[]         @relation("directNoteAuthor")
+  receivedDirectNotes  DirectNote[]         @relation("directNoteRecipient")
+  directNoteReaction   DirectNoteReaction[]
 
   @@map("account")
 }
@@ -60,15 +62,13 @@ model Following {
 }
 
 model Note {
-  id         String   @id
-  text       String   @db.Text
-  visibility Int      @default(0)
-  author     Account  @relation("author", fields: [authorId], references: [id])
-  authorId   String   @map("author_id")
-  renoteId   String?  @map("renote_id")
-  renote     Note?    @relation("renote", fields: [renoteId], references: [id])
-  sendTo     Account? @relation("conversation", fields: [sendToId], references: [id])
-  sendToId   String?  @map("send_to_id")
+  id         String  @id
+  text       String  @db.Text
+  visibility Int     @default(0)
+  author     Account @relation("author", fields: [authorId], references: [id])
+  authorId   String  @map("author_id")
+  renoteId   String? @map("renote_id")
+  renote     Note?   @relation("renote", fields: [renoteId], references: [id])
 
   createdAt      DateTime         @default(now()) @map("created_at")
   deletedAt      DateTime?        @map("deleted_at")
@@ -78,6 +78,51 @@ model Note {
   noteAttachment NoteAttachment[]
 
   @@map("note")
+}
+
+model DirectNote {
+  id          String  @id
+  text        String  @db.Text
+  author      Account @relation("directNoteAuthor", fields: [authorId], references: [id])
+  authorId    String  @map("author_id")
+  recipient   Account @relation("directNoteRecipient", fields: [recipientId], references: [id])
+  recipientId String  @map("recipient_id")
+
+  createdAt            DateTime               @default(now()) @map("created_at")
+  deletedAt            DateTime?              @map("deleted_at")
+  directNoteAttachment DirectNoteAttachment[]
+  reaction             DirectNoteReaction[]
+
+  @@map("direct_note")
+}
+
+model DirectNoteAttachment {
+  mediumId     String     @map("medium_id")
+  medium       Medium     @relation(fields: [mediumId], references: [id])
+  directNoteId String     @map("direct_note_id")
+  directNote   DirectNote @relation(fields: [directNoteId], references: [id])
+
+  alt       String
+  createdAt DateTime  @default(now()) @map("created_at")
+  deletedAt DateTime? @map("deleted_at")
+
+  @@id([mediumId, directNoteId])
+  @@map("direct_note_attachment")
+}
+
+model DirectNoteReaction {
+  reactionId  String     @id
+  reactedById String     @map("reacted_by_id")
+  reactedBy   Account    @relation(fields: [reactedById], references: [id])
+  reactedToId String     @map("reacted_to_id")
+  reactedTo   DirectNote @relation(fields: [reactedToId], references: [id])
+  body        String
+
+  createdAt DateTime  @default(now()) @map("created_at")
+  deletedAt DateTime? @map("deleted_at")
+
+  @@unique([reactedById, reactedToId])
+  @@map("direct_note_reaction")
 }
 
 model Reaction {
@@ -136,20 +181,21 @@ model ListMember {
 }
 
 model Medium {
-  id             String           @id
-  name           String
-  mime           String
-  hash           String
-  nsfw           Boolean
-  authorId       String           @map("author_id")
-  author         Account          @relation(fields: [authorId], references: [id])
-  thumbnailUrl   String
-  url            String
-  createdAt      DateTime         @default(now()) @map("created_at")
-  deletedAt      DateTime?        @map("deleted_at")
-  noteAttachment NoteAttachment[]
-  AccountAvatar  AccountAvatar[]
-  AccountHeader  AccountHeader[]
+  id                   String                 @id
+  name                 String
+  mime                 String
+  hash                 String
+  nsfw                 Boolean
+  authorId             String                 @map("author_id")
+  author               Account                @relation(fields: [authorId], references: [id])
+  thumbnailUrl         String
+  url                  String
+  createdAt            DateTime               @default(now()) @map("created_at")
+  deletedAt            DateTime?              @map("deleted_at")
+  noteAttachment       NoteAttachment[]
+  directNoteAttachment DirectNoteAttachment[]
+  AccountAvatar        AccountAvatar[]
+  AccountHeader        AccountHeader[]
 
   @@map("medium")
 }


### PR DESCRIPTION
close #1628

## What does this PR do?
- `Note`から`DirectNote`を分離
  - 対象: DBテーブル/Repository/Service/モデル
- Noteテーブルにはダイレクト投稿は入れないようにしました
- それに伴ってDirectかどうかのチェックを行っていた部分が不要になるので削除


## Additional information
- cherrypickを指示したら全部co-authoredになってしまった orz
- InMemoryRepositoryは段階的に廃止していくつもりです．このPRでも新規でInMemoryRepositoryは作らず`vi.fn()`を使っています
