### PR TITLE
refactor: リノートのリアクションの挙動を整理

### DIFF
--- a/pkg/notes/adaptor/repository/prisma/note.ts
+++ b/pkg/notes/adaptor/repository/prisma/note.ts
@@ -66,7 +66,10 @@ export class PrismaNoteRepository implements NoteRepository {
     };
   }
 
-  private deserialize(data: DeserializeNoteArgs): Note {
+  private deserialize(
+    data: DeserializeNoteArgs,
+    attachmentFileID: readonly MediumID[] = [],
+  ): Note {
     if (!data) {
       throw new Error('Invalid Note data');
     }
@@ -94,7 +97,7 @@ export class PrismaNoteRepository implements NoteRepository {
       originalNoteID: data.renoteId
         ? Option.some(data.renoteId as NoteID)
         : Option.none(),
-      attachmentFileID: [],
+      attachmentFileID,
       // ToDo: add SendTo field to schema
       sendTo: Option.none(),
       updatedAt: Option.none(),
@@ -182,8 +185,15 @@ export class PrismaNoteRepository implements NoteRepository {
           // NOTE: Exclude from the search those whose deletedAt does not appear undefined.
           deletedAt: undefined,
         },
+        include: { noteAttachment: true },
       });
-      return Option.some(this.deserialize(res));
+      const { noteAttachment, ...noteData } = res;
+      return Option.some(
+        this.deserialize(
+          noteData,
+          noteAttachment.map((a) => a.mediumId as MediumID),
+        ),
+      );
     } catch {
       return Option.none();
     }

--- a/pkg/notes/adaptor/repository/prisma/note.ts
+++ b/pkg/notes/adaptor/repository/prisma/note.ts
@@ -407,16 +407,12 @@ export class PrismaReactionRepository implements ReactionRepository {
       throw new Error('Invalid Reaction data');
     }
 
-    const reaction = Reaction.new({
+    return Reaction.reconstruct({
       id: data.reactionId as ReactionID,
       noteID: data.reactedToId as NoteID,
       accountID: data.reactedById as AccountID,
       body: data.body,
     });
-    if (Result.isErr(reaction)) {
-      throw new Error('Invalid Reaction data');
-    }
-    return Result.unwrap(reaction);
   }
 
   async create(reaction: Reaction): Promise<Result.Result<Error, void>> {

--- a/pkg/notes/mod.ts
+++ b/pkg/notes/mod.ts
@@ -159,7 +159,9 @@ const createReactionServiceObj = Ether.runEther(
     .feed(Ether.compose(noteRepoEther)).value,
 );
 const deleteReactionServiceObj = Ether.runEther(
-  Cat.cat(deleteReaction).feed(Ether.compose(noteReactionRepoEther)).value,
+  Cat.cat(deleteReaction)
+    .feed(Ether.compose(noteReactionRepoEther))
+    .feed(Ether.compose(noteRepoEther)).value,
 );
 const reactionController = new ReactionController(
   createReactionServiceObj,

--- a/pkg/notes/model/reaction.test.ts
+++ b/pkg/notes/model/reaction.test.ts
@@ -1,18 +1,45 @@
-import { Result } from '@mikuroxina/mini-fn';
+import { Option, Result } from '@mikuroxina/mini-fn';
 import { describe, expect, it } from 'vitest';
 
 import type { AccountID } from '../../accounts/model/account.js';
 import { NoteInvalidReactionError } from './errors.js';
-import type { NoteID } from './note.js';
+import { Note, type NoteID } from './note.js';
 import {
   type CreateReactionArgs,
   Reaction,
   type ReactionID,
 } from './reaction.js';
 
+const noteFactory = (
+  id: NoteID,
+  content: string,
+  originalNoteID: Option.Option<NoteID>,
+) =>
+  Result.unwrap(
+    Note.new({
+      id,
+      authorID: '10' as AccountID,
+      content,
+      visibility: 'PUBLIC',
+      contentsWarningComment: '',
+      attachmentFileID: [],
+      createdAt: new Date(),
+      originalNoteID,
+      sendTo: Option.none(),
+    }),
+  );
+
+const normalNote = noteFactory('1' as NoteID, 'test note', Option.none());
+const renoteNote = noteFactory('2' as NoteID, '', Option.some('1' as NoteID));
+const quoteNote = noteFactory(
+  '3' as NoteID,
+  'quoted content',
+  Option.some('1' as NoteID),
+);
+
 const baseArgs: CreateReactionArgs = {
   id: '100' as ReactionID,
-  noteID: '1' as NoteID,
+  note: normalNote,
   accountID: '2' as AccountID,
   body: '👍',
 };
@@ -45,6 +72,29 @@ describe('Reaction', () => {
     const reaction = Result.unwrap(Reaction.new(baseArgs));
 
     expect(reaction.getAccountID()).toBe(baseArgs.accountID);
-    expect(reaction.getNoteID()).toBe(baseArgs.noteID);
+    expect(reaction.getNoteID()).toBe(normalNote.getID());
+  });
+
+  describe('reaction target resolution', () => {
+    it('reacting on a normal note targets the note itself', () => {
+      const reaction = Result.unwrap(
+        Reaction.new({ ...baseArgs, note: normalNote }),
+      );
+      expect(reaction.getNoteID()).toBe(normalNote.getID());
+    });
+
+    it('reacting on a renote targets the original note', () => {
+      const reaction = Result.unwrap(
+        Reaction.new({ ...baseArgs, note: renoteNote }),
+      );
+      expect(reaction.getNoteID()).toBe('1' as NoteID);
+    });
+
+    it('reacting on a quote targets the quote itself', () => {
+      const reaction = Result.unwrap(
+        Reaction.new({ ...baseArgs, note: quoteNote }),
+      );
+      expect(reaction.getNoteID()).toBe(quoteNote.getID());
+    });
   });
 });

--- a/pkg/notes/model/reaction.ts
+++ b/pkg/notes/model/reaction.ts
@@ -1,10 +1,10 @@
-import { Result } from '@mikuroxina/mini-fn';
+import { Option, Result } from '@mikuroxina/mini-fn';
 import * as v from 'valibot';
 
 import type { AccountID } from '../../accounts/model/account.js';
 import type { ID } from '../../internal/id/type.js';
 import { NoteInvalidReactionError } from './errors.js';
-import type { NoteID } from './note.js';
+import type { Note, NoteID } from './note.js';
 
 const unicodeEmojiSchema = v.pipe(
   v.string(),
@@ -24,7 +24,7 @@ export type ReactionID = ID<Reaction>;
 export interface CreateReactionArgs {
   id: ReactionID;
   accountID: AccountID;
-  noteID: NoteID;
+  note: Note;
   body: string;
 }
 
@@ -34,11 +34,16 @@ export class Reaction {
   readonly #noteID: NoteID;
   readonly #emoji: Emoji;
 
-  private constructor(args: CreateReactionArgs) {
+  private constructor(args: {
+    id: ReactionID;
+    accountID: AccountID;
+    noteID: NoteID;
+    emoji: Emoji;
+  }) {
     this.#id = args.id;
     this.#accountID = args.accountID;
     this.#noteID = args.noteID;
-    this.#emoji = args.body as Emoji;
+    this.#emoji = args.emoji;
   }
 
   static new(
@@ -49,7 +54,35 @@ export class Reaction {
         new NoteInvalidReactionError('Emoji type is invalid', { cause: null }),
       );
     }
-    return Result.ok(new Reaction(arg));
+
+    // Reactions on a non-quote renote are attributed to the original note
+    const noteID =
+      arg.note.isRenote() && !arg.note.isQuote()
+        ? Option.unwrap(arg.note.getOriginalNoteID())
+        : arg.note.getID();
+
+    return Result.ok(
+      new Reaction({
+        id: arg.id,
+        accountID: arg.accountID,
+        noteID,
+        emoji: arg.body as Emoji,
+      }),
+    );
+  }
+
+  static reconstruct(arg: {
+    id: ReactionID;
+    accountID: AccountID;
+    noteID: NoteID;
+    body: string;
+  }): Reaction {
+    return new Reaction({
+      id: arg.id,
+      accountID: arg.accountID,
+      noteID: arg.noteID,
+      emoji: arg.body as Emoji,
+    });
   }
 
   getID(): ReactionID {

--- a/pkg/notes/service/createReaction.test.ts
+++ b/pkg/notes/service/createReaction.test.ts
@@ -112,5 +112,7 @@ describe('CreateReactionService', () => {
         }),
       ),
     ).toBe(true);
+    // The returned note should be the original note, not the renote
+    expect(Result.unwrap(res).getID()).toBe('1' as NoteID);
   });
 });

--- a/pkg/notes/service/createReaction.test.ts
+++ b/pkg/notes/service/createReaction.test.ts
@@ -10,22 +10,45 @@ import { Note, type NoteID } from '../model/note.js';
 import { CreateReactionService } from './createReaction.js';
 
 const idGenerator = new SnowflakeIDGenerator(1, new MockClock(new Date()));
-let reactionRepository = new InMemoryReactionRepository();
-let noteRepository = new InMemoryNoteRepository([
+
+const noteFactory = (
+  id: NoteID,
+  authorID: AccountID,
+  content: string,
+  originalNoteID: Option.Option<NoteID>,
+  createdAt: Date,
+) =>
   Result.unwrap(
     Note.new({
-      id: '1' as NoteID,
-      authorID: '2' as AccountID,
-      content: 'this is a test note',
+      id,
+      authorID,
+      content,
       visibility: 'PUBLIC',
       contentsWarningComment: '',
       attachmentFileID: [],
-      createdAt: new Date(2023, 9, 10, 0, 0),
-      originalNoteID: Option.none(),
+      createdAt,
+      originalNoteID,
       sendTo: Option.none(),
     }),
-  ),
-]);
+  );
+
+const normalNote = noteFactory(
+  '1' as NoteID,
+  '2' as AccountID,
+  'this is a test note',
+  Option.none(),
+  new Date(2023, 9, 10, 0, 0),
+);
+const renoteNote = noteFactory(
+  '2' as NoteID,
+  '3' as AccountID,
+  '',
+  Option.some('1' as NoteID),
+  new Date(2023, 9, 10, 1, 0),
+);
+
+let reactionRepository = new InMemoryReactionRepository();
+let noteRepository = new InMemoryNoteRepository([normalNote, renoteNote]);
 let service = new CreateReactionService(
   idGenerator,
   reactionRepository,
@@ -35,21 +58,7 @@ let service = new CreateReactionService(
 describe('CreateReactionService', () => {
   afterEach(() => {
     reactionRepository = new InMemoryReactionRepository();
-    noteRepository = new InMemoryNoteRepository([
-      Result.unwrap(
-        Note.new({
-          id: '1' as NoteID,
-          authorID: '2' as AccountID,
-          content: 'this is a test note',
-          visibility: 'PUBLIC',
-          contentsWarningComment: '',
-          attachmentFileID: [],
-          createdAt: new Date(2023, 9, 10, 0, 0),
-          originalNoteID: Option.none(),
-          sendTo: Option.none(),
-        }),
-      ),
-    ]);
+    noteRepository = new InMemoryNoteRepository([normalNote, renoteNote]);
     service = new CreateReactionService(
       idGenerator,
       reactionRepository,
@@ -89,5 +98,19 @@ describe('CreateReactionService', () => {
     const res = await service.handle('5' as NoteID, '3' as AccountID, '👍');
 
     expect(Result.isErr(res)).toBe(true);
+  });
+
+  it('reacting on a renote is attributed to the original note', async () => {
+    const res = await service.handle('2' as NoteID, '4' as AccountID, '👍');
+
+    expect(Result.isOk(res)).toBe(true);
+    expect(
+      Result.isOk(
+        await reactionRepository.findByCompositeID({
+          noteID: '1' as NoteID,
+          accountID: '4' as AccountID,
+        }),
+      ),
+    ).toBe(true);
   });
 });

--- a/pkg/notes/service/createReaction.ts
+++ b/pkg/notes/service/createReaction.ts
@@ -58,9 +58,12 @@ export class CreateReactionService {
     const targetNoteID = reaction.getNoteID();
     if (targetNoteID !== noteID) {
       const originalNote = await this.noteRepository.findByID(targetNoteID);
-      if (Option.isSome(originalNote)) {
-        return Result.ok(Option.unwrap(originalNote));
+      if (Option.isNone(originalNote)) {
+        return Result.err(
+          new NoteNotFoundError('Original note not found', { cause: null }),
+        );
       }
+      return Result.ok(Option.unwrap(originalNote));
     }
 
     return Result.ok(Option.unwrap(note));

--- a/pkg/notes/service/createReaction.ts
+++ b/pkg/notes/service/createReaction.ts
@@ -54,6 +54,15 @@ export class CreateReactionService {
       return res;
     }
 
+    // If the reaction was attributed to the original note (renote case), return that note
+    const targetNoteID = reaction.getNoteID();
+    if (targetNoteID !== noteID) {
+      const originalNote = await this.noteRepository.findByID(targetNoteID);
+      if (Option.isSome(originalNote)) {
+        return Result.ok(Option.unwrap(originalNote));
+      }
+    }
+
     return Result.ok(Option.unwrap(note));
   }
 }

--- a/pkg/notes/service/createReaction.ts
+++ b/pkg/notes/service/createReaction.ts
@@ -40,7 +40,7 @@ export class CreateReactionService {
 
     const reactionRes = Reaction.new({
       id: Result.unwrap(id),
-      noteID,
+      note: Option.unwrap(note),
       accountID,
       body,
     });

--- a/pkg/notes/service/deleteReaction.test.ts
+++ b/pkg/notes/service/deleteReaction.test.ts
@@ -5,7 +5,7 @@ import {
   InMemoryNoteRepository,
   InMemoryReactionRepository,
 } from '../adaptor/repository/dummy.js';
-import { NoteNotReactedYetError } from '../model/errors.js';
+import { NoteNotFoundError, NoteNotReactedYetError } from '../model/errors.js';
 import { Note, type NoteID } from '../model/note.js';
 import { Reaction, type ReactionID } from '../model/reaction.js';
 import { DeleteReactionService } from './deleteReaction.js';
@@ -55,8 +55,14 @@ describe('DeleteReactionService', () => {
     expect(Result.isOk(res)).toBe(true);
   });
 
-  it('if reaction not found, should return error', async () => {
+  it('if note not found, should return NoteNotFoundError', async () => {
     const res = await service.handle('999' as NoteID, '2' as AccountID);
+    expect(Result.isErr(res)).toBe(true);
+    expect(Result.unwrapErr(res)).toBeInstanceOf(NoteNotFoundError);
+  });
+
+  it('if reaction not found, should return NoteNotReactedYetError', async () => {
+    const res = await service.handle('1' as NoteID, '99' as AccountID);
     expect(Result.isErr(res)).toBe(true);
     expect(Result.unwrapErr(res)).toBeInstanceOf(NoteNotReactedYetError);
   });

--- a/pkg/notes/service/deleteReaction.test.ts
+++ b/pkg/notes/service/deleteReaction.test.ts
@@ -9,14 +9,12 @@ import { DeleteReactionService } from './deleteReaction.js';
 
 describe('DeleteReactionService', () => {
   const reactionRepo = new InMemoryReactionRepository([
-    Result.unwrap(
-      Reaction.new({
-        id: '100' as ReactionID,
-        noteID: '1' as NoteID,
-        accountID: '2' as AccountID,
-        body: '👍',
-      }),
-    ),
+    Reaction.reconstruct({
+      id: '100' as ReactionID,
+      noteID: '1' as NoteID,
+      accountID: '2' as AccountID,
+      body: '👍',
+    }),
   ]);
   const service = new DeleteReactionService(reactionRepo);
 

--- a/pkg/notes/service/deleteReaction.test.ts
+++ b/pkg/notes/service/deleteReaction.test.ts
@@ -1,11 +1,36 @@
-import { Result } from '@mikuroxina/mini-fn';
+import { Option, Result } from '@mikuroxina/mini-fn';
 import { describe, expect, it } from 'vitest';
 import type { AccountID } from '../../accounts/model/account.js';
-import { InMemoryReactionRepository } from '../adaptor/repository/dummy.js';
+import {
+  InMemoryNoteRepository,
+  InMemoryReactionRepository,
+} from '../adaptor/repository/dummy.js';
 import { NoteNotReactedYetError } from '../model/errors.js';
-import type { NoteID } from '../model/note.js';
+import { Note, type NoteID } from '../model/note.js';
 import { Reaction, type ReactionID } from '../model/reaction.js';
 import { DeleteReactionService } from './deleteReaction.js';
+
+const noteFactory = (
+  id: NoteID,
+  content: string,
+  originalNoteID: Option.Option<NoteID>,
+) =>
+  Result.unwrap(
+    Note.new({
+      id,
+      authorID: '10' as AccountID,
+      content,
+      visibility: 'PUBLIC',
+      contentsWarningComment: '',
+      attachmentFileID: [],
+      createdAt: new Date(),
+      originalNoteID,
+      sendTo: Option.none(),
+    }),
+  );
+
+const normalNote = noteFactory('1' as NoteID, 'test note', Option.none());
+const renoteNote = noteFactory('2' as NoteID, '', Option.some('1' as NoteID));
 
 describe('DeleteReactionService', () => {
   const reactionRepo = new InMemoryReactionRepository([
@@ -15,8 +40,15 @@ describe('DeleteReactionService', () => {
       accountID: '2' as AccountID,
       body: '👍',
     }),
+    Reaction.reconstruct({
+      id: '101' as ReactionID,
+      noteID: '1' as NoteID,
+      accountID: '3' as AccountID,
+      body: '❤️',
+    }),
   ]);
-  const service = new DeleteReactionService(reactionRepo);
+  const noteRepo = new InMemoryNoteRepository([normalNote, renoteNote]);
+  const service = new DeleteReactionService(reactionRepo, noteRepo);
 
   it('should delete a reaction', async () => {
     const res = await service.handle('1' as NoteID, '2' as AccountID);
@@ -27,5 +59,10 @@ describe('DeleteReactionService', () => {
     const res = await service.handle('999' as NoteID, '2' as AccountID);
     expect(Result.isErr(res)).toBe(true);
     expect(Result.unwrapErr(res)).toBeInstanceOf(NoteNotReactedYetError);
+  });
+
+  it('deleting reaction via renote ID resolves to original note', async () => {
+    const res = await service.handle('2' as NoteID, '3' as AccountID);
+    expect(Result.isOk(res)).toBe(true);
   });
 });

--- a/pkg/notes/service/deleteReaction.ts
+++ b/pkg/notes/service/deleteReaction.ts
@@ -1,20 +1,34 @@
-import { Ether, Result } from '@mikuroxina/mini-fn';
+import { Ether, Option, Result } from '@mikuroxina/mini-fn';
 import type { AccountID } from '../../accounts/model/account.js';
 import type { NoteID } from '../model/note.js';
 import {
+  type NoteRepository,
+  noteRepoSymbol,
   type ReactionRepository,
   reactionRepoSymbol,
 } from '../model/repository.js';
 
 export class DeleteReactionService {
-  constructor(private readonly reactionRepository: ReactionRepository) {}
+  constructor(
+    private readonly reactionRepository: ReactionRepository,
+    private readonly noteRepository: NoteRepository,
+  ) {}
 
   async handle(
     noteID: NoteID,
     accountID: AccountID,
   ): Promise<Result.Result<Error, void>> {
+    const note = await this.noteRepository.findByID(noteID);
+    let targetNoteID = noteID;
+    if (Option.isSome(note)) {
+      const unwrappedNote = Option.unwrap(note);
+      if (unwrappedNote.isRenote() && !unwrappedNote.isQuote()) {
+        targetNoteID = Option.unwrap(unwrappedNote.getOriginalNoteID());
+      }
+    }
+
     const reactionRes = await this.reactionRepository.findByCompositeID({
-      noteID,
+      noteID: targetNoteID,
       accountID,
     });
     if (Result.isErr(reactionRes)) {
@@ -30,8 +44,10 @@ export const deleteReactionSymbol =
   Ether.newEtherSymbol<DeleteReactionService>();
 export const deleteReaction = Ether.newEther(
   deleteReactionSymbol,
-  ({ reactionRepository }) => new DeleteReactionService(reactionRepository),
+  ({ reactionRepository, noteRepository }) =>
+    new DeleteReactionService(reactionRepository, noteRepository),
   {
     reactionRepository: reactionRepoSymbol,
+    noteRepository: noteRepoSymbol,
   },
 );

--- a/pkg/notes/service/deleteReaction.ts
+++ b/pkg/notes/service/deleteReaction.ts
@@ -1,5 +1,6 @@
 import { Ether, Option, Result } from '@mikuroxina/mini-fn';
 import type { AccountID } from '../../accounts/model/account.js';
+import { NoteNotFoundError } from '../model/errors.js';
 import type { NoteID } from '../model/note.js';
 import {
   type NoteRepository,
@@ -19,12 +20,16 @@ export class DeleteReactionService {
     accountID: AccountID,
   ): Promise<Result.Result<Error, void>> {
     const note = await this.noteRepository.findByID(noteID);
+    if (Option.isNone(note)) {
+      return Result.err(
+        new NoteNotFoundError('Note not found', { cause: null }),
+      );
+    }
+
+    const unwrappedNote = Option.unwrap(note);
     let targetNoteID = noteID;
-    if (Option.isSome(note)) {
-      const unwrappedNote = Option.unwrap(note);
-      if (unwrappedNote.isRenote() && !unwrappedNote.isQuote()) {
-        targetNoteID = Option.unwrap(unwrappedNote.getOriginalNoteID());
-      }
+    if (unwrappedNote.isRenote() && !unwrappedNote.isQuote()) {
+      targetNoteID = Option.unwrap(unwrappedNote.getOriginalNoteID());
     }
 
     const reactionRes = await this.reactionRepository.findByCompositeID({


### PR DESCRIPTION
close #1465 

## What does this PR do?
- リノートに付けるリアクションはオリジナルに付けたものとして扱うようにしました
  - 周辺Serviceも同時に修正しています

## Additional information
