### PR TITLE
chore: 開発用ダミーメールサーバーを入れる

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -7,6 +7,9 @@ services:
       - DATABASE_URL=postgresql://pulsate:pulsate_db_pass@db:5432/pulsate?schema=public
       - TURNSTILE_SECRET=1x0000000000000000000000000000000AA
       - VALKEY_REDIS_HOST=kv
+      - SMTP_HOST=mailpit
+      - SMTP_PORT=1025
+      - SMTP_FROM=noreply@pulsate.test
     ports:
       - "3000:3000"
   db:
@@ -26,7 +29,17 @@ services:
       - "6379:6379"
     volumes:
       - kv_data:/data
-
+  # Development-only mail catcher. Not started by a plain `docker compose up`;
+  # use `docker compose --profile dev up` so it never runs in production.
+  mailpit:
+    image: axllent/mailpit
+    container_name: mailpit
+    profiles:
+      - dev
+    restart: on-failure
+    ports:
+      - "1025:1025" # SMTP
+      - "8025:8025" # Web UI
 
 volumes:
   db_data:

--- a/pkg/intermodule/notification.ts
+++ b/pkg/intermodule/notification.ts
@@ -98,20 +98,16 @@ const notificationRepo = Ether.newEther(
 
 const smtpConfig = {
   host: process.env.SMTP_HOST ?? '',
+  port: Number(process.env.SMTP_PORT) || 587,
   user: process.env.SMTP_USER ?? '',
   pass: process.env.SMTP_PASS ?? '',
   from: process.env.SMTP_FROM ?? '',
 };
 
-const emailSenderObject = isProduction
-  ? new SmtpEmailSender({
-      host: smtpConfig.host,
-      port: 587,
-      user: smtpConfig.user,
-      pass: smtpConfig.pass,
-      from: smtpConfig.from,
-    })
-  : new DummyEmailSender();
+const emailSenderObject =
+  isProduction || smtpConfig.host !== ''
+    ? new SmtpEmailSender(smtpConfig)
+    : new DummyEmailSender();
 const emailSender = Ether.newEther(emailSenderSymbol, () => emailSenderObject);
 
 export const notificationModuleFacadeSymbol =


### PR DESCRIPTION
close #1670 

## What does this PR do?
- ローカルで動作確認する際に使えるダミーメールサーバー(mailpit)を組み込みました
  - `docker compose --profile dev up -d`で起動します
  - (明示的に指定しない時は起動しません)
- メール設定周りの環境変数の扱いを修正

## Additional information
