### PR TITLE
refactor: driveモデルのビジネスロジックをドメイン層に集約

### DIFF
--- a/pkg/accounts/adaptor/controller/account.ts
+++ b/pkg/accounts/adaptor/controller/account.ts
@@ -1,5 +1,5 @@
 import type { z } from '@hono/zod-openapi';
-import { Option, Result } from '@mikuroxina/mini-fn';
+import { Cat, Option, Result } from '@mikuroxina/mini-fn';
 
 import type { Medium, MediumID } from '../../../drive/model/medium.js';
 import type { AccountID, AccountName } from '../../model/account.js';
@@ -236,12 +236,14 @@ export class AccountController {
     const headerRes = await this.headerService.fetchByAccountID(
       account.getID(),
     );
-    const avatar = Result.mapOr('')((avatarImage: Medium): string =>
-      Option.unwrapOr('')(avatarImage.getUrl()),
-    )(avatarRes);
-    const header = Result.mapOr('')((headerImage: Medium): string =>
-      Option.unwrapOr('')(headerImage.getUrl()),
-    )(headerRes);
+    const avatar = Cat.cat(avatarRes)
+      .feed(Result.optionOk)
+      .feed(Option.andThen((avatarImage: Medium) => avatarImage.getUrl()))
+      .feed(Option.unwrapOr('')).value;
+    const header = Cat.cat(headerRes)
+      .feed(Result.optionOk)
+      .feed(Option.andThen((headerImage: Medium) => headerImage.getUrl()))
+      .feed(Option.unwrapOr('')).value;
     const followCountRes = await this.fetchFollowService.fetchFollowCount(
       account.getID(),
     );
@@ -287,12 +289,14 @@ export class AccountController {
     const headerRes = await this.headerService.fetchByAccountID(
       account.getID(),
     );
-    const avatar = Result.mapOr('')((avatarImage: Medium): string =>
-      Option.unwrapOr('')(avatarImage.getUrl()),
-    )(avatarRes);
-    const header = Result.mapOr('')((headerImage: Medium): string =>
-      Option.unwrapOr('')(headerImage.getUrl()),
-    )(headerRes);
+    const avatar = Cat.cat(avatarRes)
+      .feed(Result.optionOk)
+      .feed(Option.andThen((avatarImage: Medium) => avatarImage.getUrl()))
+      .feed(Option.unwrapOr('')).value;
+    const header = Cat.cat(headerRes)
+      .feed(Result.optionOk)
+      .feed(Option.andThen((headerImage: Medium) => headerImage.getUrl()))
+      .feed(Option.unwrapOr('')).value;
     const followCountRes = await this.fetchFollowService.fetchFollowCount(
       account.getID(),
     );
@@ -452,13 +456,15 @@ export class AccountController {
 
     for (const id of accountIDs) {
       const avatarRes = await this.avatarService.fetchByAccountID(id);
-      const avatar = Result.mapOr('')((avatarImage: Medium): string =>
-        Option.unwrapOr('')(avatarImage.getUrl()),
-      )(avatarRes);
+      const avatar = Cat.cat(avatarRes)
+        .feed(Result.optionOk)
+        .feed(Option.andThen((avatarImage: Medium) => avatarImage.getUrl()))
+        .feed(Option.unwrapOr('')).value;
       const headerRes = await this.headerService.fetchByAccountID(id);
-      const header = Result.mapOr('')((headerImage: Medium): string =>
-        Option.unwrapOr('')(headerImage.getUrl()),
-      )(headerRes);
+      const header = Cat.cat(headerRes)
+        .feed(Result.optionOk)
+        .feed(Option.andThen((headerImage: Medium) => headerImage.getUrl()))
+        .feed(Option.unwrapOr('')).value;
       headerAvatarImages.set(id, [header, avatar]);
 
       const followCountRes = await this.fetchFollowService.fetchFollowCount(id);
@@ -530,13 +536,15 @@ export class AccountController {
 
     for (const id of accountIDs) {
       const avatarRes = await this.avatarService.fetchByAccountID(id);
-      const avatar = Result.mapOr('')((avatarImage: Medium): string =>
-        Option.unwrapOr('')(avatarImage.getUrl()),
-      )(avatarRes);
+      const avatar = Cat.cat(avatarRes)
+        .feed(Result.optionOk)
+        .feed(Option.andThen((avatarImage: Medium) => avatarImage.getUrl()))
+        .feed(Option.unwrapOr('')).value;
       const headerRes = await this.headerService.fetchByAccountID(id);
-      const header = Result.mapOr('')((headerImage: Medium): string =>
-        Option.unwrapOr('')(headerImage.getUrl()),
-      )(headerRes);
+      const header = Cat.cat(headerRes)
+        .feed(Result.optionOk)
+        .feed(Option.andThen((headerImage: Medium) => headerImage.getUrl()))
+        .feed(Option.unwrapOr('')).value;
       headerAvatarImages.set(id, [header, avatar]);
 
       const followCountRes = await this.fetchFollowService.fetchFollowCount(id);

--- a/pkg/accounts/adaptor/controller/account.ts
+++ b/pkg/accounts/adaptor/controller/account.ts
@@ -237,10 +237,10 @@ export class AccountController {
       account.getID(),
     );
     const avatar = Result.mapOr('')((avatarImage: Medium): string =>
-      avatarImage.getUrl(),
+      Option.unwrapOr('')(avatarImage.getUrl()),
     )(avatarRes);
     const header = Result.mapOr('')((headerImage: Medium): string =>
-      headerImage.getUrl(),
+      Option.unwrapOr('')(headerImage.getUrl()),
     )(headerRes);
     const followCountRes = await this.fetchFollowService.fetchFollowCount(
       account.getID(),
@@ -288,10 +288,10 @@ export class AccountController {
       account.getID(),
     );
     const avatar = Result.mapOr('')((avatarImage: Medium): string =>
-      avatarImage.getUrl(),
+      Option.unwrapOr('')(avatarImage.getUrl()),
     )(avatarRes);
     const header = Result.mapOr('')((headerImage: Medium): string =>
-      headerImage.getUrl(),
+      Option.unwrapOr('')(headerImage.getUrl()),
     )(headerRes);
     const followCountRes = await this.fetchFollowService.fetchFollowCount(
       account.getID(),
@@ -453,11 +453,11 @@ export class AccountController {
     for (const id of accountIDs) {
       const avatarRes = await this.avatarService.fetchByAccountID(id);
       const avatar = Result.mapOr('')((avatarImage: Medium): string =>
-        avatarImage.getUrl(),
+        Option.unwrapOr('')(avatarImage.getUrl()),
       )(avatarRes);
       const headerRes = await this.headerService.fetchByAccountID(id);
       const header = Result.mapOr('')((headerImage: Medium): string =>
-        headerImage.getUrl(),
+        Option.unwrapOr('')(headerImage.getUrl()),
       )(headerRes);
       headerAvatarImages.set(id, [header, avatar]);
 
@@ -531,11 +531,11 @@ export class AccountController {
     for (const id of accountIDs) {
       const avatarRes = await this.avatarService.fetchByAccountID(id);
       const avatar = Result.mapOr('')((avatarImage: Medium): string =>
-        avatarImage.getUrl(),
+        Option.unwrapOr('')(avatarImage.getUrl()),
       )(avatarRes);
       const headerRes = await this.headerService.fetchByAccountID(id);
       const header = Result.mapOr('')((headerImage: Medium): string =>
-        headerImage.getUrl(),
+        Option.unwrapOr('')(headerImage.getUrl()),
       )(headerRes);
       headerAvatarImages.set(id, [header, avatar]);
 

--- a/pkg/accounts/adaptor/repository/prisma/avatar.ts
+++ b/pkg/accounts/adaptor/repository/prisma/avatar.ts
@@ -1,4 +1,4 @@
-import { Ether, Result } from '@mikuroxina/mini-fn';
+import { Ether, Option, Result } from '@mikuroxina/mini-fn';
 import type { PrismaClient } from '../../../../adaptors/prisma/client.js';
 import type { prismaClient } from '../../../../adaptors/prisma.js';
 import { Medium, type MediumID } from '../../../../drive/model/medium.js';
@@ -101,8 +101,10 @@ export class PrismaAccountAvatarRepository implements AccountAvatarRepository {
       mime: data.mime,
       name: data.name,
       nsfw: data.nsfw,
-      thumbnailUrl: data.thumbnailUrl,
-      url: data.url,
+      thumbnailUrl: Option.fromPredicate((url: string) => url !== '')(
+        data.thumbnailUrl,
+      ),
+      url: Option.fromPredicate((url: string) => url !== '')(data.url),
     });
   }
 }

--- a/pkg/accounts/adaptor/repository/prisma/header.ts
+++ b/pkg/accounts/adaptor/repository/prisma/header.ts
@@ -1,4 +1,4 @@
-import { Ether, Result } from '@mikuroxina/mini-fn';
+import { Ether, Option, Result } from '@mikuroxina/mini-fn';
 import type { PrismaClient } from '../../../../adaptors/prisma/client.js';
 import type { prismaClient } from '../../../../adaptors/prisma.js';
 import { Medium, type MediumID } from '../../../../drive/model/medium.js';
@@ -101,8 +101,10 @@ export class PrismaAccountHeaderRepository implements AccountHeaderRepository {
       mime: data.mime,
       name: data.name,
       nsfw: data.nsfw,
-      thumbnailUrl: data.thumbnailUrl,
-      url: data.url,
+      thumbnailUrl: Option.fromPredicate((url: string) => url !== '')(
+        data.thumbnailUrl,
+      ),
+      url: Option.fromPredicate((url: string) => url !== '')(data.url),
     });
   }
 }

--- a/pkg/drive/adaptor/controller/drive.ts
+++ b/pkg/drive/adaptor/controller/drive.ts
@@ -1,5 +1,5 @@
 import type { z } from '@hono/zod-openapi';
-import { Result } from '@mikuroxina/mini-fn';
+import { Option, Result } from '@mikuroxina/mini-fn';
 
 import type { AccountID } from '../../../accounts/model/account.js';
 import type { FetchMediaService } from '../../service/fetch.js';
@@ -27,8 +27,8 @@ export class DriveController {
         hash: medium.getHash(),
         mime: medium.getMime(),
         nsfw: medium.isNsfw(),
-        url: medium.getUrl(),
-        thumbnail: medium.getThumbnailUrl(),
+        url: Option.unwrapOr('')(medium.getUrl()),
+        thumbnail: Option.unwrapOr('')(medium.getThumbnailUrl()),
       })),
     );
   }

--- a/pkg/drive/adaptor/repository/prisma.ts
+++ b/pkg/drive/adaptor/repository/prisma.ts
@@ -71,8 +71,10 @@ export class PrismaMediaRepository implements MediaRepository {
       hash: medium.getHash(),
       mime: medium.getMime(),
       nsfw: medium.isNsfw(),
-      url: medium.getUrl(),
-      thumbnailUrl: medium.getThumbnailUrl(),
+      // NOTE: An undetermined URL is persisted as an empty string because the
+      // column is non-nullable.
+      url: Option.unwrapOr('')(medium.getUrl()),
+      thumbnailUrl: Option.unwrapOr('')(medium.getThumbnailUrl()),
     };
   }
 
@@ -88,8 +90,11 @@ export class PrismaMediaRepository implements MediaRepository {
       hash: args.hash,
       mime: args.mime,
       nsfw: args.nsfw,
-      url: args.url,
-      thumbnailUrl: args.thumbnailUrl,
+      // NOTE: An empty string represents an undetermined URL.
+      url: Option.fromPredicate((url: string) => url !== '')(args.url),
+      thumbnailUrl: Option.fromPredicate((url: string) => url !== '')(
+        args.thumbnailUrl,
+      ),
     });
   }
 

--- a/pkg/drive/model/medium.test.ts
+++ b/pkg/drive/model/medium.test.ts
@@ -1,0 +1,60 @@
+import { Option, Result } from '@mikuroxina/mini-fn';
+import { describe, expect, it } from 'vitest';
+
+import type { AccountID } from '../../accounts/model/account.js';
+import { MediaSizeTooLargeError, MediaTypeInvalidError } from './errors.js';
+import { Medium, type MediumID } from './medium.js';
+
+const baseArgs = {
+  id: '1' as MediumID,
+  name: 'test.webp',
+  authorId: '10' as AccountID,
+  hash: 'blurhash',
+  mime: 'image/webp',
+  nsfw: false,
+  url: Option.none(),
+  thumbnailUrl: Option.none(),
+  size: 1024,
+  maxSize: 1024 * 1024,
+} as const;
+
+describe('Medium.new', () => {
+  it('creates a medium when the source is valid', () => {
+    const res = Medium.new({ ...baseArgs, sourceMime: 'image/png' });
+
+    expect(Result.isOk(res)).toBe(true);
+    expect(Result.unwrap(res).getMime()).toBe('image/webp');
+  });
+
+  it('rejects a disallowed source MIME type', () => {
+    const res = Medium.new({ ...baseArgs, sourceMime: 'image/heic' });
+
+    expect(Result.isErr(res)).toBe(true);
+    expect(res[1]).toStrictEqual(
+      new MediaTypeInvalidError('Invalid file type', { cause: null }),
+    );
+  });
+
+  it('rejects a file larger than the limit', () => {
+    const res = Medium.new({
+      ...baseArgs,
+      sourceMime: 'image/png',
+      size: baseArgs.maxSize + 1,
+    });
+
+    expect(Result.isErr(res)).toBe(true);
+    expect(res[1]).toStrictEqual(
+      new MediaSizeTooLargeError('File size is too large', { cause: null }),
+    );
+  });
+
+  it('accepts a file exactly at the size limit', () => {
+    const res = Medium.new({
+      ...baseArgs,
+      sourceMime: 'image/png',
+      size: baseArgs.maxSize,
+    });
+
+    expect(Result.isOk(res)).toBe(true);
+  });
+});

--- a/pkg/drive/model/medium.ts
+++ b/pkg/drive/model/medium.ts
@@ -1,3 +1,5 @@
+import type { Option } from '@mikuroxina/mini-fn';
+
 import type { AccountID } from '../../accounts/model/account.js';
 import type { ID } from '../../internal/id/type.js';
 
@@ -10,20 +12,22 @@ export interface CreateMediumArgs {
   hash: string;
   mime: string;
   nsfw: boolean;
-  url: string;
-  thumbnailUrl: string;
+  // NOTE: Option rather than '' so an undetermined URL cannot be confused with a
+  // real empty value, keeping the model always in a valid state.
+  url: Option.Option<string>;
+  thumbnailUrl: Option.Option<string>;
 }
 
 export class Medium {
   private constructor(arg: CreateMediumArgs) {
-    this.id = arg.id;
-    this.name = arg.name;
-    this.authorId = arg.authorId;
-    this.hash = arg.hash;
-    this.mime = arg.mime;
-    this.nsfw = arg.nsfw;
-    this.url = arg.url;
-    this.thumbnailUrl = arg.thumbnailUrl;
+    this.#id = arg.id;
+    this.#name = arg.name;
+    this.#authorId = arg.authorId;
+    this.#hash = arg.hash;
+    this.#mime = arg.mime;
+    this.#nsfw = arg.nsfw;
+    this.#url = arg.url;
+    this.#thumbnailUrl = arg.thumbnailUrl;
   }
 
   public static new(arg: CreateMediumArgs): Medium {
@@ -34,44 +38,43 @@ export class Medium {
     return new Medium(arg);
   }
 
-  private readonly id: MediumID;
-
+  readonly #id: MediumID;
   getId(): MediumID {
-    return this.id;
+    return this.#id;
   }
-  private readonly name: string;
 
+  readonly #name: string;
   getName(): string {
-    return this.name;
+    return this.#name;
   }
-  private readonly authorId: AccountID;
 
+  readonly #authorId: AccountID;
   getAuthorId(): AccountID {
-    return this.authorId;
+    return this.#authorId;
   }
-  private readonly hash: string;
 
+  readonly #hash: string;
   getHash(): string {
-    return this.hash;
+    return this.#hash;
   }
-  private readonly mime: string;
 
+  readonly #mime: string;
   getMime(): string {
-    return this.mime;
+    return this.#mime;
   }
-  private readonly nsfw: boolean;
 
+  readonly #nsfw: boolean;
   isNsfw(): boolean {
-    return this.nsfw;
+    return this.#nsfw;
   }
-  private readonly url: string;
 
-  getUrl(): string {
-    return this.url;
+  readonly #url: Option.Option<string>;
+  getUrl(): Option.Option<string> {
+    return this.#url;
   }
-  private readonly thumbnailUrl: string;
 
-  getThumbnailUrl(): string {
-    return this.thumbnailUrl;
+  readonly #thumbnailUrl: Option.Option<string>;
+  getThumbnailUrl(): Option.Option<string> {
+    return this.#thumbnailUrl;
   }
 }

--- a/pkg/drive/model/medium.ts
+++ b/pkg/drive/model/medium.ts
@@ -1,9 +1,27 @@
-import type { Option } from '@mikuroxina/mini-fn';
+import { type Option, Result } from '@mikuroxina/mini-fn';
+import * as v from 'valibot';
 
 import type { AccountID } from '../../accounts/model/account.js';
 import type { ID } from '../../internal/id/type.js';
+import { MediaSizeTooLargeError, MediaTypeInvalidError } from './errors.js';
 
 export type MediumID = ID<Medium>;
+
+const ALLOWED_MIME_TYPES = [
+  'image/apng',
+  'image/avif',
+  'image/gif',
+  'image/jpeg',
+  'image/png',
+  'image/webp',
+  'audio/wav',
+  'audio/mpeg',
+  'audio/ogg',
+  'video/webm',
+  'video/mp4',
+] as const;
+
+const sourceMimeSchema = v.picklist(ALLOWED_MIME_TYPES);
 
 export interface CreateMediumArgs {
   id: MediumID;
@@ -12,10 +30,14 @@ export interface CreateMediumArgs {
   hash: string;
   mime: string;
   nsfw: boolean;
-  // NOTE: Option rather than '' so an undetermined URL cannot be confused with a
-  // real empty value, keeping the model always in a valid state.
   url: Option.Option<string>;
   thumbnailUrl: Option.Option<string>;
+}
+
+export interface NewMediumArgs extends CreateMediumArgs {
+  sourceMime: string;
+  size: number;
+  maxSize: number;
 }
 
 export class Medium {
@@ -30,8 +52,22 @@ export class Medium {
     this.#thumbnailUrl = arg.thumbnailUrl;
   }
 
-  public static new(arg: CreateMediumArgs): Medium {
-    return new Medium(arg);
+  public static new(
+    arg: NewMediumArgs,
+  ): Result.Result<MediaSizeTooLargeError | MediaTypeInvalidError, Medium> {
+    if (!v.safeParse(sourceMimeSchema, arg.sourceMime).success) {
+      return Result.err(
+        new MediaTypeInvalidError('Invalid file type', { cause: null }),
+      );
+    }
+    // NOTE: maxSize is provided per call, so the size schema is built here.
+    const sizeSchema = v.pipe(v.number(), v.maxValue(arg.maxSize));
+    if (!v.safeParse(sizeSchema, arg.size).success) {
+      return Result.err(
+        new MediaSizeTooLargeError('File size is too large', { cause: null }),
+      );
+    }
+    return Result.ok(new Medium(arg));
   }
 
   public static reconstruct(arg: CreateMediumArgs): Medium {

--- a/pkg/drive/service/fetch.test.ts
+++ b/pkg/drive/service/fetch.test.ts
@@ -7,7 +7,7 @@ import { Medium, type MediumID } from '../model/medium.js';
 import { FetchMediaService } from './fetch.js';
 
 describe('FetchMediaService', () => {
-  const dummyMedium = Medium.new({
+  const dummyMedium = Medium.reconstruct({
     id: '1' as MediumID,
     authorId: '10' as AccountID,
     hash: 'ssjrkgnkksjn',

--- a/pkg/drive/service/fetch.test.ts
+++ b/pkg/drive/service/fetch.test.ts
@@ -1,4 +1,4 @@
-import { Result } from '@mikuroxina/mini-fn';
+import { Option, Result } from '@mikuroxina/mini-fn';
 import { describe, expect, it } from 'vitest';
 
 import type { AccountID } from '../../accounts/model/account.js';
@@ -14,8 +14,8 @@ describe('FetchMediaService', () => {
     mime: 'img/png',
     name: 'main.png',
     nsfw: false,
-    thumbnailUrl: 'https://example.com/thumbnail.png',
-    url: 'https://example.com/main.png',
+    thumbnailUrl: Option.some('https://example.com/thumbnail.png'),
+    url: Option.some('https://example.com/main.png'),
   });
   const mediaRepository = new InMemoryMediaRepository([dummyMedium]);
   const service = new FetchMediaService(mediaRepository);

--- a/pkg/drive/service/upload.ts
+++ b/pkg/drive/service/upload.ts
@@ -54,7 +54,9 @@ export class UploadMediaService {
       authorId: args.authorId,
       nsfw: args.nsfw,
       mime: 'image/webp',
-      hash: Option.isSome(processed) ? processed[1].hash : '',
+      hash: Option.unwrapOr('')(
+        Option.map((p: { hash: string }) => p.hash)(processed),
+      ),
       url: Option.none(),
       thumbnailUrl: Option.none(),
       sourceMime: mime[1],

--- a/pkg/drive/service/upload.ts
+++ b/pkg/drive/service/upload.ts
@@ -5,11 +5,7 @@ import sharp from 'sharp';
 
 import type { AccountID } from '../../accounts/model/account.js';
 import type { SnowflakeIDGenerator } from '../../internal/id/mod.js';
-import {
-  DriveInternalError,
-  MediaSizeTooLargeError,
-  MediaTypeInvalidError,
-} from '../model/errors.js';
+import { DriveInternalError, MediaTypeInvalidError } from '../model/errors.js';
 import { Medium } from '../model/medium.js';
 import type { MediaRepository } from '../model/repository.js';
 import type { Storage } from '../model/storage.js';
@@ -41,23 +37,39 @@ export class UploadMediaService {
         new MediaTypeInvalidError('Invalid file type', { cause: null }),
       );
     }
-    if (args.file.length > this.MAX_MEDIA_SIZE) {
-      return Result.err(
-        new MediaSizeTooLargeError('File size is too large', { cause: null }),
-      );
+
+    const id = this.idGenerator.generate<Medium>();
+    if (Result.isErr(id)) {
+      return id;
     }
 
+    // NOTE: Processing runs first because the hash comes from it. If it fails
+    // the empty hash is harmless: an invalid source is rejected by Medium.new,
+    // and a valid source is reported as an internal error below.
     const processed = await this.imageProcessing(args.file);
+
+    const medium = Medium.new({
+      id: id[1],
+      name: args.name,
+      authorId: args.authorId,
+      nsfw: args.nsfw,
+      mime: 'image/webp',
+      hash: Option.isSome(processed) ? processed[1].hash : '',
+      url: Option.none(),
+      thumbnailUrl: Option.none(),
+      sourceMime: mime[1],
+      size: args.file.length,
+      maxSize: this.MAX_MEDIA_SIZE,
+    });
+    if (Result.isErr(medium)) {
+      return medium;
+    }
+
+    // NOTE: The source is valid, so a failed processing is an internal error.
     if (Option.isNone(processed)) {
       return Result.err(
         new DriveInternalError('Failed to process image', { cause: null }),
       );
-    }
-
-    const id = this.idGenerator.generate<Medium>();
-
-    if (Result.isErr(id)) {
-      return id;
     }
 
     await this.storage.upload(`${id[1]}.webp`, processed[1].resized);
@@ -66,23 +78,12 @@ export class UploadMediaService {
       processed[1].thumbnail,
     );
 
-    const medium = Medium.new({
-      id: id[1],
-      name: args.name,
-      authorId: args.authorId,
-      nsfw: args.nsfw,
-      mime: 'image/webp',
-      hash: processed[1].hash,
-      url: Option.none(),
-      thumbnailUrl: Option.none(),
-    });
-
-    const res = await this.repository.create(medium);
+    const res = await this.repository.create(medium[1]);
     if (Result.isErr(res)) {
       return res;
     }
 
-    return Result.ok(medium);
+    return Result.ok(medium[1]);
   }
 
   private async detectFileType(
@@ -90,23 +91,6 @@ export class UploadMediaService {
   ): Promise<Option.Option<string>> {
     const detected = await fileTypeFromBuffer(file);
     if (!detected) {
-      return Option.none();
-    }
-
-    const allowedTypes = [
-      'image/apng',
-      'image/avif',
-      'image/gif',
-      'image/jpeg',
-      'image/png',
-      'image/webp',
-      'audio/wav',
-      'audio/mpeg',
-      'audio/ogg',
-      'video/webm',
-      'video/mp4',
-    ];
-    if (!allowedTypes.includes(detected.mime)) {
       return Option.none();
     }
     return Option.some(detected.mime);
@@ -119,20 +103,26 @@ export class UploadMediaService {
   > {
     // ToDo: separate cases when images are animated
 
-    const resized = await sharp(file).webp().toBuffer();
-    const thumbnail = await sharp(resized).resize(200, 200).toBuffer();
+    // NOTE: sharp throws on unsupported or corrupt inputs; treat that as a
+    // failed processing so the caller can decide the resulting error.
+    try {
+      const resized = await sharp(file).webp().toBuffer();
+      const thumbnail = await sharp(resized).resize(200, 200).toBuffer();
 
-    const { data, info } = await sharp(thumbnail)
-      .ensureAlpha()
-      .raw()
-      .toBuffer({ resolveWithObject: true });
-    const hash = encode(
-      new Uint8ClampedArray(data),
-      info.width,
-      info.height,
-      4,
-      4,
-    );
-    return Option.some({ resized, thumbnail, hash: hash });
+      const { data, info } = await sharp(thumbnail)
+        .ensureAlpha()
+        .raw()
+        .toBuffer({ resolveWithObject: true });
+      const hash = encode(
+        new Uint8ClampedArray(data),
+        info.width,
+        info.height,
+        4,
+        4,
+      );
+      return Option.some({ resized, thumbnail, hash: hash });
+    } catch {
+      return Option.none();
+    }
   }
 }

--- a/pkg/drive/service/upload.ts
+++ b/pkg/drive/service/upload.ts
@@ -73,8 +73,8 @@ export class UploadMediaService {
       nsfw: args.nsfw,
       mime: 'image/webp',
       hash: processed[1].hash,
-      url: '',
-      thumbnailUrl: '',
+      url: Option.none(),
+      thumbnailUrl: Option.none(),
     });
 
     const res = await this.repository.create(medium);

--- a/pkg/drive/testData/testData.ts
+++ b/pkg/drive/testData/testData.ts
@@ -1,3 +1,5 @@
+import { Option } from '@mikuroxina/mini-fn';
+
 import type { AccountID } from '../../accounts/model/account.js';
 import { Medium, type MediumID } from '../model/medium.js';
 
@@ -7,8 +9,8 @@ export const testMedium = Medium.new({
   mime: 'image/jpeg',
   authorId: '101' as AccountID,
   nsfw: false,
-  url: 'https://example.com/test.jpg',
-  thumbnailUrl: 'https://example.com/test_thumbnail.jpg',
+  url: Option.some('https://example.com/test.jpg'),
+  thumbnailUrl: Option.some('https://example.com/test_thumbnail.jpg'),
   hash: '40kdflnrh',
 });
 
@@ -18,8 +20,8 @@ export const testNSFWMedium = Medium.new({
   mime: 'image/jpeg',
   authorId: '101' as AccountID,
   nsfw: true,
-  url: 'https://example.com/test.jpg',
-  thumbnailUrl: 'https://example.com/test_thumbnail.jpg',
+  url: Option.some('https://example.com/test.jpg'),
+  thumbnailUrl: Option.some('https://example.com/test_thumbnail.jpg'),
   hash: '40kdflnrh',
 });
 
@@ -29,7 +31,7 @@ export const testOtherMedium = Medium.new({
   mime: 'image/jpeg',
   authorId: '102' as AccountID,
   nsfw: false,
-  url: 'https://example.com/test.jpg',
-  thumbnailUrl: 'https://example.com/test_thumbnail.jpg',
+  url: Option.some('https://example.com/test.jpg'),
+  thumbnailUrl: Option.some('https://example.com/test_thumbnail.jpg'),
   hash: '40kdflnrh',
 });

--- a/pkg/drive/testData/testData.ts
+++ b/pkg/drive/testData/testData.ts
@@ -3,7 +3,7 @@ import { Option } from '@mikuroxina/mini-fn';
 import type { AccountID } from '../../accounts/model/account.js';
 import { Medium, type MediumID } from '../model/medium.js';
 
-export const testMedium = Medium.new({
+export const testMedium = Medium.reconstruct({
   id: '300' as MediumID,
   name: 'test.jpg',
   mime: 'image/jpeg',
@@ -14,7 +14,7 @@ export const testMedium = Medium.new({
   hash: '40kdflnrh',
 });
 
-export const testNSFWMedium = Medium.new({
+export const testNSFWMedium = Medium.reconstruct({
   id: '301' as MediumID,
   name: 'test.jpg',
   mime: 'image/jpeg',
@@ -25,7 +25,7 @@ export const testNSFWMedium = Medium.new({
   hash: '40kdflnrh',
 });
 
-export const testOtherMedium = Medium.new({
+export const testOtherMedium = Medium.reconstruct({
   id: '303' as MediumID,
   name: 'test.jpg',
   mime: 'image/jpeg',

--- a/pkg/intermodule/account.ts
+++ b/pkg/intermodule/account.ts
@@ -125,9 +125,10 @@ export class AccountModuleFacade {
     id: AccountID,
   ): Promise<Result.Result<Error, string>> {
     const res = await this.avatarService.fetchByAccountID(id);
-    const avatar = Result.mapOr('')((avatarImage: Medium): string =>
-      Option.unwrapOr('')(avatarImage.getUrl()),
-    )(res);
+    const avatar = Cat.cat(res)
+      .feed(Result.optionOk)
+      .feed(Option.andThen((avatarImage: Medium) => avatarImage.getUrl()))
+      .feed(Option.unwrapOr('')).value;
     return Result.ok(avatar);
   }
 
@@ -135,9 +136,10 @@ export class AccountModuleFacade {
     id: AccountID,
   ): Promise<Result.Result<Error, string>> {
     const res = await this.headerService.fetchByAccountID(id);
-    const header = Result.mapOr('')((headerImage: Medium): string =>
-      Option.unwrapOr('')(headerImage.getUrl()),
-    )(res);
+    const header = Cat.cat(res)
+      .feed(Result.optionOk)
+      .feed(Option.andThen((headerImage: Medium) => headerImage.getUrl()))
+      .feed(Option.unwrapOr('')).value;
     return Result.ok(header);
   }
 

--- a/pkg/intermodule/account.ts
+++ b/pkg/intermodule/account.ts
@@ -1,4 +1,4 @@
-import { Cat, Ether, Result } from '@mikuroxina/mini-fn';
+import { Cat, Ether, Option, Result } from '@mikuroxina/mini-fn';
 import { InMemoryAccountRepository } from '../accounts/adaptor/repository/dummy/account.js';
 import { inMemoryAccountAvatarRepo } from '../accounts/adaptor/repository/dummy/avatar.js';
 import { newFollowRepo } from '../accounts/adaptor/repository/dummy/follow.js';
@@ -126,7 +126,7 @@ export class AccountModuleFacade {
   ): Promise<Result.Result<Error, string>> {
     const res = await this.avatarService.fetchByAccountID(id);
     const avatar = Result.mapOr('')((avatarImage: Medium): string =>
-      avatarImage.getUrl(),
+      Option.unwrapOr('')(avatarImage.getUrl()),
     )(res);
     return Result.ok(avatar);
   }
@@ -136,7 +136,7 @@ export class AccountModuleFacade {
   ): Promise<Result.Result<Error, string>> {
     const res = await this.headerService.fetchByAccountID(id);
     const header = Result.mapOr('')((headerImage: Medium): string =>
-      headerImage.getUrl(),
+      Option.unwrapOr('')(headerImage.getUrl()),
     )(res);
     return Result.ok(header);
   }
@@ -163,18 +163,22 @@ export class AccountModuleFacade {
     const res = new Map<AccountID, { avatarURL: string; headerURL: string }>();
 
     for (const v of avatar) {
-      res.set(v.getAuthorId(), { avatarURL: v.getUrl(), headerURL: '' });
+      res.set(v.getAuthorId(), {
+        avatarURL: Option.unwrapOr('')(v.getUrl()),
+        headerURL: '',
+      });
     }
     for (const v of header) {
+      const headerURL = Option.unwrapOr('')(v.getUrl());
       const avatarURL = res.get(v.getAuthorId())?.avatarURL;
       if (avatarURL) {
         res.set(v.getAuthorId(), {
           avatarURL,
-          headerURL: v.getUrl(),
+          headerURL,
         });
         continue;
       }
-      res.set(v.getAuthorId(), { avatarURL: '', headerURL: v.getUrl() });
+      res.set(v.getAuthorId(), { avatarURL: '', headerURL });
     }
 
     return Result.ok(res);

--- a/pkg/notes/adaptor/controller/bookmark.ts
+++ b/pkg/notes/adaptor/controller/bookmark.ts
@@ -1,5 +1,5 @@
 import type { z } from '@hono/zod-openapi';
-import { Result } from '@mikuroxina/mini-fn';
+import { Option, Result } from '@mikuroxina/mini-fn';
 
 import type { AccountID } from '../../../accounts/model/account.js';
 import type { NoteID } from '../../model/note.js';
@@ -49,11 +49,11 @@ export class BookmarkController {
           id: v.getId(),
           name: v.getName(),
           mime: v.getMime(),
-          url: v.getUrl(),
+          url: Option.unwrapOr('')(v.getUrl()),
           hash: v.getHash(),
           author_id: v.getAuthorId(),
           nsfw: v.isNsfw(),
-          thumbnail: v.getThumbnailUrl(),
+          thumbnail: Option.unwrapOr('')(v.getThumbnailUrl()),
         };
       }),
       created_at: bookmark.getCreatedAt().toUTCString(),

--- a/pkg/notes/adaptor/controller/note.ts
+++ b/pkg/notes/adaptor/controller/note.ts
@@ -61,11 +61,11 @@ export class NoteController {
           id: v.getId(),
           name: v.getName(),
           mime: v.getMime(),
-          url: v.getUrl(),
+          url: Option.unwrapOr('')(v.getUrl()),
           hash: v.getHash(),
           author_id: v.getAuthorId(),
           nsfw: v.isNsfw(),
-          thumbnail: v.getThumbnailUrl(),
+          thumbnail: Option.unwrapOr('')(v.getThumbnailUrl()),
         };
       }),
     });
@@ -125,11 +125,11 @@ export class NoteController {
           id: v.getId(),
           name: v.getName(),
           mime: v.getMime(),
-          url: v.getUrl(),
+          url: Option.unwrapOr('')(v.getUrl()),
           hash: v.getHash(),
           author_id: v.getAuthorId(),
           nsfw: v.isNsfw(),
-          thumbnail: v.getThumbnailUrl(),
+          thumbnail: Option.unwrapOr('')(v.getThumbnailUrl()),
         };
       }),
       reactions: reactions.map((v) => {
@@ -194,11 +194,11 @@ export class NoteController {
           id: v.getId(),
           name: v.getName(),
           mime: v.getMime(),
-          url: v.getUrl(),
+          url: Option.unwrapOr('')(v.getUrl()),
           hash: v.getHash(),
           author_id: v.getAuthorId(),
           nsfw: v.isNsfw(),
-          thumbnail: v.getThumbnailUrl(),
+          thumbnail: Option.unwrapOr('')(v.getThumbnailUrl()),
         };
       }),
       created_at: renote.getCreatedAt().toUTCString(),

--- a/pkg/notes/adaptor/controller/reaction.ts
+++ b/pkg/notes/adaptor/controller/reaction.ts
@@ -1,5 +1,5 @@
 import type { z } from '@hono/zod-openapi';
-import { Result } from '@mikuroxina/mini-fn';
+import { Option, Result } from '@mikuroxina/mini-fn';
 import type { AccountID } from '../../../accounts/model/account.js';
 import type { NoteID } from '../../model/note.js';
 import type { CreateReactionService } from '../../service/createReaction.js';
@@ -52,11 +52,11 @@ export class ReactionController {
         id: v.getId(),
         name: v.getName(),
         mime: v.getMime(),
-        url: v.getUrl(),
+        url: Option.unwrapOr('')(v.getUrl()),
         hash: v.getHash(),
         author_id: v.getAuthorId(),
         nsfw: v.isNsfw(),
-        thumbnail: v.getThumbnailUrl(),
+        thumbnail: Option.unwrapOr('')(v.getThumbnailUrl()),
       })),
       created_at: note.getCreatedAt().toUTCString(),
     });

--- a/pkg/notes/adaptor/repository/prisma/directNote.ts
+++ b/pkg/notes/adaptor/repository/prisma/directNote.ts
@@ -126,8 +126,10 @@ export class PrismaDirectNoteAttachmentRepository
         mime: medium.mime,
         name: medium.name,
         nsfw: medium.nsfw,
-        thumbnailUrl: medium.thumbnailUrl,
-        url: medium.url,
+        thumbnailUrl: Option.fromPredicate((url: string) => url !== '')(
+          medium.thumbnailUrl,
+        ),
+        url: Option.fromPredicate((url: string) => url !== '')(medium.url),
       });
     });
   }

--- a/pkg/notes/adaptor/repository/prisma/note.ts
+++ b/pkg/notes/adaptor/repository/prisma/note.ts
@@ -356,8 +356,10 @@ export class PrismaNoteAttachmentRepository
         mime: medium.mime,
         name: medium.name,
         nsfw: medium.nsfw,
-        thumbnailUrl: medium.thumbnailUrl,
-        url: medium.url,
+        thumbnailUrl: Option.fromPredicate((url: string) => url !== '')(
+          medium.thumbnailUrl,
+        ),
+        url: Option.fromPredicate((url: string) => url !== '')(medium.url),
       });
     });
   }

--- a/pkg/notes/service/create.test.ts
+++ b/pkg/notes/service/create.test.ts
@@ -1,4 +1,4 @@
-import { Result } from '@mikuroxina/mini-fn';
+import { Option, Result } from '@mikuroxina/mini-fn';
 import { describe, expect, it } from 'vitest';
 
 import type { AccountID } from '../../accounts/model/account.js';
@@ -20,8 +20,8 @@ const attachmentRepository = new InMemoryNoteAttachmentRepository(
       name: (i + 10).toString(),
       mime: 'image/png',
       hash: 'ewkjnfgr]g:ge+ealksmc',
-      url: '',
-      thumbnailUrl: '',
+      url: Option.none(),
+      thumbnailUrl: Option.none(),
       nsfw: false,
       authorId: '1' as AccountID,
     });

--- a/pkg/notes/service/renote.test.ts
+++ b/pkg/notes/service/renote.test.ts
@@ -39,8 +39,8 @@ const attachmentRepository = new InMemoryNoteAttachmentRepository(
       name: (i + 10).toString(),
       mime: 'image/png',
       hash: 'ewkjnfgr]g:ge+ealksmc',
-      url: '',
-      thumbnailUrl: '',
+      url: Option.none(),
+      thumbnailUrl: Option.none(),
       nsfw: false,
       authorId: '1' as AccountID,
     });

--- a/pkg/timeline/adaptor/controller/timeline.ts
+++ b/pkg/timeline/adaptor/controller/timeline.ts
@@ -240,8 +240,8 @@ export class TimelineController {
           hash: file.getHash(),
           mime: file.getMime(),
           nsfw: file.isNsfw(),
-          url: file.getUrl(),
-          thumbnail: file.getThumbnailUrl(),
+          url: Option.unwrapOr('')(file.getUrl()),
+          thumbnail: Option.unwrapOr('')(file.getThumbnailUrl()),
         })),
         author: {
           id: v.author.getID(),
@@ -322,8 +322,8 @@ export class TimelineController {
           hash: file.getHash(),
           mime: file.getMime(),
           nsfw: file.isNsfw(),
-          url: file.getUrl(),
-          thumbnail: file.getThumbnailUrl(),
+          url: Option.unwrapOr('')(file.getUrl()),
+          thumbnail: Option.unwrapOr('')(file.getThumbnailUrl()),
         })),
         author: {
           id: v.author.getID(),
@@ -390,8 +390,8 @@ export class TimelineController {
               hash: file.getHash(),
               mime: file.getMime(),
               nsfw: file.isNsfw(),
-              url: file.getUrl(),
-              thumbnail: file.getThumbnailUrl(),
+              url: Option.unwrapOr('')(file.getUrl()),
+              thumbnail: Option.unwrapOr('')(file.getThumbnailUrl()),
             };
           }),
           reactions: v.reactions.map((reaction) => {
@@ -613,8 +613,8 @@ export class TimelineController {
         hash: file.getHash(),
         mime: file.getMime(),
         nsfw: file.isNsfw(),
-        url: file.getUrl(),
-        thumbnail: file.getThumbnailUrl(),
+        url: Option.unwrapOr('')(file.getUrl()),
+        thumbnail: Option.unwrapOr('')(file.getThumbnailUrl()),
       })),
       author: {
         id: v.author.getID(),
@@ -744,8 +744,8 @@ export class TimelineController {
           hash: file.getHash(),
           mime: file.getMime(),
           nsfw: file.isNsfw(),
-          url: file.getUrl(),
-          thumbnail: file.getThumbnailUrl(),
+          url: Option.unwrapOr('')(file.getUrl()),
+          thumbnail: Option.unwrapOr('')(file.getThumbnailUrl()),
         })),
         author: {
           id: v.author.getID(),


### PR DESCRIPTION
close #1685 

## What does this PR do?
- Driveモデルにバリデーション追加
- Driveモデルのメンバ変数をハードプライベートに
- `Drive.thumbnailUrl`をOptionに

## Additional information