### PR TITLE
refactor: AccountモジュールのServiceから処理をDomain層に委譲

### DIFF
--- a/pkg/accounts/adaptor/repository/dummy/verifyToken.ts
+++ b/pkg/accounts/adaptor/repository/dummy/verifyToken.ts
@@ -4,6 +4,7 @@ import {
   type AccountVerifyTokenRepository,
   verifyTokenRepoSymbol,
 } from '../../../model/repository.js';
+import { VerifyToken } from '../../../model/verifyToken.js';
 
 export class InMemoryAccountVerifyTokenRepository
   implements AccountVerifyTokenRepository
@@ -23,15 +24,19 @@ export class InMemoryAccountVerifyTokenRepository
     return Result.ok(undefined);
   }
 
-  async findByID(
-    id: AccountID,
-  ): Promise<Option.Option<{ token: string; expire: Date }>> {
+  async findByID(id: AccountID): Promise<Option.Option<VerifyToken>> {
     const data = this.data.get(id);
     if (!data) {
       return Option.none();
     }
 
-    return Option.some(data);
+    return Option.some(
+      VerifyToken.reconstruct({
+        accountID: id,
+        token: data.token,
+        expire: data.expire,
+      }),
+    );
   }
 
   async delete(id: AccountID): Promise<Result.Result<Error, void>> {

--- a/pkg/accounts/adaptor/repository/prisma/prisma.ts
+++ b/pkg/accounts/adaptor/repository/prisma/prisma.ts
@@ -27,6 +27,7 @@ import {
   followRepoSymbol,
   verifyTokenRepoSymbol,
 } from '../../../model/repository.js';
+import { VerifyToken } from '../../../model/verifyToken.js';
 
 type AccountPrismaArgs = Awaited<
   ReturnType<typeof prismaClient.account.findUnique>
@@ -225,9 +226,7 @@ export class PrismaAccountVerifyTokenRepository
     return Result.ok(undefined);
   }
 
-  async findByID(
-    id: AccountID,
-  ): Promise<Option.Option<{ token: string; expire: Date }>> {
+  async findByID(id: AccountID): Promise<Option.Option<VerifyToken>> {
     const res = await this.prisma.accountVerifyToken.findUnique({
       where: {
         accountId: id,
@@ -237,10 +236,13 @@ export class PrismaAccountVerifyTokenRepository
     if (!res) {
       return Option.none();
     }
-    return Option.some({
-      token: res.token,
-      expire: res.expiresAt,
-    });
+    return Option.some(
+      VerifyToken.reconstruct({
+        accountID: id,
+        token: res.token,
+        expire: res.expiresAt,
+      }),
+    );
   }
 
   async delete(id: AccountID): Promise<Result.Result<Error, void>> {

--- a/pkg/accounts/model/followDomainService.ts
+++ b/pkg/accounts/model/followDomainService.ts
@@ -5,7 +5,7 @@ import type { AccountFollow } from './follow.js';
  * Returns true if `fromID` is in the followers list (i.e., fromID follows the account that owns `followers`).
  */
 export const isFollowedBy = (
-  followers: AccountFollow[],
+  followers: readonly AccountFollow[],
   fromID: AccountID,
 ): boolean => followers.some((f) => f.getFromID() === fromID);
 
@@ -13,6 +13,6 @@ export const isFollowedBy = (
  * Returns true if `targetID` is in the following list (i.e., the account that owns `following` follows targetID).
  */
 export const isFollowing = (
-  following: AccountFollow[],
+  following: readonly AccountFollow[],
   targetID: AccountID,
 ): boolean => following.some((f) => f.getTargetID() === targetID);

--- a/pkg/accounts/model/followDomainService.ts
+++ b/pkg/accounts/model/followDomainService.ts
@@ -1,0 +1,18 @@
+import type { AccountID } from './account.js';
+import type { AccountFollow } from './follow.js';
+
+/**
+ * Returns true if `fromID` is in the followers list (i.e., fromID follows the account that owns `followers`).
+ */
+export const isFollowedBy = (
+  followers: AccountFollow[],
+  fromID: AccountID,
+): boolean => followers.some((f) => f.getFromID() === fromID);
+
+/**
+ * Returns true if `targetID` is in the following list (i.e., the account that owns `following` follows targetID).
+ */
+export const isFollowing = (
+  following: AccountFollow[],
+  targetID: AccountID,
+): boolean => following.some((f) => f.getTargetID() === targetID);

--- a/pkg/accounts/model/repository.ts
+++ b/pkg/accounts/model/repository.ts
@@ -4,6 +4,7 @@ import type { Medium, MediumID } from '../../drive/model/medium.js';
 import type { Account, AccountID } from './account.js';
 import type { AccountFollow } from './follow.js';
 import type { InactiveAccount } from './inactiveAccount.js';
+import type { VerifyToken } from './verifyToken.js';
 
 export interface AccountRepository {
   create(account: Account): Promise<Result.Result<Error, void>>;
@@ -32,10 +33,7 @@ export interface AccountVerifyTokenRepository {
     token: string,
     expire: Date,
   ): Promise<Result.Result<Error, void>>;
-  // TODO(laminne): Consider create a type for token/expire
-  findByID(
-    id: AccountID,
-  ): Promise<Option.Option<{ token: string; expire: Date }>>;
+  findByID(id: AccountID): Promise<Option.Option<VerifyToken>>;
 
   /**
    * Delete a token by account ID.\

--- a/pkg/accounts/model/verifyToken.test.ts
+++ b/pkg/accounts/model/verifyToken.test.ts
@@ -1,0 +1,69 @@
+import { Result } from '@mikuroxina/mini-fn';
+import { describe, expect, it } from 'vitest';
+import type { AccountID } from './account.js';
+import { VerifyToken, VerifyTokenEmptyError } from './verifyToken.js';
+
+const accountID = '1' as AccountID;
+const future = new Date('2099-01-01T00:00:00Z');
+const past = new Date('2000-01-01T00:00:00Z');
+
+describe('VerifyToken', () => {
+  describe('new', () => {
+    it('returns VerifyToken when token is valid', () => {
+      const result = VerifyToken.new({
+        accountID,
+        token: 'abc123',
+        expire: future,
+      });
+
+      expect(Result.isOk(result)).toBe(true);
+    });
+
+    it('returns VerifyTokenEmptyError when token is empty', () => {
+      const result = VerifyToken.new({
+        accountID,
+        token: '',
+        expire: future,
+      });
+
+      expect(Result.isErr(result)).toBe(true);
+      expect(Result.unwrapErr(result)).toBeInstanceOf(VerifyTokenEmptyError);
+    });
+  });
+
+  describe('isExpired', () => {
+    it('returns false when expire is in the future', () => {
+      const token = Result.unwrap(
+        VerifyToken.new({ accountID, token: 'abc', expire: future }),
+      );
+
+      expect(token.isExpired(new Date('2024-01-01T00:00:00Z'))).toBe(false);
+    });
+
+    it('returns true when expire is in the past', () => {
+      const token = Result.unwrap(
+        VerifyToken.new({ accountID, token: 'abc', expire: past }),
+      );
+
+      expect(token.isExpired(new Date('2024-01-01T00:00:00Z'))).toBe(true);
+    });
+  });
+
+  describe('matches', () => {
+    it('returns true when token matches', () => {
+      const token = Result.unwrap(
+        VerifyToken.new({ accountID, token: 'correct', expire: future }),
+      );
+
+      expect(token.matches('correct')).toBe(true);
+    });
+
+    it('returns false when token does not match', () => {
+      const token = Result.unwrap(
+        VerifyToken.new({ accountID, token: 'correct', expire: future }),
+      );
+
+      expect(token.matches('wrong')).toBe(false);
+    });
+  });
+});

--- a/pkg/accounts/model/verifyToken.ts
+++ b/pkg/accounts/model/verifyToken.ts
@@ -1,0 +1,62 @@
+import { Result } from '@mikuroxina/mini-fn';
+
+import type { AccountID } from './account.js';
+
+export class VerifyTokenEmptyError extends Error {
+  override readonly name = 'VerifyTokenEmptyError' as const;
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.cause = options?.cause;
+  }
+}
+
+export interface VerifyTokenArgs {
+  accountID: AccountID;
+  token: string;
+  expire: Date;
+}
+
+export class VerifyToken {
+  readonly #accountID: AccountID;
+  readonly #token: string;
+  readonly #expire: Date;
+
+  private constructor(args: VerifyTokenArgs) {
+    this.#accountID = args.accountID;
+    this.#token = args.token;
+    this.#expire = args.expire;
+  }
+
+  static new(
+    args: VerifyTokenArgs,
+  ): Result.Result<VerifyTokenEmptyError, VerifyToken> {
+    if (args.token.length === 0) {
+      return Result.err(new VerifyTokenEmptyError('token must not be empty'));
+    }
+    return Result.ok(new VerifyToken(args));
+  }
+
+  static reconstruct(args: VerifyTokenArgs): VerifyToken {
+    return new VerifyToken(args);
+  }
+
+  getAccountID(): AccountID {
+    return this.#accountID;
+  }
+
+  getToken(): string {
+    return this.#token;
+  }
+
+  getExpire(): Date {
+    return this.#expire;
+  }
+
+  isExpired(now: Date): boolean {
+    return this.#expire < now;
+  }
+
+  matches(inputToken: string): boolean {
+    return this.#token === inputToken;
+  }
+}

--- a/pkg/accounts/service/relationships.ts
+++ b/pkg/accounts/service/relationships.ts
@@ -2,6 +2,7 @@ import { Ether, Option, Result } from '@mikuroxina/mini-fn';
 
 import type { AccountID } from '../model/account.js';
 import { AccountNotFoundError } from '../model/errors.js';
+import { isFollowedBy, isFollowing } from '../model/followDomainService.js';
 import {
   type AccountFollowRepository,
   type AccountRepository,
@@ -35,32 +36,24 @@ export class FetchRelationshipService {
       );
     }
 
-    // Check if target is following from (is_followed)
     const followersResult =
       await this.accountFollowRepository.fetchAllFollowers(fromAccountID);
     if (Result.isErr(followersResult)) {
       return Result.err(Result.unwrapErr(followersResult));
     }
     const followers = Result.unwrap(followersResult);
-    const isFollowed = followers.some(
-      (follow) => follow.getFromID() === targetAccountID,
-    );
 
-    // Check if from is following target (is_following)
     const followingResult =
       await this.accountFollowRepository.fetchAllFollowing(fromAccountID);
     if (Result.isErr(followingResult)) {
       return Result.err(Result.unwrapErr(followingResult));
     }
     const following = Result.unwrap(followingResult);
-    const isFollowing = following.some(
-      (follow) => follow.getTargetID() === targetAccountID,
-    );
 
     return Result.ok({
       id: targetAccountID,
-      isFollowed: isFollowed,
-      isFollowing: isFollowing,
+      isFollowed: isFollowedBy(followers, targetAccountID),
+      isFollowing: isFollowing(following, targetAccountID),
       // ToDo: implement follow request feature
       isFollowRequesting: false,
     });

--- a/pkg/accounts/service/verifyToken.ts
+++ b/pkg/accounts/service/verifyToken.ts
@@ -14,6 +14,7 @@ import {
   inactiveAccountRepoSymbol,
   verifyTokenRepoSymbol,
 } from '../model/repository.js';
+import { VerifyToken } from '../model/verifyToken.js';
 
 export class VerifyAccountTokenService {
   constructor(
@@ -43,16 +44,26 @@ export class VerifyAccountTokenService {
       );
     }
 
+    const tokenRes = VerifyToken.new({
+      accountID: account[1].getID(),
+      token: encodedToken,
+      expire: expireDate,
+    });
+    if (Result.isErr(tokenRes)) {
+      return Result.err(tokenRes[1]);
+    }
+    const token = Result.unwrap(tokenRes);
+
     const res = await this.repository.create(
-      account[1].getID(),
-      encodedToken,
-      expireDate,
+      token.getAccountID(),
+      token.getToken(),
+      token.getExpire(),
     );
     if (Result.isErr(res)) {
       return Result.err(res[1]);
     }
 
-    return Result.ok(encodedToken);
+    return Result.ok(token.getToken());
   }
 
   async verify(
@@ -74,9 +85,9 @@ export class VerifyAccountTokenService {
         new AccountNotFoundError('account not found', { cause: null }),
       );
     }
-    const tokenData = Option.unwrap(tokenRes);
+    const verifyToken = Option.unwrap(tokenRes);
 
-    if (tokenData.expire < new Date()) {
+    if (verifyToken.isExpired(new Date())) {
       return Result.err(
         new AccountMailAddressVerificationTokenInvalidError('Token expired', {
           cause: null,
@@ -84,7 +95,7 @@ export class VerifyAccountTokenService {
       );
     }
 
-    if (tokenData.token !== token) {
+    if (!verifyToken.matches(token)) {
       return Result.err(
         new AccountMailAddressVerificationTokenInvalidError('Token not match', {
           cause: null,


### PR DESCRIPTION
close #1683 

## What does this PR do?
- `VerifyToken`を値オブジェクトにしました
  - 有効期限の計算を移動させました
  - バリデーションは #1682 を実装するときにvalibotを使ったものに変更するつもりです
- フォローしているか/フォローされているか の判定をそのまま手書きしている部分があったので分離しました

## Additional information

