### PR TITLE
refactor: NoteモジュールのServiceから処理をモデル/ドメインサービスに移動

### DIFF
--- a/pkg/accounts/service/register.test.ts
+++ b/pkg/accounts/service/register.test.ts
@@ -1,5 +1,5 @@
 import { Result } from '@mikuroxina/mini-fn';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 import { notificationModule } from '../../intermodule/notification.js';
 import { MockClock, SnowflakeIDGenerator } from '../../internal/id/mod.js';
 import { Argon2idPasswordEncoder } from '../../internal/password/mod.js';
@@ -36,6 +36,8 @@ const exampleInput = {
 };
 
 describe('RegisterService', () => {
+  afterEach(() => inactiveAccountRepository.reset());
+
   it('register account', async () => {
     const res = await registerService.handle(
       exampleInput.name,
@@ -49,7 +51,6 @@ describe('RegisterService', () => {
     expect(res[1].getMail()).toBe(exampleInput.mail);
     expect(res[1].getRole()).toBe(exampleInput.role);
     expect(res[1].isActivated()).toBe(false);
-    inactiveAccountRepository.reset();
   });
 
   it('rejects passphrase shorter than requirements', async () => {
@@ -61,6 +62,5 @@ describe('RegisterService', () => {
     );
 
     expect(Result.isErr(res)).toBe(true);
-    inactiveAccountRepository.reset();
   });
 });

--- a/pkg/accounts/service/register.test.ts
+++ b/pkg/accounts/service/register.test.ts
@@ -51,4 +51,16 @@ describe('RegisterService', () => {
     expect(res[1].isActivated()).toBe(false);
     inactiveAccountRepository.reset();
   });
+
+  it('rejects passphrase shorter than requirements', async () => {
+    const res = await registerService.handle(
+      exampleInput.name,
+      exampleInput.mail,
+      'short',
+      exampleInput.role,
+    );
+
+    expect(Result.isErr(res)).toBe(true);
+    inactiveAccountRepository.reset();
+  });
 });

--- a/pkg/accounts/service/register.ts
+++ b/pkg/accounts/service/register.ts
@@ -11,7 +11,11 @@ import {
   type PasswordEncoder,
   passwordEncoderSymbol,
 } from '../../internal/password/mod.js';
-import type { Account, AccountName, AccountRole } from '../model/account.js';
+import {
+  Account,
+  type AccountName,
+  type AccountRole,
+} from '../model/account.js';
 import { InactiveAccount } from '../model/inactiveAccount.js';
 import {
   type InactiveAccountRepository,
@@ -61,6 +65,11 @@ export class RegisterService {
       return Result.err(
         new AccountAlreadyExistsError('account already exists'),
       );
+    }
+
+    const validateResult = Account.validatePassphrase(passphrase);
+    if (Result.isErr(validateResult)) {
+      return validateResult;
     }
 
     const passphraseHash =

--- a/pkg/notes/adaptor/validator/schema.ts
+++ b/pkg/notes/adaptor/validator/schema.ts
@@ -186,13 +186,12 @@ export const RenoteRequestSchema = z.object({
       'Note content (max 3000 characters/if attachment file exists, allow 0 character)',
     default: '',
   }),
-  visibility: z
-    .union([z.literal('PUBLIC'), z.literal('HOME'), z.literal('FOLLOWERS')])
-    .openapi({
-      example: 'PUBLIC',
-      description: 'Note visibility (PUBLIC/HOME/FOLLOWERS)',
-      default: 'PUBLIC',
-    }),
+  visibility: z.union([z.literal('PUBLIC'), z.literal('HOME')]).openapi({
+    example: 'PUBLIC',
+    // NOTE: A renote/quote's own visibility can only be PUBLIC or HOME (see Note.#checkRenoteVisibility)
+    description: 'Note visibility (PUBLIC/HOME)',
+    default: 'PUBLIC',
+  }),
   attachment_file_ids: z
     .array(z.string())
     .max(16)

--- a/pkg/notes/mod.ts
+++ b/pkg/notes/mod.ts
@@ -107,6 +107,7 @@ export const noteCreateServiceInstance = Ether.runEther(
     .feed(Ether.compose(noteClockEther))
     .feed(Ether.compose(noteIdGeneratorEther))
     .feed(Ether.compose(noteAttachmentRepoEther))
+    .feed(Ether.compose(accountModuleFacade))
     .feed(Ether.compose(timelineModuleFacadeEther)).value,
 );
 export const noteHandlers = new OpenAPIHono<{

--- a/pkg/notes/model/createDomainService.test.ts
+++ b/pkg/notes/model/createDomainService.test.ts
@@ -1,0 +1,32 @@
+import { Result } from '@mikuroxina/mini-fn';
+import { describe, expect, it } from 'vitest';
+
+import { checkVisibilityForSilencedActor } from './createDomainService.js';
+import { NoteAccountSilencedError } from './errors.js';
+
+describe('checkVisibilityForSilencedActor', () => {
+  it('rejects PUBLIC visibility for a silenced actor', () => {
+    const res = checkVisibilityForSilencedActor(true, 'PUBLIC');
+    expect(Result.isErr(res)).toBe(true);
+    expect(Result.unwrapErr(res)).toBeInstanceOf(NoteAccountSilencedError);
+  });
+
+  it.each([
+    'HOME',
+    'FOLLOWERS',
+    'DIRECT',
+  ] as const)('allows %s visibility for a silenced actor', (visibility) => {
+    const res = checkVisibilityForSilencedActor(true, visibility);
+    expect(Result.isOk(res)).toBe(true);
+  });
+
+  it.each([
+    'PUBLIC',
+    'HOME',
+    'FOLLOWERS',
+    'DIRECT',
+  ] as const)('allows %s visibility for a non-silenced actor', (visibility) => {
+    const res = checkVisibilityForSilencedActor(false, visibility);
+    expect(Result.isOk(res)).toBe(true);
+  });
+});

--- a/pkg/notes/model/createDomainService.ts
+++ b/pkg/notes/model/createDomainService.ts
@@ -1,0 +1,24 @@
+import { Result } from '@mikuroxina/mini-fn';
+
+import { NoteAccountSilencedError } from './errors.js';
+import type { NoteVisibility } from './note.js';
+
+/**
+ * Silenced accounts may still post notes, but not with PUBLIC visibility.
+ * Frozen/unapproved accounts are not considered here; that is handled
+ * elsewhere (authorization).
+ */
+export const checkVisibilityForSilencedActor = (
+  isSilenced: boolean,
+  visibility: NoteVisibility,
+): Result.Result<NoteAccountSilencedError, void> => {
+  if (isSilenced && visibility === 'PUBLIC') {
+    return Result.err(
+      new NoteAccountSilencedError(
+        'Silenced account cannot set note visibility to PUBLIC',
+        { cause: null },
+      ),
+    );
+  }
+  return Result.ok(undefined);
+};

--- a/pkg/notes/model/note.test.ts
+++ b/pkg/notes/model/note.test.ts
@@ -276,16 +276,6 @@ describe('Note', () => {
     });
   });
 
-  describe('checkRenoteVisibility', () => {
-    it.each(['PUBLIC', 'HOME'] as const)('allows %s', (visibility) => {
-      expect(Result.isOk(Note.checkRenoteVisibility(visibility))).toBe(true);
-    });
-
-    it.each(['FOLLOWERS', 'DIRECT'] as const)('rejects %s', (visibility) => {
-      expect(Result.isErr(Note.checkRenoteVisibility(visibility))).toBe(true);
-    });
-  });
-
   describe('canBeRenotedBy', () => {
     const author = '2' as AccountID;
 

--- a/pkg/notes/model/note.test.ts
+++ b/pkg/notes/model/note.test.ts
@@ -257,5 +257,109 @@ describe('Note', () => {
         Option.some('300' as NoteID),
       );
     });
+
+    it.each([
+      'FOLLOWERS',
+      'DIRECT',
+    ] as const)('renote/quote visibility must be PUBLIC or HOME (rejects %s)', (visibility) => {
+      const res = Note.new({
+        ...exampleInput,
+        visibility,
+        sendTo:
+          visibility === 'DIRECT'
+            ? Option.some('999' as AccountID)
+            : Option.none(),
+        originalNoteID: Option.some('100' as NoteID),
+      });
+
+      expect(Result.isErr(res)).toBe(true);
+    });
+  });
+
+  describe('checkRenoteVisibility', () => {
+    it.each(['PUBLIC', 'HOME'] as const)('allows %s', (visibility) => {
+      expect(Result.isOk(Note.checkRenoteVisibility(visibility))).toBe(true);
+    });
+
+    it.each(['FOLLOWERS', 'DIRECT'] as const)('rejects %s', (visibility) => {
+      expect(Result.isErr(Note.checkRenoteVisibility(visibility))).toBe(true);
+    });
+  });
+
+  describe('canBeRenotedBy', () => {
+    const author = '2' as AccountID;
+
+    it.each([
+      'PUBLIC',
+      'HOME',
+    ] as const)('%s note can be renoted by anyone', (visibility) => {
+      const note = Result.unwrap(Note.new({ ...exampleInput, visibility }));
+      expect(Result.isOk(note.canBeRenotedBy('999' as AccountID))).toBe(true);
+    });
+
+    it('FOLLOWERS note can be renoted by its author', () => {
+      const note = Result.unwrap(
+        Note.new({
+          ...exampleInput,
+          authorID: author,
+          visibility: 'FOLLOWERS',
+        }),
+      );
+      expect(Result.isOk(note.canBeRenotedBy(author))).toBe(true);
+    });
+
+    it('FOLLOWERS note cannot be renoted by others', () => {
+      const note = Result.unwrap(
+        Note.new({
+          ...exampleInput,
+          authorID: author,
+          visibility: 'FOLLOWERS',
+        }),
+      );
+      expect(Result.isErr(note.canBeRenotedBy('999' as AccountID))).toBe(true);
+    });
+
+    it('DIRECT note cannot be renoted', () => {
+      const note = Result.unwrap(
+        Note.new({
+          ...exampleInput,
+          authorID: author,
+          visibility: 'DIRECT',
+          sendTo: Option.some('999' as AccountID),
+        }),
+      );
+      expect(Result.isErr(note.canBeRenotedBy(author))).toBe(true);
+    });
+  });
+
+  describe('getReactionTargetNoteID', () => {
+    it('returns its own ID for an ordinary note', () => {
+      const note = Result.unwrap(Note.new(exampleInput));
+      expect(note.getReactionTargetNoteID()).toBe(note.getID());
+    });
+
+    it('returns the original note ID for a pure renote', () => {
+      const note = Result.unwrap(
+        Note.new({
+          ...exampleInput,
+          content: '',
+          contentsWarningComment: '',
+          attachmentFileID: [],
+          originalNoteID: Option.some('999' as NoteID),
+        }),
+      );
+      expect(note.getReactionTargetNoteID()).toBe('999' as NoteID);
+    });
+
+    it('returns its own ID for a quote', () => {
+      const note = Result.unwrap(
+        Note.new({
+          ...exampleInput,
+          content: 'quoting!',
+          originalNoteID: Option.some('999' as NoteID),
+        }),
+      );
+      expect(note.getReactionTargetNoteID()).toBe(note.getID());
+    });
   });
 });

--- a/pkg/notes/model/note.ts
+++ b/pkg/notes/model/note.ts
@@ -9,6 +9,7 @@ import {
   NoteDateInvalidError,
   NoteNoDestinationError,
   NoteTooManyAttachmentsError,
+  NoteVisibilityInvalidError,
 } from './errors.js';
 
 export type NoteID = ID<Note>;
@@ -33,10 +34,14 @@ export type NewNoteArgs = Omit<CreateNoteArgs, 'updatedAt' | 'deletedAt'>;
 type NoteValidationError =
   | NoteContentLengthError
   | NoteTooManyAttachmentsError
-  | NoteNoDestinationError;
+  | NoteNoDestinationError
+  | NoteVisibilityInvalidError;
 
 const segmenter = new Intl.Segmenter();
 const graphemeLength = (s: string): number => [...segmenter.segment(s)].length;
+
+const isPublicOrHome = (visibility: NoteVisibility): boolean =>
+  visibility === 'PUBLIC' || visibility === 'HOME';
 
 export const noteContentSchema = v.pipe(
   v.string(),
@@ -168,6 +173,9 @@ export class Note {
       | 'createdAt'
     >,
   ): Result.Result<NoteValidationError, Note> {
+    const visibilityErr = Note.checkRenoteVisibility(arg.visibility);
+    if (Result.isErr(visibilityErr)) return visibilityErr;
+
     const normalizedArg = {
       ...arg,
       // NOTE: Renotes do not have content or contentsWarningComment
@@ -200,6 +208,9 @@ export class Note {
       | 'createdAt'
     >,
   ): Result.Result<NoteValidationError, Note> {
+    const visibilityErr = Note.checkRenoteVisibility(arg.visibility);
+    if (Result.isErr(visibilityErr)) return visibilityErr;
+
     if (
       arg.content === '' &&
       arg.contentsWarningComment === '' &&
@@ -221,6 +232,25 @@ export class Note {
         updatedAt: Option.none(),
         deletedAt: Option.none(),
       }),
+    );
+  }
+
+  /**
+   * A renote/quote's own visibility can only be PUBLIC or HOME. Exposed so
+   * callers (e.g. RenoteService) can fail fast before doing any repository
+   * lookups, instead of only discovering this once Note.new() is called.
+   */
+  static checkRenoteVisibility(
+    visibility: NoteVisibility,
+  ): Result.Result<NoteVisibilityInvalidError, void> {
+    if (isPublicOrHome(visibility)) {
+      return Result.ok(undefined);
+    }
+    return Result.err(
+      new NoteVisibilityInvalidError(
+        'Renote/Quote visibility must be PUBLIC or HOME',
+        { cause: null },
+      ),
     );
   }
 
@@ -280,6 +310,45 @@ export class Note {
 
   getAttachmentFileID(): readonly MediumID[] {
     return this.#attachmentFileID;
+  }
+
+  /**
+   * Decides whether {@link accountID} may renote this note, based on this
+   * note's own visibility (not the visibility of the renote being created).
+   */
+  canBeRenotedBy(
+    accountID: AccountID,
+  ): Result.Result<NoteVisibilityInvalidError, void> {
+    if (isPublicOrHome(this.#visibility)) {
+      return Result.ok(undefined);
+    }
+    if (this.#visibility === 'FOLLOWERS') {
+      if (this.#authorID !== accountID) {
+        return Result.err(
+          new NoteVisibilityInvalidError(
+            'Can not renote others FOLLOWERS note',
+            { cause: null },
+          ),
+        );
+      }
+      return Result.ok(undefined);
+    }
+    return Result.err(
+      new NoteVisibilityInvalidError('Cannot renote this note', {
+        cause: null,
+      }),
+    );
+  }
+
+  /**
+   * Reactions on a pure renote (not a quote) are attributed to the
+   * original note, since the renote itself carries no content of its own.
+   */
+  getReactionTargetNoteID(): NoteID {
+    if (this.isRenote() && !this.isQuote()) {
+      return Option.unwrap(this.#originalNoteID);
+    }
+    return this.#id;
   }
 
   getCreatedAt(): Date {

--- a/pkg/notes/model/note.ts
+++ b/pkg/notes/model/note.ts
@@ -173,7 +173,7 @@ export class Note {
       | 'createdAt'
     >,
   ): Result.Result<NoteValidationError, Note> {
-    const visibilityErr = Note.checkRenoteVisibility(arg.visibility);
+    const visibilityErr = Note.#checkRenoteVisibility(arg.visibility);
     if (Result.isErr(visibilityErr)) return visibilityErr;
 
     const normalizedArg = {
@@ -208,7 +208,7 @@ export class Note {
       | 'createdAt'
     >,
   ): Result.Result<NoteValidationError, Note> {
-    const visibilityErr = Note.checkRenoteVisibility(arg.visibility);
+    const visibilityErr = Note.#checkRenoteVisibility(arg.visibility);
     if (Result.isErr(visibilityErr)) return visibilityErr;
 
     if (
@@ -236,11 +236,9 @@ export class Note {
   }
 
   /**
-   * A renote/quote's own visibility can only be PUBLIC or HOME. Exposed so
-   * callers (e.g. RenoteService) can fail fast before doing any repository
-   * lookups, instead of only discovering this once Note.new() is called.
+   * A renote/quote's own visibility can only be PUBLIC or HOME.
    */
-  static checkRenoteVisibility(
+  static #checkRenoteVisibility(
     visibility: NoteVisibility,
   ): Result.Result<NoteVisibilityInvalidError, void> {
     if (isPublicOrHome(visibility)) {

--- a/pkg/notes/model/reaction.ts
+++ b/pkg/notes/model/reaction.ts
@@ -1,4 +1,4 @@
-import { Option, Result } from '@mikuroxina/mini-fn';
+import { Result } from '@mikuroxina/mini-fn';
 import * as v from 'valibot';
 
 import type { AccountID } from '../../accounts/model/account.js';
@@ -55,11 +55,7 @@ export class Reaction {
       );
     }
 
-    // Reactions on a non-quote renote are attributed to the original note
-    const noteID =
-      arg.note.isRenote() && !arg.note.isQuote()
-        ? Option.unwrap(arg.note.getOriginalNoteID())
-        : arg.note.getID();
+    const noteID = arg.note.getReactionTargetNoteID();
 
     return Result.ok(
       new Reaction({

--- a/pkg/notes/model/renoteDomainService.test.ts
+++ b/pkg/notes/model/renoteDomainService.test.ts
@@ -1,0 +1,70 @@
+import { Option } from '@mikuroxina/mini-fn';
+import { describe, expect, it } from 'vitest';
+
+import type { AccountID } from '../../accounts/model/account.js';
+import type { MediumID } from '../../drive/model/medium.js';
+import { Note, type NoteID } from './note.js';
+import { getRenoteChainRootID } from './renoteDomainService.js';
+
+const baseNoteArgs = {
+  authorID: '101' as AccountID,
+  content: '',
+  contentsWarningComment: '',
+  createdAt: new Date('2023-09-10T00:00:00.000Z'),
+  sendTo: Option.none(),
+  attachmentFileID: [],
+  visibility: 'PUBLIC' as const,
+  updatedAt: Option.none(),
+  deletedAt: Option.none(),
+};
+
+const reconstructNote = (
+  overrides: Partial<Parameters<typeof Note.reconstruct>[0]>,
+): Note =>
+  Note.reconstruct({
+    id: '1' as NoteID,
+    ...baseNoteArgs,
+    originalNoteID: Option.none(),
+    ...overrides,
+  });
+
+describe('getRenoteChainRootID', () => {
+  it('returns None for an ordinary note', () => {
+    const note = reconstructNote({ originalNoteID: Option.none() });
+
+    expect(getRenoteChainRootID(note)).toStrictEqual(Option.none());
+  });
+
+  it('returns the original NoteID for a pure renote (follow the chain one hop)', () => {
+    const note = reconstructNote({
+      id: '2' as NoteID,
+      originalNoteID: Option.some('1' as NoteID),
+    });
+
+    expect(getRenoteChainRootID(note)).toStrictEqual(
+      Option.some('1' as NoteID),
+    );
+  });
+
+  it('returns None for a quote (does not follow the chain)', () => {
+    const quote = reconstructNote({
+      id: '20' as NoteID,
+      content: 'quoting!',
+      originalNoteID: Option.some('2' as NoteID),
+    });
+
+    expect(quote.isQuote()).toBe(true);
+    expect(getRenoteChainRootID(quote)).toStrictEqual(Option.none());
+  });
+
+  it('returns None for a quote with attachments (does not follow the chain)', () => {
+    const quote = reconstructNote({
+      id: '21' as NoteID,
+      originalNoteID: Option.some('2' as NoteID),
+      attachmentFileID: ['10' as MediumID],
+    });
+
+    expect(quote.isQuote()).toBe(true);
+    expect(getRenoteChainRootID(quote)).toStrictEqual(Option.none());
+  });
+});

--- a/pkg/notes/model/renoteDomainService.ts
+++ b/pkg/notes/model/renoteDomainService.ts
@@ -1,0 +1,25 @@
+import { Option } from '@mikuroxina/mini-fn';
+
+import type { Note, NoteID } from './note.js';
+
+/**
+ * Decides which Note a renote/quote targeting {@link note} should ultimately
+ * reference as its `originalNoteID`.
+ *
+ * - Pure renote (renote of renote, a "chain"): follow one hop to the target's
+ *   original. Renoting a renote refers to the root, not the intermediate
+ *   renote.
+ * - Quote: do NOT follow the chain. Renoting a quote refers to the quote
+ *   itself, not the root that the quote references.
+ * - Ordinary note: the note itself is the reference target.
+ *
+ * Returns `Some(nextID)` when the caller must additionally fetch `nextID`
+ * to get the resolved original (pure-renote chain), or `None` when `note`
+ * itself is the resolved target.
+ */
+export const getRenoteChainRootID = (note: Note): Option.Option<NoteID> => {
+  if (note.isRenote() && !note.isQuote()) {
+    return note.getOriginalNoteID();
+  }
+  return Option.none();
+};

--- a/pkg/notes/service/create.test.ts
+++ b/pkg/notes/service/create.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 
 import type { AccountID } from '../../accounts/model/account.js';
 import { Medium, type MediumID } from '../../drive/model/medium.js';
+import { dummyAccountModuleFacade } from '../../intermodule/account.js';
 import { dummyTimelineModuleFacade } from '../../intermodule/timeline.js';
 import { MockClock, SnowflakeIDGenerator } from '../../internal/id/mod.js';
 import { InMemoryTimelineCacheRepository } from '../../timeline/adaptor/repository/dummyCache.js';
@@ -10,6 +11,7 @@ import {
   InMemoryNoteAttachmentRepository,
   InMemoryNoteRepository,
 } from '../adaptor/repository/dummy.js';
+import { NoteAccountSilencedError } from '../model/errors.js';
 import { CreateService } from './create.js';
 
 const noteRepository = new InMemoryNoteRepository();
@@ -40,6 +42,7 @@ const createService = new CreateService({
     now: () => BigInt(Date.UTC(2023, 9, 10, 0, 0)),
   }),
   noteAttachmentRepository: attachmentRepository,
+  accountModule: dummyAccountModuleFacade,
   timelineModule: dummyTimelineModuleFacade(timelineCacheRepository),
   clock: new MockClock(new Date('2023-09-10T00:00:00Z')),
 });
@@ -49,7 +52,7 @@ describe('CreateService', () => {
     const res = await createService.handle(
       'Hello world',
       '',
-      '1' as AccountID,
+      '102' as AccountID,
       [],
       'PUBLIC',
     );
@@ -61,7 +64,7 @@ describe('CreateService', () => {
     const res = await createService.handle(
       'Hello world',
       '',
-      '1' as AccountID,
+      '102' as AccountID,
       ['10' as MediumID, '11' as MediumID],
       'PUBLIC',
     );
@@ -119,5 +122,28 @@ describe('CreateService', () => {
     );
     expect(Result.isOk(res1)).toBe(true);
     expect(Result.unwrap(res1)).toHaveLength(1);
+  });
+
+  it('if actor silenced, must not set PUBLIC', async () => {
+    const publicRes = await createService.handle(
+      'Hello world',
+      '',
+      '105' as AccountID,
+      [],
+      'PUBLIC',
+    );
+    expect(Result.isErr(publicRes)).toBe(true);
+    expect(Result.unwrapErr(publicRes)).toBeInstanceOf(
+      NoteAccountSilencedError,
+    );
+
+    const homeRes = await createService.handle(
+      'Hello world',
+      '',
+      '105' as AccountID,
+      [],
+      'HOME',
+    );
+    expect(Result.isOk(homeRes)).toBe(true);
   });
 });

--- a/pkg/notes/service/create.ts
+++ b/pkg/notes/service/create.ts
@@ -3,6 +3,10 @@ import { Ether, Option, Result } from '@mikuroxina/mini-fn';
 import type { AccountID } from '../../accounts/model/account.js';
 import type { MediumID } from '../../drive/model/medium.js';
 import {
+  type AccountModuleFacade,
+  accountModuleFacadeSymbol,
+} from '../../intermodule/account.js';
+import {
   type TimelineModuleFacade,
   timelineModuleFacadeSymbol,
 } from '../../intermodule/timeline.js';
@@ -12,6 +16,7 @@ import {
   type SnowflakeIDGenerator,
   snowflakeIDGeneratorSymbol,
 } from '../../internal/id/mod.js';
+import { checkVisibilityForSilencedActor } from '../model/createDomainService.js';
 import {
   NoteInternalError,
   NoteVisibilityInvalidError,
@@ -23,6 +28,7 @@ import {
   noteAttachmentRepoSymbol,
   noteRepoSymbol,
 } from '../model/repository.js';
+import { fetchActor } from './fetchActor.js';
 
 export class CreateService {
   async handle(
@@ -40,6 +46,20 @@ export class CreateService {
         ),
       );
     }
+
+    const actorRes = await fetchActor(this.deps.accountModule, authorID);
+    if (Result.isErr(actorRes)) {
+      return actorRes;
+    }
+    const actor = Result.unwrap(actorRes);
+    const silencedCheckRes = checkVisibilityForSilencedActor(
+      actor.isSilenced(),
+      visibility,
+    );
+    if (Result.isErr(silencedCheckRes)) {
+      return silencedCheckRes;
+    }
+
     const id = this.deps.idGenerator.generate<Note>();
     if (Result.isErr(id)) {
       return Result.err(
@@ -92,6 +112,7 @@ export class CreateService {
       noteRepository: NoteRepository;
       idGenerator: SnowflakeIDGenerator;
       noteAttachmentRepository: NoteAttachmentRepository;
+      accountModule: AccountModuleFacade;
       timelineModule: TimelineModuleFacade;
       clock: Clock;
     },
@@ -119,6 +140,7 @@ export const createService = Ether.newEther(
     noteRepository: noteRepoSymbol,
     idGenerator: snowflakeIDGeneratorSymbol,
     noteAttachmentRepository: noteAttachmentRepoSymbol,
+    accountModule: accountModuleFacadeSymbol,
     timelineModule: timelineModuleFacadeSymbol,
     clock: clockSymbol,
   },

--- a/pkg/notes/service/deleteReaction.ts
+++ b/pkg/notes/service/deleteReaction.ts
@@ -27,10 +27,7 @@ export class DeleteReactionService {
     }
 
     const unwrappedNote = Option.unwrap(note);
-    let targetNoteID = noteID;
-    if (unwrappedNote.isRenote() && !unwrappedNote.isQuote()) {
-      targetNoteID = Option.unwrap(unwrappedNote.getOriginalNoteID());
-    }
+    const targetNoteID = unwrappedNote.getReactionTargetNoteID();
 
     const reactionRes = await this.reactionRepository.findByCompositeID({
       noteID: targetNoteID,

--- a/pkg/notes/service/fetchActor.test.ts
+++ b/pkg/notes/service/fetchActor.test.ts
@@ -1,0 +1,25 @@
+import { Result } from '@mikuroxina/mini-fn';
+import { describe, expect, it } from 'vitest';
+
+import type { AccountID } from '../../accounts/model/account.js';
+import { AccountNotFoundError } from '../../accounts/model/errors.js';
+import { dummyAccountModuleFacade } from '../../intermodule/account.js';
+import { fetchActor } from './fetchActor.js';
+
+describe('fetchActor', () => {
+  it('returns the account when found', async () => {
+    const res = await fetchActor(dummyAccountModuleFacade, '101' as AccountID);
+
+    expect(Result.isOk(res)).toBe(true);
+    expect(Result.unwrap(res).getID()).toBe('101' as AccountID);
+  });
+
+  it('preserves the underlying fetch failure as cause when the account is missing', async () => {
+    const res = await fetchActor(dummyAccountModuleFacade, '999' as AccountID);
+
+    expect(Result.isErr(res)).toBe(true);
+    const err = Result.unwrapErr(res);
+    expect(err).toBeInstanceOf(AccountNotFoundError);
+    expect(err.cause).not.toBeNull();
+  });
+});

--- a/pkg/notes/service/fetchActor.ts
+++ b/pkg/notes/service/fetchActor.ts
@@ -1,0 +1,25 @@
+import { Result } from '@mikuroxina/mini-fn';
+
+import type { Account, AccountID } from '../../accounts/model/account.js';
+import { AccountNotFoundError } from '../../accounts/model/errors.js';
+import type { AccountModuleFacade } from '../../intermodule/account.js';
+
+/**
+ * Fetches the actor account, preserving the underlying fetch failure as
+ * `cause` so the real reason (e.g. a transient repository error) isn't
+ * lost behind a generic "not found".
+ */
+export const fetchActor = async (
+  accountModule: AccountModuleFacade,
+  authorID: AccountID,
+): Promise<Result.Result<AccountNotFoundError, Account>> => {
+  const res = await accountModule.fetchAccount(authorID);
+  if (Result.isErr(res)) {
+    return Result.err(
+      new AccountNotFoundError('Account not found', {
+        cause: Result.unwrapErr(res),
+      }),
+    );
+  }
+  return Result.ok(Result.unwrap(res));
+};

--- a/pkg/notes/service/renote.test.ts
+++ b/pkg/notes/service/renote.test.ts
@@ -183,9 +183,9 @@ describe('RenoteService', () => {
     expect(Result.isErr(res)).toBe(true);
   });
 
-  it('rejects invalid renote visibility before looking up the original note', async () => {
+  it('rejects invalid renote visibility', async () => {
     const res = await service.handle(
-      '999' as NoteID,
+      '2' as NoteID,
       '',
       '',
       '101' as AccountID,

--- a/pkg/notes/service/renote.test.ts
+++ b/pkg/notes/service/renote.test.ts
@@ -167,6 +167,7 @@ describe('RenoteService', () => {
     );
 
     expect(Result.isErr(res)).toBe(true);
+    expect(Result.unwrapErr(res)).toBeInstanceOf(NoteVisibilityInvalidError);
   });
 
   it('if original note not found', async () => {
@@ -180,6 +181,20 @@ describe('RenoteService', () => {
     );
 
     expect(Result.isErr(res)).toBe(true);
+  });
+
+  it('rejects invalid renote visibility before looking up the original note', async () => {
+    const res = await service.handle(
+      '999' as NoteID,
+      '',
+      '',
+      '101' as AccountID,
+      [],
+      'FOLLOWERS',
+    );
+
+    expect(Result.isErr(res)).toBe(true);
+    expect(Result.unwrapErr(res)).toBeInstanceOf(NoteVisibilityInvalidError);
   });
 
   it('should not be able to renote others FOLLOWERS notes', async () => {

--- a/pkg/notes/service/renote.ts
+++ b/pkg/notes/service/renote.ts
@@ -1,7 +1,6 @@
 import { Ether, Option, Result } from '@mikuroxina/mini-fn';
 
 import type { Account, AccountID } from '../../accounts/model/account.js';
-import { AccountNotFoundError } from '../../accounts/model/errors.js';
 import type { MediumID } from '../../drive/model/medium.js';
 import {
   type AccountModuleFacade,
@@ -17,13 +16,12 @@ import {
   type SnowflakeIDGenerator,
   snowflakeIDGeneratorSymbol,
 } from '../../internal/id/mod.js';
+import { checkVisibilityForSilencedActor } from '../model/createDomainService.js';
 import {
   NoteInsufficientPermissionError,
   NoteNotFoundError,
-  NoteVisibilityInvalidError,
 } from '../model/errors.js';
-import type { NoteID, NoteVisibility } from '../model/note.js';
-import { Note } from '../model/note.js';
+import { Note, type NoteID, type NoteVisibility } from '../model/note.js';
 import { getRenoteChainRootID } from '../model/renoteDomainService.js';
 import {
   type NoteAttachmentRepository,
@@ -31,6 +29,7 @@ import {
   noteAttachmentRepoSymbol,
   noteRepoSymbol,
 } from '../model/repository.js';
+import { fetchActor } from './fetchActor.js';
 
 export class RenoteService {
   constructor(
@@ -56,11 +55,9 @@ export class RenoteService {
     attachmentFileID: MediumID[],
     visibility: NoteVisibility,
   ): Promise<Result.Result<Error, Note>> {
-    const actorRes = await this.deps.accountModule.fetchAccount(authorID);
+    const actorRes = await fetchActor(this.deps.accountModule, authorID);
     if (Result.isErr(actorRes)) {
-      return Result.err(
-        new AccountNotFoundError('Account not found', { cause: null }),
-      );
+      return actorRes;
     }
     const actor = Result.unwrap(actorRes);
     if (!this.isAllowed(actor, visibility)) {
@@ -69,15 +66,9 @@ export class RenoteService {
       );
     }
 
-    // NOTE: PUBLIC, HOME note can be renote
-    switch (visibility) {
-      case 'PUBLIC':
-      case 'HOME':
-        break;
-      default:
-        return Result.err(
-          new NoteVisibilityInvalidError('Invalid visibility', { cause: null }),
-        );
+    const renoteVisibilityRes = Note.checkRenoteVisibility(visibility);
+    if (Result.isErr(renoteVisibilityRes)) {
+      return renoteVisibilityRes;
     }
 
     const originalNoteRes = await this.resolveOriginalNote(originalID);
@@ -86,10 +77,7 @@ export class RenoteService {
     }
     const originalNote = Result.unwrap(originalNoteRes);
 
-    const visibilityCheckRes = this.checkOriginalVisibility(
-      originalNote,
-      authorID,
-    );
+    const visibilityCheckRes = originalNote.canBeRenotedBy(authorID);
     if (Result.isErr(visibilityCheckRes)) {
       return visibilityCheckRes;
     }
@@ -171,33 +159,6 @@ export class RenoteService {
     return Result.ok(Option.unwrap(rootRes));
   }
 
-  private checkOriginalVisibility(
-    originalNote: Note,
-    authorID: AccountID,
-  ): Result.Result<Error, void> {
-    switch (originalNote.getVisibility()) {
-      case 'PUBLIC':
-      case 'HOME':
-        return Result.ok(undefined);
-      case 'FOLLOWERS':
-        if (originalNote.getAuthorID() !== authorID) {
-          return Result.err(
-            new NoteVisibilityInvalidError(
-              'Can not renote others FOLLOWERS note',
-              { cause: null },
-            ),
-          );
-        }
-        return Result.ok(undefined);
-      default:
-        return Result.err(
-          new NoteVisibilityInvalidError('Cannot renote this note', {
-            cause: null,
-          }),
-        );
-    }
-  }
-
   private isAllowed(actor: Account, visibility: NoteVisibility): boolean {
     // NOTE: an actor must be active
     if (!actor.isActivated()) {
@@ -208,13 +169,9 @@ export class RenoteService {
       return false;
     }
 
-    if (actor.isSilenced()) {
-      // NOTE: silenced account cannot set note visibility to PUBLIC
-      if (visibility === 'PUBLIC') {
-        return false;
-      }
-    }
-    return true;
+    return Result.isOk(
+      checkVisibilityForSilencedActor(actor.isSilenced(), visibility),
+    );
   }
 }
 export const renoteSymbol = Ether.newEtherSymbol<RenoteService>();

--- a/pkg/notes/service/renote.ts
+++ b/pkg/notes/service/renote.ts
@@ -24,6 +24,7 @@ import {
 } from '../model/errors.js';
 import type { NoteID, NoteVisibility } from '../model/note.js';
 import { Note } from '../model/note.js';
+import { getRenoteChainRootID } from '../model/renoteDomainService.js';
 import {
   type NoteAttachmentRepository,
   type NoteRepository,
@@ -151,14 +152,17 @@ export class RenoteService {
     }
     const note = Option.unwrap(res);
 
-    // NOTE: Only pure renotes (not quotes) are resolved to their original.
-    // Quoting a quote refers to the quote itself, not the root.
-    if (!note.isRenote() || note.isQuote()) {
+    // NOTE: For pure renotes the chain is followed one hop to the root; for
+    // quotes and ordinary notes the target note itself is the original. The
+    // decision is owned by the renote domain service.
+    const chainRootID = getRenoteChainRootID(note);
+    if (Option.isNone(chainRootID)) {
       return Result.ok(note);
     }
 
-    const rootID = Option.unwrap(note.getOriginalNoteID());
-    const rootRes = await this.deps.noteRepository.findByID(rootID);
+    const rootRes = await this.deps.noteRepository.findByID(
+      Option.unwrap(chainRootID),
+    );
     if (Option.isNone(rootRes)) {
       return Result.err(
         new NoteNotFoundError('Original note not found', { cause: null }),

--- a/pkg/notes/service/renote.ts
+++ b/pkg/notes/service/renote.ts
@@ -66,11 +66,6 @@ export class RenoteService {
       );
     }
 
-    const renoteVisibilityRes = Note.checkRenoteVisibility(visibility);
-    if (Result.isErr(renoteVisibilityRes)) {
-      return renoteVisibilityRes;
-    }
-
     const originalNoteRes = await this.resolveOriginalNote(originalID);
     if (Result.isErr(originalNoteRes)) {
       return originalNoteRes;


### PR DESCRIPTION
close #1626

## What does this PR do?
- リノートがチェーンするときの判定をNoteモデルへ移動
- 共通化できる物を共通化

## Additional information
