### PR TITLE
fix!: アカウント有効化トークンを6桁の数字に変更

### DIFF
--- a/pkg/accounts/adaptor/validator/schema.ts
+++ b/pkg/accounts/adaptor/validator/schema.ts
@@ -120,7 +120,7 @@ export const VerifyEmailRequestSchema = z
   .object({
     token: z.string().openapi({
       description: 'Verification token',
-      example: 'vq34rvyanho10q9hbc98ydbvaervna43r0varhj',
+      example: '123456',
     }),
   })
   .openapi('VerifyEmailRequest');

--- a/pkg/accounts/model/verifyToken.test.ts
+++ b/pkg/accounts/model/verifyToken.test.ts
@@ -1,49 +1,44 @@
-import { Result } from '@mikuroxina/mini-fn';
 import { describe, expect, it } from 'vitest';
 import type { AccountID } from './account.js';
-import { VerifyToken, VerifyTokenEmptyError } from './verifyToken.js';
+import { VerifyToken } from './verifyToken.js';
 
 const accountID = '1' as AccountID;
 const future = new Date('2099-01-01T00:00:00Z');
 const past = new Date('2000-01-01T00:00:00Z');
 
 describe('VerifyToken', () => {
-  describe('new', () => {
-    it('returns VerifyToken when token is valid', () => {
-      const result = VerifyToken.new({
-        accountID,
-        token: 'abc123',
-        expire: future,
-      });
+  describe('generate', () => {
+    it('generates a 6-digit numeric token', () => {
+      const token = VerifyToken.new(accountID, future);
 
-      expect(Result.isOk(result)).toBe(true);
+      expect(token.getToken()).toMatch(/^\d{6}$/);
     });
 
-    it('returns VerifyTokenEmptyError when token is empty', () => {
-      const result = VerifyToken.new({
-        accountID,
-        token: '',
-        expire: future,
-      });
+    it('sets the given accountID and expire', () => {
+      const token = VerifyToken.new(accountID, future);
 
-      expect(Result.isErr(result)).toBe(true);
-      expect(Result.unwrapErr(result)).toBeInstanceOf(VerifyTokenEmptyError);
+      expect(token.getAccountID()).toBe(accountID);
+      expect(token.getExpire()).toBe(future);
     });
   });
 
   describe('isExpired', () => {
     it('returns false when expire is in the future', () => {
-      const token = Result.unwrap(
-        VerifyToken.new({ accountID, token: 'abc', expire: future }),
-      );
+      const token = VerifyToken.reconstruct({
+        accountID,
+        token: '123456',
+        expire: future,
+      });
 
       expect(token.isExpired(new Date('2024-01-01T00:00:00Z'))).toBe(false);
     });
 
     it('returns true when expire is in the past', () => {
-      const token = Result.unwrap(
-        VerifyToken.new({ accountID, token: 'abc', expire: past }),
-      );
+      const token = VerifyToken.reconstruct({
+        accountID,
+        token: '123456',
+        expire: past,
+      });
 
       expect(token.isExpired(new Date('2024-01-01T00:00:00Z'))).toBe(true);
     });
@@ -51,19 +46,23 @@ describe('VerifyToken', () => {
 
   describe('matches', () => {
     it('returns true when token matches', () => {
-      const token = Result.unwrap(
-        VerifyToken.new({ accountID, token: 'correct', expire: future }),
-      );
+      const token = VerifyToken.reconstruct({
+        accountID,
+        token: '123456',
+        expire: future,
+      });
 
-      expect(token.matches('correct')).toBe(true);
+      expect(token.matches('123456')).toBe(true);
     });
 
     it('returns false when token does not match', () => {
-      const token = Result.unwrap(
-        VerifyToken.new({ accountID, token: 'correct', expire: future }),
-      );
+      const token = VerifyToken.reconstruct({
+        accountID,
+        token: '123456',
+        expire: future,
+      });
 
-      expect(token.matches('wrong')).toBe(false);
+      expect(token.matches('654321')).toBe(false);
     });
   });
 });

--- a/pkg/accounts/model/verifyToken.ts
+++ b/pkg/accounts/model/verifyToken.ts
@@ -1,14 +1,4 @@
-import { Result } from '@mikuroxina/mini-fn';
-
 import type { AccountID } from './account.js';
-
-export class VerifyTokenEmptyError extends Error {
-  override readonly name = 'VerifyTokenEmptyError' as const;
-  constructor(message: string, options?: { cause?: unknown }) {
-    super(message, options);
-    this.cause = options?.cause;
-  }
-}
 
 export interface VerifyTokenArgs {
   accountID: AccountID;
@@ -27,17 +17,17 @@ export class VerifyToken {
     this.#expire = args.expire;
   }
 
-  static new(
-    args: VerifyTokenArgs,
-  ): Result.Result<VerifyTokenEmptyError, VerifyToken> {
-    if (args.token.length === 0) {
-      return Result.err(new VerifyTokenEmptyError('token must not be empty'));
-    }
-    return Result.ok(new VerifyToken(args));
-  }
-
   static reconstruct(args: VerifyTokenArgs): VerifyToken {
     return new VerifyToken(args);
+  }
+
+  static new(accountID: AccountID, expire: Date): VerifyToken {
+    const randomBytes = crypto.getRandomValues(new Uint8Array(6));
+    const token = Array.from(randomBytes, (byte) =>
+      (byte % 10).toString(),
+    ).join('');
+
+    return new VerifyToken({ accountID, token, expire });
   }
 
   getAccountID(): AccountID {

--- a/pkg/accounts/service/verifyToken.test.ts
+++ b/pkg/accounts/service/verifyToken.test.ts
@@ -52,15 +52,6 @@ describe('VerifyAccountTokenService', () => {
     );
   });
 
-  it('generates a 6-digit numeric token', async () => {
-    const token = await service.generate('@johndoe@example.com');
-    if (Result.isErr(token)) {
-      throw new Error('unreachable');
-    }
-
-    expect(token[1]).toMatch(/^\d{6}$/);
-  });
-
   it('expired token', async () => {
     const dummyService = new VerifyAccountTokenService(
       repository,
@@ -80,7 +71,7 @@ describe('VerifyAccountTokenService', () => {
 
   it('invalid token', async () => {
     const token = await service.generate('@johndoe@example.com');
-    const verify = await service.verify('@johndoe@example.com', 'abcde');
+    const verify = await service.verify('@johndoe@example.com', '000000');
 
     expect(Result.isOk(token)).toBe(true);
     expect(Result.isOk(verify)).toBe(false);

--- a/pkg/accounts/service/verifyToken.test.ts
+++ b/pkg/accounts/service/verifyToken.test.ts
@@ -52,6 +52,15 @@ describe('VerifyAccountTokenService', () => {
     );
   });
 
+  it('generates a 6-digit numeric token', async () => {
+    const token = await service.generate('@johndoe@example.com');
+    if (Result.isErr(token)) {
+      throw new Error('unreachable');
+    }
+
+    expect(token[1]).toMatch(/^\d{6}$/);
+  });
+
   it('expired token', async () => {
     const dummyService = new VerifyAccountTokenService(
       repository,

--- a/pkg/accounts/service/verifyToken.ts
+++ b/pkg/accounts/service/verifyToken.ts
@@ -27,14 +27,16 @@ export class VerifyAccountTokenService {
   async generate(
     accountName: AccountName,
   ): Promise<Result.Result<Error, string>> {
-    const verifyToken = crypto.getRandomValues(new Uint8Array(32));
+    // 6 random digits (000000-999999); brute force is mitigated by rate limiting (handled separately)
+    const randomBytes = crypto.getRandomValues(new Uint8Array(6));
+    const verifyToken = Array.from(randomBytes, (byte) =>
+      (byte % 10).toString(),
+    ).join('');
 
     // expireDate: After 7 days
     const expireDate = new Date(
       Number(this.clock.now()) + 7 * 24 * 60 * 60 * 1000,
     );
-
-    const encodedToken = Buffer.from(verifyToken).toString('base64url');
 
     const account =
       await this.inactiveAccountRepository.findByName(accountName);
@@ -46,7 +48,7 @@ export class VerifyAccountTokenService {
 
     const tokenRes = VerifyToken.new({
       accountID: account[1].getID(),
-      token: encodedToken,
+      token: verifyToken,
       expire: expireDate,
     });
     if (Result.isErr(tokenRes)) {

--- a/pkg/accounts/service/verifyToken.ts
+++ b/pkg/accounts/service/verifyToken.ts
@@ -27,12 +27,6 @@ export class VerifyAccountTokenService {
   async generate(
     accountName: AccountName,
   ): Promise<Result.Result<Error, string>> {
-    // 6 random digits (000000-999999); brute force is mitigated by rate limiting (handled separately)
-    const randomBytes = crypto.getRandomValues(new Uint8Array(6));
-    const verifyToken = Array.from(randomBytes, (byte) =>
-      (byte % 10).toString(),
-    ).join('');
-
     // expireDate: After 7 days
     const expireDate = new Date(
       Number(this.clock.now()) + 7 * 24 * 60 * 60 * 1000,
@@ -46,15 +40,7 @@ export class VerifyAccountTokenService {
       );
     }
 
-    const tokenRes = VerifyToken.new({
-      accountID: account[1].getID(),
-      token: verifyToken,
-      expire: expireDate,
-    });
-    if (Result.isErr(tokenRes)) {
-      return Result.err(tokenRes[1]);
-    }
-    const token = Result.unwrap(tokenRes);
+    const token = VerifyToken.new(account[1].getID(), expireDate);
 
     const res = await this.repository.create(
       token.getAccountID(),


### PR DESCRIPTION
close #1682


## What does this PR do?
- Breaking Changes:
  - アカウントを有効化するときのトークンを32文字の文字列から6桁の数字に変更しました．

## Additional information
- トークンの生成をnewメソッドに入れてみています．DomainService化するか微妙なラインだと思っていますが，これで十分と判断しました