### PR TITLE
refactor: TimelineモジュールのServiceをCat.doTを使って書き直した

### DIFF
--- a/pkg/timeline/service/appendMember.ts
+++ b/pkg/timeline/service/appendMember.ts
@@ -50,10 +50,10 @@ export class AppendListMemberService {
           ),
       )
       .runWith(({ list }) =>
-        Promise.resolve(list.addMember(accountID)).then(Result.map(() => [])),
+        monad.map(() => [])(Promise.resolve(list.addMember(accountID))),
       )
       .runWith(({ list }) =>
-        this.listRepository.appendListMember(list).then(Result.map(() => [])),
+        monad.map(() => [])(this.listRepository.appendListMember(list)),
       )
       .finish(() => undefined);
   }

--- a/pkg/timeline/service/appendMember.ts
+++ b/pkg/timeline/service/appendMember.ts
@@ -1,5 +1,6 @@
-import { Ether, Result } from '@mikuroxina/mini-fn';
+import { Cat, Ether, Promise, Result } from '@mikuroxina/mini-fn';
 import type { AccountID } from '../../accounts/model/account.js';
+import { resultPromiseMonad } from '../../internal/monad/mod.js';
 import {
   ListNotFoundError,
   TimelineInsufficientPermissionError,
@@ -23,43 +24,42 @@ export class AppendListMemberService {
     accountID: AccountID,
     actorID: AccountID,
   ): Promise<Result.Result<Error, void>> {
-    const listRes = await this.listRepository.fetchList(listID);
-    if (Result.isErr(listRes)) {
-      return Result.err(
-        new ListNotFoundError('List not found', {
-          cause: Result.unwrapErr(listRes),
-        }),
-      );
-    }
-    const list = Result.unwrap(listRes);
+    const monad = resultPromiseMonad<Error>();
 
-    const allowedRes = this.verifyActorPermission(actorID, list);
-    if (Result.isErr(allowedRes)) {
-      return allowedRes;
-    }
-
-    const addRes = list.addMember(accountID);
-    if (Result.isErr(addRes)) {
-      return addRes;
-    }
-
-    return await this.listRepository.appendListMember(list);
+    return Cat.doT(monad)
+      .addM(
+        'list',
+        this.listRepository
+          .fetchList(listID)
+          .then(
+            Result.mapErr(
+              (e) => new ListNotFoundError('List not found', { cause: e }),
+            ),
+          ),
+      )
+      .when(
+        ({ list }) => !this.isAllowed(actorID, list),
+        () =>
+          Promise.resolve(
+            Result.err(
+              new TimelineInsufficientPermissionError(
+                "Account don't have permission to do this action",
+                { cause: null },
+              ),
+            ),
+          ),
+      )
+      .runWith(({ list }) =>
+        Promise.resolve(list.addMember(accountID)).then(Result.map(() => [])),
+      )
+      .runWith(({ list }) =>
+        this.listRepository.appendListMember(list).then(Result.map(() => [])),
+      )
+      .finish(() => undefined);
   }
 
-  private verifyActorPermission(
-    actor: AccountID,
-    list: List,
-  ): Result.Result<Error, void> {
-    if (list.getOwnerId() !== actor) {
-      return Result.err(
-        new TimelineInsufficientPermissionError(
-          "Account don't have permission to do this action",
-          { cause: null },
-        ),
-      );
-    }
-
-    return Result.ok(undefined);
+  private isAllowed(actor: AccountID, list: List): boolean {
+    return list.getOwnerId() === actor;
   }
 }
 export const appendListMemberSymbol =

--- a/pkg/timeline/service/createList.ts
+++ b/pkg/timeline/service/createList.ts
@@ -1,4 +1,4 @@
-import { Cat, Ether, Promise, Result } from '@mikuroxina/mini-fn';
+import { Cat, Ether, Promise, type Result } from '@mikuroxina/mini-fn';
 
 import type { AccountID } from '../../accounts/model/account.js';
 import {
@@ -40,7 +40,7 @@ export class CreateListService {
         ),
       )
       .runWith(({ list }) =>
-        this.listRepository.create(list).then(Result.map(() => [])),
+        monad.map(() => [])(this.listRepository.create(list)),
       )
       .finish(({ list }) => list);
   }

--- a/pkg/timeline/service/createList.ts
+++ b/pkg/timeline/service/createList.ts
@@ -1,4 +1,4 @@
-import { Ether, Result } from '@mikuroxina/mini-fn';
+import { Cat, Ether, Promise, Result } from '@mikuroxina/mini-fn';
 
 import type { AccountID } from '../../accounts/model/account.js';
 import {
@@ -7,6 +7,7 @@ import {
   type SnowflakeIDGenerator,
   snowflakeIDGeneratorSymbol,
 } from '../../internal/id/mod.js';
+import { resultPromiseMonad } from '../../internal/monad/mod.js';
 import { List } from '../model/list.js';
 import { type ListRepository, listRepoSymbol } from '../model/repository.js';
 
@@ -22,30 +23,26 @@ export class CreateListService {
     isPublic: boolean,
     ownerId: AccountID,
   ): Promise<Result.Result<Error, List>> {
-    const id = this.idGenerator.generate<List>();
-    if (Result.isErr(id)) {
-      return id;
-    }
+    const monad = resultPromiseMonad<Error>();
 
-    const now = this.clock.now();
-    const list = List.new({
-      id: Result.unwrap(id),
-      title,
-      publicity: isPublic ? 'PUBLIC' : 'PRIVATE',
-      ownerId,
-      memberIds: [] as const,
-      createdAt: new Date(Number(now)),
-    });
-    if (Result.isErr(list)) {
-      return list;
-    }
-
-    const res = await this.listRepository.create(Result.unwrap(list));
-    if (Result.isErr(res)) {
-      return res;
-    }
-
-    return Result.ok(Result.unwrap(list));
+    return Cat.doT(monad)
+      .addM('id', Promise.resolve(this.idGenerator.generate<List>()))
+      .addMWith('list', ({ id }) =>
+        Promise.resolve(
+          List.new({
+            id,
+            title,
+            publicity: isPublic ? 'PUBLIC' : 'PRIVATE',
+            ownerId,
+            memberIds: [] as const,
+            createdAt: new Date(Number(this.clock.now())),
+          }),
+        ),
+      )
+      .runWith(({ list }) =>
+        this.listRepository.create(list).then(Result.map(() => [])),
+      )
+      .finish(({ list }) => list);
   }
 }
 

--- a/pkg/timeline/service/editList.ts
+++ b/pkg/timeline/service/editList.ts
@@ -1,4 +1,4 @@
-import { Cat, Ether, Promise, Result } from '@mikuroxina/mini-fn';
+import { Cat, Ether, Promise, type Result } from '@mikuroxina/mini-fn';
 import type { ID } from '../../internal/id/type.js';
 import { resultPromiseMonad } from '../../internal/monad/mod.js';
 import type { List } from '../model/list.js';
@@ -16,10 +16,10 @@ export class EditListService {
     return Cat.doT(monad)
       .addM('list', this.listRepository.fetchList(listId))
       .runWith(({ list }) =>
-        Promise.resolve(list.setTitle(title)).then(Result.map(() => [])),
+        monad.map(() => [])(Promise.resolve(list.setTitle(title))),
       )
       .runWith(({ list }) =>
-        this.listRepository.edit(list).then(Result.map(() => [])),
+        monad.map(() => [])(this.listRepository.edit(list)),
       )
       .finish(() => undefined);
   }
@@ -32,12 +32,14 @@ export class EditListService {
     return Cat.doT(monad)
       .addM('list', this.listRepository.fetchList(listId))
       .runWith(({ list }) =>
-        Promise.resolve(
-          publicity === 'PUBLIC' ? list.toPublic() : list.toPrivate(),
-        ).then(Result.map(() => [])),
+        monad.map(() => [])(
+          Promise.resolve(
+            publicity === 'PUBLIC' ? list.toPublic() : list.toPrivate(),
+          ),
+        ),
       )
       .runWith(({ list }) =>
-        this.listRepository.edit(list).then(Result.map(() => [])),
+        monad.map(() => [])(this.listRepository.edit(list)),
       )
       .finish(() => undefined);
   }

--- a/pkg/timeline/service/editList.ts
+++ b/pkg/timeline/service/editList.ts
@@ -1,5 +1,6 @@
-import { Ether, Result } from '@mikuroxina/mini-fn';
+import { Cat, Ether, Promise, Result } from '@mikuroxina/mini-fn';
 import type { ID } from '../../internal/id/type.js';
+import { resultPromiseMonad } from '../../internal/monad/mod.js';
 import type { List } from '../model/list.js';
 import { type ListRepository, listRepoSymbol } from '../model/repository.js';
 
@@ -10,38 +11,35 @@ export class EditListService {
     listId: ID<List>,
     title: string,
   ): Promise<Result.Result<Error, void>> {
-    const res = await this.listRepository.fetchList(listId);
-    if (Result.isErr(res)) {
-      return res;
-    }
+    const monad = resultPromiseMonad<Error>();
 
-    const list = Result.unwrap(res);
-
-    const setTitleRes = list.setTitle(title);
-    if (Result.isErr(setTitleRes)) {
-      return setTitleRes;
-    }
-
-    return await this.listRepository.edit(list);
+    return Cat.doT(monad)
+      .addM('list', this.listRepository.fetchList(listId))
+      .runWith(({ list }) =>
+        Promise.resolve(list.setTitle(title)).then(Result.map(() => [])),
+      )
+      .runWith(({ list }) =>
+        this.listRepository.edit(list).then(Result.map(() => [])),
+      )
+      .finish(() => undefined);
   }
   async editPublicity(
     listId: ID<List>,
     publicity: 'PUBLIC' | 'PRIVATE',
   ): Promise<Result.Result<Error, void>> {
-    const res = await this.listRepository.fetchList(listId);
-    if (Result.isErr(res)) {
-      return res;
-    }
+    const monad = resultPromiseMonad<Error>();
 
-    const list = Result.unwrap(res);
-
-    const setPublicityRes =
-      publicity === 'PUBLIC' ? list.toPublic() : list.toPrivate();
-    if (Result.isErr(setPublicityRes)) {
-      return setPublicityRes;
-    }
-
-    return await this.listRepository.edit(list);
+    return Cat.doT(monad)
+      .addM('list', this.listRepository.fetchList(listId))
+      .runWith(({ list }) =>
+        Promise.resolve(
+          publicity === 'PUBLIC' ? list.toPublic() : list.toPrivate(),
+        ).then(Result.map(() => [])),
+      )
+      .runWith(({ list }) =>
+        this.listRepository.edit(list).then(Result.map(() => [])),
+      )
+      .finish(() => undefined);
   }
 }
 

--- a/pkg/timeline/service/fetchMember.ts
+++ b/pkg/timeline/service/fetchMember.ts
@@ -1,9 +1,10 @@
-import { Ether, Result } from '@mikuroxina/mini-fn';
+import { Cat, Ether, type Result } from '@mikuroxina/mini-fn';
 import {
   type Account,
   type AccountModuleFacade,
   accountModuleFacadeSymbol,
 } from '../../intermodule/account.js';
+import { resultPromiseMonad } from '../../internal/monad/mod.js';
 import type { ListID } from '../model/list.js';
 import { type ListRepository, listRepoSymbol } from '../model/repository.js';
 
@@ -14,13 +15,14 @@ export class FetchListMemberService {
   ) {}
 
   async handle(listID: ListID): Promise<Result.Result<Error, Account[]>> {
-    const list = await this.listRepository.fetchListMembers(listID);
-    if (Result.isErr(list)) {
-      return list;
-    }
-    const unwrappedAccountID = Result.unwrap(list);
+    const monad = resultPromiseMonad<Error>();
 
-    return await this.accountModule.fetchAccounts(unwrappedAccountID);
+    return Cat.doT(monad)
+      .addM('memberIDs', this.listRepository.fetchListMembers(listID))
+      .addMWith('accounts', ({ memberIDs }) =>
+        this.accountModule.fetchAccounts(memberIDs),
+      )
+      .finish(({ accounts }) => accounts);
   }
 }
 

--- a/pkg/timeline/service/fetchSubscribed.ts
+++ b/pkg/timeline/service/fetchSubscribed.ts
@@ -12,12 +12,8 @@ export class FetchSubscribedListService {
    * @returns ListID[] which specified account is assigned
    */
   async handle(accountID: AccountID): Promise<Result.Result<Error, ListID[]>> {
-    const lists =
-      await this.listRepository.fetchListsByMemberAccountID(accountID);
-    if (Result.isErr(lists)) {
-      return lists;
-    }
-    const unwrapped = Result.unwrap(lists);
-    return Result.ok(unwrapped.map((list) => list.getId()));
+    return this.listRepository
+      .fetchListsByMemberAccountID(accountID)
+      .then(Result.map((lists) => lists.map((list) => list.getId())));
   }
 }

--- a/pkg/timeline/service/fetchSubscribed.ts
+++ b/pkg/timeline/service/fetchSubscribed.ts
@@ -1,6 +1,7 @@
-import { Result } from '@mikuroxina/mini-fn';
+import type { Result } from '@mikuroxina/mini-fn';
 import type { AccountID } from '../../accounts/model/account.js';
-import type { ListID } from '../model/list.js';
+import { resultPromiseMonad } from '../../internal/monad/mod.js';
+import type { List, ListID } from '../model/list.js';
 import type { ListRepository } from '../model/repository.js';
 
 export class FetchSubscribedListService {
@@ -12,8 +13,9 @@ export class FetchSubscribedListService {
    * @returns ListID[] which specified account is assigned
    */
   async handle(accountID: AccountID): Promise<Result.Result<Error, ListID[]>> {
-    return this.listRepository
-      .fetchListsByMemberAccountID(accountID)
-      .then(Result.map((lists) => lists.map((list) => list.getId())));
+    const monad = resultPromiseMonad<Error>();
+    return monad.map((lists: List[]) => lists.map((list) => list.getId()))(
+      this.listRepository.fetchListsByMemberAccountID(accountID),
+    );
   }
 }

--- a/pkg/timeline/service/removeMember.ts
+++ b/pkg/timeline/service/removeMember.ts
@@ -48,9 +48,9 @@ export class RemoveListMemberService {
           ),
       )
       .runWith(() =>
-        this.listRepository
-          .removeListMember(listID, accountID)
-          .then(Result.map(() => [])),
+        monad.map(() => [])(
+          this.listRepository.removeListMember(listID, accountID),
+        ),
       )
       .finish(() => undefined);
   }

--- a/pkg/timeline/service/removeMember.ts
+++ b/pkg/timeline/service/removeMember.ts
@@ -1,5 +1,6 @@
-import { Ether, Result } from '@mikuroxina/mini-fn';
+import { Cat, Ether, Promise, Result } from '@mikuroxina/mini-fn';
 import type { AccountID } from '../../accounts/model/account.js';
+import { resultPromiseMonad } from '../../internal/monad/mod.js';
 import {
   ListNotFoundError,
   TimelineInsufficientPermissionError,
@@ -21,39 +22,41 @@ export class RemoveListMemberService {
     accountID: AccountID,
     actorID: AccountID,
   ): Promise<Result.Result<Error, void>> {
-    const listRes = await this.listRepository.fetchList(listID);
-    if (Result.isErr(listRes)) {
-      return Result.err(
-        new ListNotFoundError('List not found', {
-          cause: Result.unwrapErr(listRes),
-        }),
-      );
-    }
-    const allowedRes = this.verifyActorPermission(
-      actorID,
-      Result.unwrap(listRes),
-    );
-    if (Result.isErr(allowedRes)) {
-      return allowedRes;
-    }
+    const monad = resultPromiseMonad<Error>();
 
-    return await this.listRepository.removeListMember(listID, accountID);
+    return Cat.doT(monad)
+      .addM(
+        'list',
+        this.listRepository
+          .fetchList(listID)
+          .then(
+            Result.mapErr(
+              (e) => new ListNotFoundError('List not found', { cause: e }),
+            ),
+          ),
+      )
+      .when(
+        ({ list }) => !this.isAllowed(actorID, list),
+        () =>
+          Promise.resolve(
+            Result.err(
+              new TimelineInsufficientPermissionError(
+                "Account don't have permission to remove member",
+                { cause: null },
+              ),
+            ),
+          ),
+      )
+      .runWith(() =>
+        this.listRepository
+          .removeListMember(listID, accountID)
+          .then(Result.map(() => [])),
+      )
+      .finish(() => undefined);
   }
 
-  private verifyActorPermission(
-    actor: AccountID,
-    list: List,
-  ): Result.Result<Error, void> {
-    if (list.getOwnerId() !== actor) {
-      return Result.err(
-        new TimelineInsufficientPermissionError(
-          "Account don't have permission to remove member",
-          { cause: null },
-        ),
-      );
-    }
-
-    return Result.ok(undefined);
+  private isAllowed(actor: AccountID, list: List): boolean {
+    return list.getOwnerId() === actor;
   }
 }
 export const removeListMemberSymbol =


### PR DESCRIPTION
close #1711 

## What does this PR do?
- TimelineモジュールのServiceをCat.doTを使って書き直しました
- エラーを(明示的に返す)ステップはwhenにしてみました
  - verifyActorPermissionを分解して`isAllowed(...): boolean`とwhenにしています

## Additional information
- このあたりのメソッドの使い方についてガイドを作った方がよさそう