### PR TITLE
chore: resultPromiseMonadをmini-fnのresultMonadに置き換える

### DIFF
--- a/pkg/accounts/service/authenticate.ts
+++ b/pkg/accounts/service/authenticate.ts
@@ -1,6 +1,5 @@
 import { Cat, Ether, Option, Promise, Result } from '@mikuroxina/mini-fn';
 
-import { resultPromiseMonad } from '../../internal/monad/mod.js';
 import {
   type PasswordEncoder,
   passwordEncoderSymbol,
@@ -39,7 +38,7 @@ export class AuthenticateService {
     email: string,
     passphrase: string,
   ): Promise<Result.Result<Error, AuthenticationToken>> {
-    const monad = resultPromiseMonad<Error>();
+    const monad = Promise.resultMonad<Error>();
 
     return Cat.doT(monad)
       .addM(

--- a/pkg/accounts/service/avatar.ts
+++ b/pkg/accounts/service/avatar.ts
@@ -4,7 +4,6 @@ import {
   type MediaModuleFacade,
   mediaModuleFacadeSymbol,
 } from '../../intermodule/media.js';
-import { resultPromiseMonad } from '../../internal/monad/mod.js';
 import type { AccountID } from '../model/account.js';
 import { AccountInsufficientPermissionError } from '../model/errors.js';
 import {
@@ -40,7 +39,7 @@ export class AccountAvatarService {
     mediumID: MediumID,
     actorID: AccountID,
   ): Promise<Result.Result<Error, void>> {
-    const monad = resultPromiseMonad<Error>();
+    const monad = Promise.resultMonad<Error>();
 
     // ToDo: Check media type
     return Cat.doT(monad)
@@ -82,7 +81,7 @@ export class AccountAvatarService {
     accountID: AccountID,
     actorID: AccountID,
   ): Promise<Result.Result<Error, void>> {
-    const monad = resultPromiseMonad<Error>();
+    const monad = Promise.resultMonad<Error>();
 
     return Cat.doT(monad)
       .runWith(() =>

--- a/pkg/accounts/service/edit.ts
+++ b/pkg/accounts/service/edit.ts
@@ -1,6 +1,5 @@
 import { Cat, Ether, Option, Promise, Result } from '@mikuroxina/mini-fn';
 
-import { resultPromiseMonad } from '../../internal/monad/mod.js';
 import {
   type PasswordEncoder,
   passwordEncoderSymbol,
@@ -28,7 +27,7 @@ export class EditService {
     nickname: string,
     actorName: AccountName,
   ): Promise<Result.Result<Error, boolean>> {
-    const monad = resultPromiseMonad<Error>();
+    const monad = Promise.resultMonad<Error>();
 
     return Cat.doT(monad)
       .addM('account', this.findAccount(target, 'account not found'))
@@ -51,7 +50,7 @@ export class EditService {
     newPassphrase: string,
     actorName: AccountName,
   ): Promise<Result.Result<Error, boolean>> {
-    const monad = resultPromiseMonad<Error>();
+    const monad = Promise.resultMonad<Error>();
 
     return Cat.doT(monad)
       .addM('account', this.findAccount(target, 'account not found'))
@@ -93,7 +92,7 @@ export class EditService {
     newEmail: string,
     actorName: AccountName,
   ): Promise<Result.Result<Error, boolean>> {
-    const monad = resultPromiseMonad<Error>();
+    const monad = Promise.resultMonad<Error>();
 
     // TODO: add a process to check the email is active
     return Cat.doT(monad)
@@ -117,7 +116,7 @@ export class EditService {
     bio: string,
     actorName: AccountName,
   ): Promise<Result.Result<Error, boolean>> {
-    const monad = resultPromiseMonad<Error>();
+    const monad = Promise.resultMonad<Error>();
 
     return Cat.doT(monad)
       .addM('account', this.findAccount(target, 'account not found'))

--- a/pkg/accounts/service/fetchFollow.ts
+++ b/pkg/accounts/service/fetchFollow.ts
@@ -1,6 +1,5 @@
-import { Cat, Ether, Option, type Result } from '@mikuroxina/mini-fn';
+import { Cat, Ether, Option, Promise, type Result } from '@mikuroxina/mini-fn';
 
-import { resultPromiseMonad } from '../../internal/monad/mod.js';
 import type { AccountID, AccountName } from '../model/account.js';
 import { AccountNotFoundError } from '../model/errors.js';
 import type { AccountFollow } from '../model/follow.js';
@@ -32,7 +31,7 @@ export class FetchFollowService {
   async fetchFollowingsByName(
     name: AccountName,
   ): Promise<Result.Result<Error, AccountFollow[]>> {
-    const monad = resultPromiseMonad<Error>();
+    const monad = Promise.resultMonad<Error>();
 
     return Cat.doT(monad)
       .addM(
@@ -57,7 +56,7 @@ export class FetchFollowService {
   async fetchFollowersByName(
     name: AccountName,
   ): Promise<Result.Result<Error, AccountFollow[]>> {
-    const monad = resultPromiseMonad<Error>();
+    const monad = Promise.resultMonad<Error>();
 
     return Cat.doT(monad)
       .addM(

--- a/pkg/accounts/service/follow.ts
+++ b/pkg/accounts/service/follow.ts
@@ -1,7 +1,6 @@
-import { Cat, Ether, Option, Result } from '@mikuroxina/mini-fn';
+import { Cat, Ether, Option, Promise, Result } from '@mikuroxina/mini-fn';
 
 import { type Clock, clockSymbol } from '../../internal/id/mod.js';
-import { resultPromiseMonad } from '../../internal/monad/mod.js';
 import type { AccountName } from '../model/account.js';
 import { AccountNotFoundError } from '../model/errors.js';
 import { AccountFollow } from '../model/follow.js';
@@ -30,7 +29,7 @@ export class FollowService {
     from: AccountName,
     target: AccountName,
   ): Promise<Result.Result<Error, AccountFollow>> {
-    const monad = resultPromiseMonad<Error>();
+    const monad = Promise.resultMonad<Error>();
 
     return Cat.doT(monad)
       .addM(

--- a/pkg/accounts/service/freeze.ts
+++ b/pkg/accounts/service/freeze.ts
@@ -1,6 +1,5 @@
 import { Cat, Ether, Option, Promise, Result } from '@mikuroxina/mini-fn';
 
-import { resultPromiseMonad } from '../../internal/monad/mod.js';
 import type { Account, AccountName } from '../model/account.js';
 import { AccountNotFoundError } from '../model/errors.js';
 import {
@@ -18,7 +17,7 @@ export class FreezeService {
     targetName: AccountName,
     actorName: AccountName,
   ): Promise<Result.Result<Error, boolean>> {
-    const monad = resultPromiseMonad<Error>();
+    const monad = Promise.resultMonad<Error>();
 
     return Cat.doT(monad)
       .addM('account', this.findAccount(targetName, 'account not found'))
@@ -40,7 +39,7 @@ export class FreezeService {
     targetName: AccountName,
     actorName: AccountName,
   ): Promise<Result.Result<Error, boolean>> {
-    const monad = resultPromiseMonad<Error>();
+    const monad = Promise.resultMonad<Error>();
 
     return Cat.doT(monad)
       .addM('account', this.findAccount(targetName, 'account not found'))

--- a/pkg/accounts/service/header.ts
+++ b/pkg/accounts/service/header.ts
@@ -4,7 +4,6 @@ import {
   type MediaModuleFacade,
   mediaModuleFacadeSymbol,
 } from '../../intermodule/media.js';
-import { resultPromiseMonad } from '../../internal/monad/mod.js';
 import type { AccountID } from '../model/account.js';
 import { AccountInsufficientPermissionError } from '../model/errors.js';
 import {
@@ -40,7 +39,7 @@ export class AccountHeaderService {
     mediumID: MediumID,
     actorID: AccountID,
   ): Promise<Result.Result<Error, void>> {
-    const monad = resultPromiseMonad<Error>();
+    const monad = Promise.resultMonad<Error>();
 
     // ToDo: Check media type
     return Cat.doT(monad)
@@ -82,7 +81,7 @@ export class AccountHeaderService {
     accountID: AccountID,
     actorID: AccountID,
   ): Promise<Result.Result<Error, void>> {
-    const monad = resultPromiseMonad<Error>();
+    const monad = Promise.resultMonad<Error>();
 
     return Cat.doT(monad)
       .runWith(() =>

--- a/pkg/accounts/service/register.ts
+++ b/pkg/accounts/service/register.ts
@@ -7,7 +7,6 @@ import {
   type SnowflakeIDGenerator,
   snowflakeIDGeneratorSymbol,
 } from '../../internal/id/mod.js';
-import { resultPromiseMonad } from '../../internal/monad/mod.js';
 import {
   type PasswordEncoder,
   passwordEncoderSymbol,
@@ -62,7 +61,7 @@ export class RegisterService {
     passphrase: string,
     role: AccountRole,
   ): Promise<Result.Result<Error, InactiveAccount>> {
-    const monad = resultPromiseMonad<Error>();
+    const monad = Promise.resultMonad<Error>();
 
     // ToDo: Notification Body
     return Cat.doT(monad)

--- a/pkg/accounts/service/relationships.ts
+++ b/pkg/accounts/service/relationships.ts
@@ -1,6 +1,5 @@
-import { Cat, Ether, Option, type Result } from '@mikuroxina/mini-fn';
+import { Cat, Ether, Option, Promise, type Result } from '@mikuroxina/mini-fn';
 
-import { resultPromiseMonad } from '../../internal/monad/mod.js';
 import type { AccountID } from '../model/account.js';
 import { AccountNotFoundError } from '../model/errors.js';
 import { isFollowedBy, isFollowing } from '../model/followDomainService.js';
@@ -33,7 +32,7 @@ export class FetchRelationshipService {
     targetAccountID: AccountID,
     fromAccountID: AccountID,
   ): Promise<Result.Result<Error, AccountRelationships>> {
-    const monad = resultPromiseMonad<Error>();
+    const monad = Promise.resultMonad<Error>();
 
     return Cat.doT(monad)
       .addM(

--- a/pkg/accounts/service/resendToken.ts
+++ b/pkg/accounts/service/resendToken.ts
@@ -1,9 +1,8 @@
-import { Cat, Ether, Option, Result } from '@mikuroxina/mini-fn';
+import { Cat, Ether, Option, Promise, Result } from '@mikuroxina/mini-fn';
 import {
   type NotificationModuleFacade,
   notificationModuleFacadeSymbol,
 } from '../../intermodule/notification.js';
-import { resultPromiseMonad } from '../../internal/monad/mod.js';
 import type { AccountName } from '../model/account.js';
 import { AccountNotFoundError } from '../model/errors.js';
 import {
@@ -31,7 +30,7 @@ export class ResendVerifyTokenService {
   }
 
   async handle(name: AccountName): Promise<Option.Option<Error>> {
-    const monad = resultPromiseMonad<Error>();
+    const monad = Promise.resultMonad<Error>();
 
     const res = await Cat.doT(monad)
       .addM(

--- a/pkg/accounts/service/silence.ts
+++ b/pkg/accounts/service/silence.ts
@@ -1,6 +1,5 @@
 import { Cat, Ether, Option, Promise, Result } from '@mikuroxina/mini-fn';
 
-import { resultPromiseMonad } from '../../internal/monad/mod.js';
 import type { Account, AccountName } from '../model/account.js';
 import { AccountNotFoundError } from '../model/errors.js';
 import {
@@ -19,7 +18,7 @@ export class SilenceService {
     targetName: AccountName,
     actorName: AccountName,
   ): Promise<Result.Result<Error, boolean>> {
-    const monad = resultPromiseMonad<Error>();
+    const monad = Promise.resultMonad<Error>();
 
     return Cat.doT(monad)
       .addM('account', this.findAccount(targetName, 'account not found'))
@@ -41,7 +40,7 @@ export class SilenceService {
     targetName: AccountName,
     actorName: AccountName,
   ): Promise<Result.Result<Error, boolean>> {
-    const monad = resultPromiseMonad<Error>();
+    const monad = Promise.resultMonad<Error>();
 
     return Cat.doT(monad)
       .addM('account', this.findAccount(targetName, 'account not found'))

--- a/pkg/accounts/service/unfollow.ts
+++ b/pkg/accounts/service/unfollow.ts
@@ -1,6 +1,5 @@
-import { Cat, Ether, Option, Result } from '@mikuroxina/mini-fn';
+import { Cat, Ether, Option, Promise, Result } from '@mikuroxina/mini-fn';
 
-import { resultPromiseMonad } from '../../internal/monad/mod.js';
 import type { AccountName } from '../model/account.js';
 import { AccountNotFoundError } from '../model/errors.js';
 import {
@@ -25,7 +24,7 @@ export class UnfollowService {
     from: AccountName,
     target: AccountName,
   ): Promise<Option.Option<Error>> {
-    const monad = resultPromiseMonad<Error>();
+    const monad = Promise.resultMonad<Error>();
 
     const res = await Cat.doT(monad)
       .addM(

--- a/pkg/accounts/service/verifyToken.ts
+++ b/pkg/accounts/service/verifyToken.ts
@@ -1,7 +1,6 @@
 import { Cat, Ether, Option, Promise, Result } from '@mikuroxina/mini-fn';
 
 import { type Clock, clockSymbol } from '../../internal/id/mod.js';
-import { resultPromiseMonad } from '../../internal/monad/mod.js';
 import type { AccountName } from '../model/account.js';
 import {
   AccountMailAddressVerificationTokenInvalidError,
@@ -37,7 +36,7 @@ export class VerifyAccountTokenService {
   async generate(
     accountName: AccountName,
   ): Promise<Result.Result<Error, string>> {
-    const monad = resultPromiseMonad<Error>();
+    const monad = Promise.resultMonad<Error>();
     // expireDate: After 7 days
     const expireDate = new Date(
       Number(this.#clock.now()) + 7 * 24 * 60 * 60 * 1000,
@@ -73,7 +72,7 @@ export class VerifyAccountTokenService {
     accountName: AccountName,
     token: string,
   ): Promise<Result.Result<Error, void>> {
-    const monad = resultPromiseMonad<Error>();
+    const monad = Promise.resultMonad<Error>();
 
     return Cat.doT(monad)
       .addM(

--- a/pkg/drive/service/upload.ts
+++ b/pkg/drive/service/upload.ts
@@ -5,7 +5,6 @@ import sharp from 'sharp';
 
 import type { AccountID } from '../../accounts/model/account.js';
 import type { SnowflakeIDGenerator } from '../../internal/id/mod.js';
-import { resultPromiseMonad } from '../../internal/monad/mod.js';
 import { DriveInternalError, MediaTypeInvalidError } from '../model/errors.js';
 import { Medium } from '../model/medium.js';
 import type { MediaRepository } from '../model/repository.js';
@@ -47,7 +46,7 @@ export class UploadMediaService {
     nsfw: boolean;
     file: Uint8Array;
   }): Promise<Result.Result<Error, Medium>> {
-    const monad = resultPromiseMonad<Error>();
+    const monad = Promise.resultMonad<Error>();
     const invalidType = () =>
       new MediaTypeInvalidError('Invalid file type', { cause: null });
 

--- a/pkg/internal/monad/mod.ts
+++ b/pkg/internal/monad/mod.ts
@@ -1,4 +1,0 @@
-import { Promise, Result } from '@mikuroxina/mini-fn';
-
-export const resultPromiseMonad = <E>() =>
-  Promise.monadT(Result.traversableMonad<E>());

--- a/pkg/notes/service/create.ts
+++ b/pkg/notes/service/create.ts
@@ -16,7 +16,6 @@ import {
   type SnowflakeIDGenerator,
   snowflakeIDGeneratorSymbol,
 } from '../../internal/id/mod.js';
-import { resultPromiseMonad } from '../../internal/monad/mod.js';
 import { checkVisibilityForSilencedActor } from '../model/createDomainService.js';
 import { NoteVisibilityInvalidError } from '../model/errors.js';
 import { Note, type NoteID, type NoteVisibility } from '../model/note.js';
@@ -48,7 +47,7 @@ export class CreateService {
     const now = this.#deps.clock.now();
 
     return (
-      Cat.doT(resultPromiseMonad<Error>())
+      Cat.doT(Promise.resultMonad<Error>())
         .addM('actor', fetchActor(this.#deps.accountModule, authorID))
         .runWith(({ actor }) =>
           Promise.resolve(

--- a/pkg/notes/service/createBookmark.ts
+++ b/pkg/notes/service/createBookmark.ts
@@ -1,7 +1,6 @@
-import { Cat, Ether, Option, Result } from '@mikuroxina/mini-fn';
+import { Cat, Ether, Option, Promise, Result } from '@mikuroxina/mini-fn';
 
 import type { AccountID } from '../../accounts/model/account.js';
-import { resultPromiseMonad } from '../../internal/monad/mod.js';
 import {
   NoteBookmarkAlreadyCreatedError,
   NoteNotFoundError,
@@ -29,7 +28,7 @@ export class CreateBookmarkService {
     noteID: NoteID,
     accountID: AccountID,
   ): Promise<Result.Result<Error, Note>> {
-    return Cat.doT(resultPromiseMonad<Error>())
+    return Cat.doT(Promise.resultMonad<Error>())
       .addM(
         'result',
         this.#noteRepository

--- a/pkg/notes/service/createDirect.ts
+++ b/pkg/notes/service/createDirect.ts
@@ -13,7 +13,6 @@ import {
   type SnowflakeIDGenerator,
   snowflakeIDGeneratorSymbol,
 } from '../../internal/id/mod.js';
-import { resultPromiseMonad } from '../../internal/monad/mod.js';
 import { DirectNote, type DirectNoteID } from '../model/directNote.js';
 import {
   type DirectNoteAttachmentRepository,
@@ -49,7 +48,7 @@ export class CreateDirectNoteService {
   ): Promise<Result.Result<Error, DirectNote>> {
     const now = this.#deps.clock.now();
 
-    return Cat.doT(resultPromiseMonad<Error>())
+    return Cat.doT(Promise.resultMonad<Error>())
       .runWith(() =>
         this.#deps.accountModule
           .fetchAccount(authorID)

--- a/pkg/notes/service/createReaction.ts
+++ b/pkg/notes/service/createReaction.ts
@@ -4,7 +4,6 @@ import {
   type SnowflakeIDGenerator,
   snowflakeIDGeneratorSymbol,
 } from '../../internal/id/mod.js';
-import { resultPromiseMonad } from '../../internal/monad/mod.js';
 import { NoteNotFoundError } from '../model/errors.js';
 import type { Note, NoteID } from '../model/note.js';
 import { Reaction } from '../model/reaction.js';
@@ -38,7 +37,7 @@ export class CreateReactionService {
     const notFound = (message: string) => () =>
       new NoteNotFoundError(message, { cause: null });
 
-    return Cat.doT(resultPromiseMonad<Error>())
+    return Cat.doT(Promise.resultMonad<Error>())
       .addM(
         'note',
         this.#noteRepository

--- a/pkg/notes/service/deleteReaction.ts
+++ b/pkg/notes/service/deleteReaction.ts
@@ -1,6 +1,5 @@
-import { Cat, Ether, Option, type Result } from '@mikuroxina/mini-fn';
+import { Cat, Ether, Option, Promise, type Result } from '@mikuroxina/mini-fn';
 import type { AccountID } from '../../accounts/model/account.js';
-import { resultPromiseMonad } from '../../internal/monad/mod.js';
 import { NoteNotFoundError } from '../model/errors.js';
 import type { NoteID } from '../model/note.js';
 import {
@@ -25,7 +24,7 @@ export class DeleteReactionService {
     noteID: NoteID,
     accountID: AccountID,
   ): Promise<Result.Result<Error, void>> {
-    return Cat.doT(resultPromiseMonad<Error>())
+    return Cat.doT(Promise.resultMonad<Error>())
       .addM(
         'note',
         this.#noteRepository

--- a/pkg/notes/service/renote.ts
+++ b/pkg/notes/service/renote.ts
@@ -16,7 +16,6 @@ import {
   type SnowflakeIDGenerator,
   snowflakeIDGeneratorSymbol,
 } from '../../internal/id/mod.js';
-import { resultPromiseMonad } from '../../internal/monad/mod.js';
 import { checkVisibilityForSilencedActor } from '../model/createDomainService.js';
 import {
   NoteInsufficientPermissionError,
@@ -66,7 +65,7 @@ export class RenoteService {
   ): Promise<Result.Result<Error, Note>> {
     const now = this.#deps.clock.now();
 
-    const res = await Cat.doT(resultPromiseMonad<Error>())
+    const res = await Cat.doT(Promise.resultMonad<Error>())
       .addM('actor', fetchActor(this.#deps.accountModule, authorID))
       .runWith(({ actor }) =>
         Promise.resolve(
@@ -131,7 +130,7 @@ export class RenoteService {
     const notFound = () =>
       new NoteNotFoundError('Original note not found', { cause: null });
 
-    return Cat.doT(resultPromiseMonad<Error>())
+    return Cat.doT(Promise.resultMonad<Error>())
       .addM(
         'note',
         this.#deps.noteRepository

--- a/pkg/notification/service/create.ts
+++ b/pkg/notification/service/create.ts
@@ -6,7 +6,6 @@ import {
   type SnowflakeIDGenerator,
   snowflakeIDGeneratorSymbol,
 } from '../../internal/id/mod.js';
-import { resultPromiseMonad } from '../../internal/monad/mod.js';
 import type { NoteID } from '../../notes/model/note.js';
 import type { ReactionID } from '../../notes/model/reaction.js';
 import {
@@ -41,7 +40,7 @@ export class CreateNotificationService {
     recipientID: AccountID;
     actorID: AccountID;
   }): Promise<Result.Result<Error, void>> {
-    const monad = resultPromiseMonad<Error>();
+    const monad = Promise.resultMonad<Error>();
 
     return Cat.doT(monad)
       .addM(
@@ -70,7 +69,7 @@ export class CreateNotificationService {
     recipientID: AccountID;
     actorID: AccountID;
   }): Promise<Result.Result<Error, void>> {
-    const monad = resultPromiseMonad<Error>();
+    const monad = Promise.resultMonad<Error>();
 
     return Cat.doT(monad)
       .addM(
@@ -99,7 +98,7 @@ export class CreateNotificationService {
     recipientID: AccountID;
     actorID: AccountID;
   }): Promise<Result.Result<Error, void>> {
-    const monad = resultPromiseMonad<Error>();
+    const monad = Promise.resultMonad<Error>();
 
     return Cat.doT(monad)
       .addM(
@@ -129,7 +128,7 @@ export class CreateNotificationService {
     actorID: AccountID;
     activityID: NoteID;
   }): Promise<Result.Result<Error, void>> {
-    const monad = resultPromiseMonad<Error>();
+    const monad = Promise.resultMonad<Error>();
 
     return Cat.doT(monad)
       .addM(
@@ -161,7 +160,7 @@ export class CreateNotificationService {
     sourceID: NoteID;
     activityID: NoteID;
   }): Promise<Result.Result<Error, void>> {
-    const monad = resultPromiseMonad<Error>();
+    const monad = Promise.resultMonad<Error>();
 
     return Cat.doT(monad)
       .addM(
@@ -194,7 +193,7 @@ export class CreateNotificationService {
     sourceID: NoteID;
     activityID: ReactionID;
   }): Promise<Result.Result<Error, void>> {
-    const monad = resultPromiseMonad<Error>();
+    const monad = Promise.resultMonad<Error>();
 
     return Cat.doT(monad)
       .addM(

--- a/pkg/notification/service/fetch.ts
+++ b/pkg/notification/service/fetch.ts
@@ -1,6 +1,5 @@
 import { Cat, Ether, Promise, Result } from '@mikuroxina/mini-fn';
 import type { AccountID } from '../../accounts/model/account.js';
-import { resultPromiseMonad } from '../../internal/monad/mod.js';
 import type {
   Notification,
   NotificationID,
@@ -21,7 +20,7 @@ export class FetchNotificationService {
     id: NotificationID,
     actorID: AccountID,
   ): Promise<Result.Result<Error, Notification>> {
-    const monad = resultPromiseMonad<Error>();
+    const monad = Promise.resultMonad<Error>();
     const notAllowed = () => new Error('not allowed');
 
     return Cat.doT(monad)
@@ -37,7 +36,7 @@ export class FetchNotificationService {
     recipientID: AccountID,
     filter: NotificationFilter,
   ): Promise<Result.Result<Error, Notification[]>> {
-    const monad = resultPromiseMonad<Error>();
+    const monad = Promise.resultMonad<Error>();
     const notAllowed = () => new Error('not allowed');
 
     return Cat.doT(monad)

--- a/pkg/notification/service/markAsRead.ts
+++ b/pkg/notification/service/markAsRead.ts
@@ -1,7 +1,6 @@
 import { Cat, Ether, Promise, Result } from '@mikuroxina/mini-fn';
 import type { AccountID } from '../../accounts/model/account.js';
 import { type Clock, clockSymbol } from '../../internal/id/mod.js';
-import { resultPromiseMonad } from '../../internal/monad/mod.js';
 import type {
   Notification,
   NotificationID,
@@ -23,7 +22,7 @@ export class MarkAsReadNotificationService {
     notificationID: NotificationID,
     actorID: AccountID,
   ): Promise<Result.Result<Error, Notification>> {
-    const monad = resultPromiseMonad<Error>();
+    const monad = Promise.resultMonad<Error>();
 
     return Cat.doT(monad)
       .addM(

--- a/pkg/timeline/service/appendMember.ts
+++ b/pkg/timeline/service/appendMember.ts
@@ -1,6 +1,5 @@
 import { Cat, Ether, Promise, Result } from '@mikuroxina/mini-fn';
 import type { AccountID } from '../../accounts/model/account.js';
-import { resultPromiseMonad } from '../../internal/monad/mod.js';
 import {
   ListNotFoundError,
   TimelineInsufficientPermissionError,
@@ -27,7 +26,7 @@ export class AppendListMemberService {
     accountID: AccountID,
     actorID: AccountID,
   ): Promise<Result.Result<Error, void>> {
-    const monad = resultPromiseMonad<Error>();
+    const monad = Promise.resultMonad<Error>();
 
     return Cat.doT(monad)
       .addM(

--- a/pkg/timeline/service/createList.ts
+++ b/pkg/timeline/service/createList.ts
@@ -7,7 +7,6 @@ import {
   type SnowflakeIDGenerator,
   snowflakeIDGeneratorSymbol,
 } from '../../internal/id/mod.js';
-import { resultPromiseMonad } from '../../internal/monad/mod.js';
 import { List } from '../model/list.js';
 import { type ListRepository, listRepoSymbol } from '../model/repository.js';
 
@@ -30,7 +29,7 @@ export class CreateListService {
     isPublic: boolean,
     ownerId: AccountID,
   ): Promise<Result.Result<Error, List>> {
-    const monad = resultPromiseMonad<Error>();
+    const monad = Promise.resultMonad<Error>();
 
     return Cat.doT(monad)
       .addM('id', Promise.resolve(this.#idGenerator.generate<List>()))

--- a/pkg/timeline/service/editList.ts
+++ b/pkg/timeline/service/editList.ts
@@ -1,6 +1,5 @@
 import { Cat, Ether, Promise, type Result } from '@mikuroxina/mini-fn';
 import type { ID } from '../../internal/id/type.js';
-import { resultPromiseMonad } from '../../internal/monad/mod.js';
 import type { List } from '../model/list.js';
 import { type ListRepository, listRepoSymbol } from '../model/repository.js';
 
@@ -14,7 +13,7 @@ export class EditListService {
     listId: ID<List>,
     title: string,
   ): Promise<Result.Result<Error, void>> {
-    const monad = resultPromiseMonad<Error>();
+    const monad = Promise.resultMonad<Error>();
 
     return Cat.doT(monad)
       .addM('list', this.#listRepository.fetchList(listId))
@@ -30,7 +29,7 @@ export class EditListService {
     listId: ID<List>,
     publicity: 'PUBLIC' | 'PRIVATE',
   ): Promise<Result.Result<Error, void>> {
-    const monad = resultPromiseMonad<Error>();
+    const monad = Promise.resultMonad<Error>();
 
     return Cat.doT(monad)
       .addM('list', this.#listRepository.fetchList(listId))

--- a/pkg/timeline/service/fetchMember.ts
+++ b/pkg/timeline/service/fetchMember.ts
@@ -1,10 +1,9 @@
-import { Cat, Ether, type Result } from '@mikuroxina/mini-fn';
+import { Cat, Ether, Promise, type Result } from '@mikuroxina/mini-fn';
 import {
   type Account,
   type AccountModuleFacade,
   accountModuleFacadeSymbol,
 } from '../../intermodule/account.js';
-import { resultPromiseMonad } from '../../internal/monad/mod.js';
 import type { ListID } from '../model/list.js';
 import { type ListRepository, listRepoSymbol } from '../model/repository.js';
 
@@ -20,7 +19,7 @@ export class FetchListMemberService {
   }
 
   async handle(listID: ListID): Promise<Result.Result<Error, Account[]>> {
-    const monad = resultPromiseMonad<Error>();
+    const monad = Promise.resultMonad<Error>();
 
     return Cat.doT(monad)
       .addM('memberIDs', this.#listRepository.fetchListMembers(listID))

--- a/pkg/timeline/service/fetchSubscribed.ts
+++ b/pkg/timeline/service/fetchSubscribed.ts
@@ -1,6 +1,5 @@
-import type { Result } from '@mikuroxina/mini-fn';
+import { Promise, type Result } from '@mikuroxina/mini-fn';
 import type { AccountID } from '../../accounts/model/account.js';
-import { resultPromiseMonad } from '../../internal/monad/mod.js';
 import type { List, ListID } from '../model/list.js';
 import type { ListRepository } from '../model/repository.js';
 
@@ -16,7 +15,7 @@ export class FetchSubscribedListService {
    * @returns ListID[] which specified account is assigned
    */
   async handle(accountID: AccountID): Promise<Result.Result<Error, ListID[]>> {
-    const monad = resultPromiseMonad<Error>();
+    const monad = Promise.resultMonad<Error>();
     return monad.map((lists: List[]) => lists.map((list) => list.getId()))(
       this.#listRepository.fetchListsByMemberAccountID(accountID),
     );

--- a/pkg/timeline/service/removeMember.ts
+++ b/pkg/timeline/service/removeMember.ts
@@ -1,6 +1,5 @@
 import { Cat, Ether, Promise, Result } from '@mikuroxina/mini-fn';
 import type { AccountID } from '../../accounts/model/account.js';
-import { resultPromiseMonad } from '../../internal/monad/mod.js';
 import {
   ListNotFoundError,
   TimelineInsufficientPermissionError,
@@ -25,7 +24,7 @@ export class RemoveListMemberService {
     accountID: AccountID,
     actorID: AccountID,
   ): Promise<Result.Result<Error, void>> {
-    const monad = resultPromiseMonad<Error>();
+    const monad = Promise.resultMonad<Error>();
 
     return Cat.doT(monad)
       .addM(


### PR DESCRIPTION
close #1752

## What does this PR do?

- `resultPromiseMonad` を `mini-fn` が提供する `Promise.resultMonad` に置き換えました。
- 重複していた内部モナドモジュールを削除しました。

## Additional information

> worked with ai