### PR TITLE
chore: esbuildを廃止しNode.jsでTypeScriptを直接実行する

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -47,9 +47,6 @@ jobs:
         run: |
           pnpm test:coverage
 
-      - name: Run build
-        run: |
-          pnpm build
 
       - name: Upload coverage to codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6

--- a/.github/workflows/publish-api-schema.yaml
+++ b/.github/workflows/publish-api-schema.yaml
@@ -46,9 +46,6 @@ jobs:
       - name: Run install
         run: pnpm i --frozen-lockfile
 
-      - name: Run build
-        run: pnpm build
-
       - name: Generate API schema
         run: pnpm run build:api
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Base with pnpm
-FROM node:24-slim AS base
+FROM node:26-slim AS base
 ENV PNPM_HOME=/pnpm
 ENV PATH="${PNPM_HOME}:${PATH}"
 RUN corepack enable
@@ -12,22 +12,22 @@ FROM base AS prod-deps
 # Use --ignore-scripts to skip postinstall scripts (lefthook is a dev dependency)
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile --ignore-scripts
 
-# Stage 3: Build the application
+# Stage 3: Generate Prisma Client
 FROM base AS build
 COPY . .
 COPY --from=prod-deps /app/node_modules ./node_modules
-# Use --ignore-scripts to skip postinstall scripts
-RUN pnpm run prepare && pnpm run build
+RUN pnpm run prepare
 
 # Stage 4: Final slim image
-FROM node:24-slim
+FROM node:26-slim
 WORKDIR /app
 COPY --from=build /app/node_modules /app/node_modules
-COPY --from=build /app/build /app/build
 COPY --from=build /app/package.json /app/package.json
 COPY --from=build /app/prisma /app/prisma
+COPY --from=build /app/pkg /app/pkg
+COPY --from=build /app/main.ts /app/main.ts
 
 EXPOSE 3000
 
 ENV NODE_ENV=production
-CMD [ "node", "--enable-source-maps", "./build/main.js" ]
+CMD [ "node", "--enable-source-maps", "main.ts" ]

--- a/main.ts
+++ b/main.ts
@@ -3,13 +3,13 @@ import { Scalar } from '@scalar/hono-api-reference';
 import { Hono } from 'hono';
 import { cors } from 'hono/cors';
 
-import { accounts } from './pkg/accounts/mod.js';
-import { drive } from './pkg/drive/mod.js';
-import { noteHandlers } from './pkg/notes/mod.js';
-import { timeline } from './pkg/timeline/mod.js';
+import { accounts } from './pkg/accounts/mod.ts';
+import { drive } from './pkg/drive/mod.ts';
+import { noteHandlers } from './pkg/notes/mod.ts';
+import { timeline } from './pkg/timeline/mod.ts';
 import { Logger } from 'tslog';
-import { isProduction } from './pkg/adaptors/env.js';
-import { notification } from './pkg/notification/mod.js';
+import { isProduction } from './pkg/adaptors/env.ts';
+import { notification } from './pkg/notification/mod.ts';
 
 const coreLogger = new Logger({
   name: "Pulsate",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "description": "Easy-to-change, faster, developer friendly next generation decentralized social media.",
   "type": "module",
-  "main": "./build/main.js",
+  "main": "main.ts",
   "license": "Apache-2.0",
   "keywords": [],
   "packageManager": "pnpm@11.20.0",
@@ -15,9 +15,8 @@
     "node": "26.7.0"
   },
   "scripts": {
-    "start": "node --env-file=.env --enable-source-maps ./build/main.js",
-    "build": "esbuild main.ts --outdir=build --bundle --format=esm --platform=node --packages=external",
-    "build:api": "mkdir -p build/scripts && cp scripts/apidoc.ts build/scripts/apidoc.ts && node build/scripts/apidoc.ts",
+    "start": "node --env-file=.env --enable-source-maps main.ts",
+    "build:api": "node scripts/apidoc.ts",
     "build:prisma": "prisma generate",
     "clean": "rm -r ./build",
     "format": "biome format --write .",
@@ -63,7 +62,6 @@
     "@types/pacote": "^11.1.8",
     "@types/pg": "^8.15.6",
     "@vitest/coverage-v8": "^4.0.0",
-    "esbuild": "^0.28.0",
     "lefthook": "^2.0.0",
     "pacote": "^22.0.0",
     "typescript": "^6.0.0",

--- a/pkg/accounts/adaptor/captcha/turnstile.ts
+++ b/pkg/accounts/adaptor/captcha/turnstile.ts
@@ -1,7 +1,7 @@
 import { Ether, Option } from '@mikuroxina/mini-fn';
 
-import { type Captcha, captchaSymbol } from '../../model/captcha.js';
-import { AccountCaptchaTokenInvalidError } from '../../model/errors.js';
+import { type Captcha, captchaSymbol } from '../../model/captcha.ts';
+import { AccountCaptchaTokenInvalidError } from '../../model/errors.ts';
 
 export class TurnstileCaptchaValidator implements Captcha {
   readonly #secret: string;

--- a/pkg/accounts/adaptor/controller/account.ts
+++ b/pkg/accounts/adaptor/controller/account.ts
@@ -1,28 +1,28 @@
 import type { z } from '@hono/zod-openapi';
 import { Cat, Option, Result } from '@mikuroxina/mini-fn';
 
-import type { Medium, MediumID } from '../../../drive/model/medium.js';
-import type { AccountID, AccountName } from '../../model/account.js';
-import type { AccountFollow } from '../../model/follow.js';
-import type { AccountFollowCount } from '../../model/repository.js';
-import type { AuthenticateService } from '../../service/authenticate.js';
+import type { Medium, MediumID } from '../../../drive/model/medium.ts';
+import type { AccountID, AccountName } from '../../model/account.ts';
+import type { AccountFollow } from '../../model/follow.ts';
+import type { AccountFollowCount } from '../../model/repository.ts';
+import type { AuthenticateService } from '../../service/authenticate.ts';
 import type {
   AuthenticationToken,
   AuthenticationTokenService,
-} from '../../service/authenticationTokenService.js';
-import type { AccountAvatarService } from '../../service/avatar.js';
-import type { EditService } from '../../service/edit.js';
-import type { FetchService } from '../../service/fetch.js';
-import type { FetchFollowService } from '../../service/fetchFollow.js';
-import type { FollowService } from '../../service/follow.js';
-import type { FreezeService } from '../../service/freeze.js';
-import type { AccountHeaderService } from '../../service/header.js';
-import type { RegisterService } from '../../service/register.js';
-import type { FetchRelationshipService } from '../../service/relationships.js';
-import type { ResendVerifyTokenService } from '../../service/resendToken.js';
-import type { SilenceService } from '../../service/silence.js';
-import type { UnfollowService } from '../../service/unfollow.js';
-import type { VerifyAccountTokenService } from '../../service/verifyToken.js';
+} from '../../service/authenticationTokenService.ts';
+import type { AccountAvatarService } from '../../service/avatar.ts';
+import type { EditService } from '../../service/edit.ts';
+import type { FetchService } from '../../service/fetch.ts';
+import type { FetchFollowService } from '../../service/fetchFollow.ts';
+import type { FollowService } from '../../service/follow.ts';
+import type { FreezeService } from '../../service/freeze.ts';
+import type { AccountHeaderService } from '../../service/header.ts';
+import type { RegisterService } from '../../service/register.ts';
+import type { FetchRelationshipService } from '../../service/relationships.ts';
+import type { ResendVerifyTokenService } from '../../service/resendToken.ts';
+import type { SilenceService } from '../../service/silence.ts';
+import type { UnfollowService } from '../../service/unfollow.ts';
+import type { VerifyAccountTokenService } from '../../service/verifyToken.ts';
 import type {
   CreateAccountResponseSchema,
   GetAccountFollowerSchema,
@@ -32,7 +32,7 @@ import type {
   LoginResponseSchema,
   RefreshResponseSchema,
   UpdateAccountResponseSchema,
-} from '../validator/schema.js';
+} from '../validator/schema.ts';
 
 export class AccountController {
   readonly #registerService: RegisterService;

--- a/pkg/accounts/adaptor/middileware/captcha.ts
+++ b/pkg/accounts/adaptor/middileware/captcha.ts
@@ -1,7 +1,7 @@
 import { Ether, Option } from '@mikuroxina/mini-fn';
 import { createMiddleware } from 'hono/factory';
 
-import { type Captcha, captchaSymbol } from '../../model/captcha.js';
+import { type Captcha, captchaSymbol } from '../../model/captcha.ts';
 
 export class CaptchaMiddleware {
   readonly #captcha: Captcha;

--- a/pkg/accounts/adaptor/repository/dummy/account.test.ts
+++ b/pkg/accounts/adaptor/repository/dummy/account.test.ts
@@ -1,8 +1,8 @@
 import { Result } from '@mikuroxina/mini-fn';
 import { describe, expect, it } from 'vitest';
-import { Account, type AccountID } from '../../../model/account.js';
+import { Account, type AccountID } from '../../../model/account.ts';
 
-import { InMemoryAccountRepository } from './account.js';
+import { InMemoryAccountRepository } from './account.ts';
 
 describe('InMemoryAccountRepository', () => {
   const dummyInput: Account[] = [

--- a/pkg/accounts/adaptor/repository/dummy/account.ts
+++ b/pkg/accounts/adaptor/repository/dummy/account.ts
@@ -1,9 +1,9 @@
 import { Ether, Option, Result } from '@mikuroxina/mini-fn';
-import type { Account, AccountID } from '../../../model/account.js';
+import type { Account, AccountID } from '../../../model/account.ts';
 import {
   type AccountRepository,
   accountRepoSymbol,
-} from '../../../model/repository.js';
+} from '../../../model/repository.ts';
 
 export class InMemoryAccountRepository implements AccountRepository {
   #data: Set<Account>;

--- a/pkg/accounts/adaptor/repository/dummy/avatar.ts
+++ b/pkg/accounts/adaptor/repository/dummy/avatar.ts
@@ -1,12 +1,12 @@
 import { Ether, Result } from '@mikuroxina/mini-fn';
-import { MediaNotFoundError } from '../../../../drive/model/errors.js';
-import type { Medium, MediumID } from '../../../../drive/model/medium.js';
-import type { AccountID } from '../../../model/account.js';
-import { AccountNotFoundError } from '../../../model/errors.js';
+import { MediaNotFoundError } from '../../../../drive/model/errors.ts';
+import type { Medium, MediumID } from '../../../../drive/model/medium.ts';
+import type { AccountID } from '../../../model/account.ts';
+import { AccountNotFoundError } from '../../../model/errors.ts';
 import {
   type AccountAvatarRepository,
   accountAvatarRepoSymbol,
-} from '../../../model/repository.js';
+} from '../../../model/repository.ts';
 
 export class InMemoryAccountAvatarRepository
   implements AccountAvatarRepository

--- a/pkg/accounts/adaptor/repository/dummy/follow.ts
+++ b/pkg/accounts/adaptor/repository/dummy/follow.ts
@@ -1,12 +1,12 @@
 import { Ether, Result } from '@mikuroxina/mini-fn';
-import type { AccountID } from '../../../model/account.js';
-import { AccountNotFoundError } from '../../../model/errors.js';
-import type { AccountFollow } from '../../../model/follow.js';
+import type { AccountID } from '../../../model/account.ts';
+import { AccountNotFoundError } from '../../../model/errors.ts';
+import type { AccountFollow } from '../../../model/follow.ts';
 import {
   type AccountFollowCount,
   type AccountFollowRepository,
   followRepoSymbol,
-} from '../../../model/repository.js';
+} from '../../../model/repository.ts';
 
 export class InMemoryAccountFollowRepository
   implements AccountFollowRepository

--- a/pkg/accounts/adaptor/repository/dummy/header.ts
+++ b/pkg/accounts/adaptor/repository/dummy/header.ts
@@ -1,12 +1,12 @@
 import { Ether, Result } from '@mikuroxina/mini-fn';
-import { MediaNotFoundError } from '../../../../drive/model/errors.js';
-import type { Medium, MediumID } from '../../../../drive/model/medium.js';
-import type { AccountID } from '../../../model/account.js';
-import { AccountNotFoundError } from '../../../model/errors.js';
+import { MediaNotFoundError } from '../../../../drive/model/errors.ts';
+import type { Medium, MediumID } from '../../../../drive/model/medium.ts';
+import type { AccountID } from '../../../model/account.ts';
+import { AccountNotFoundError } from '../../../model/errors.ts';
 import {
   type AccountHeaderRepository,
   accountHeaderRepoSymbol,
-} from '../../../model/repository.js';
+} from '../../../model/repository.ts';
 
 export class InMemoryAccountHeaderRepository
   implements AccountHeaderRepository

--- a/pkg/accounts/adaptor/repository/dummy/inactiveAccount.ts
+++ b/pkg/accounts/adaptor/repository/dummy/inactiveAccount.ts
@@ -1,10 +1,10 @@
 import { Ether, Option, Result } from '@mikuroxina/mini-fn';
-import type { AccountID } from '../../../model/account.js';
-import type { InactiveAccount } from '../../../model/inactiveAccount.js';
+import type { AccountID } from '../../../model/account.ts';
+import type { InactiveAccount } from '../../../model/inactiveAccount.ts';
 import {
   type InactiveAccountRepository,
   inactiveAccountRepoSymbol,
-} from '../../../model/repository.js';
+} from '../../../model/repository.ts';
 
 export class InMemoryInactiveAccountRepository
   implements InactiveAccountRepository

--- a/pkg/accounts/adaptor/repository/dummy/verifyToken.ts
+++ b/pkg/accounts/adaptor/repository/dummy/verifyToken.ts
@@ -1,10 +1,10 @@
 import { Ether, Option, Result } from '@mikuroxina/mini-fn';
-import type { AccountID } from '../../../model/account.js';
+import type { AccountID } from '../../../model/account.ts';
 import {
   type AccountVerifyTokenRepository,
   verifyTokenRepoSymbol,
-} from '../../../model/repository.js';
-import { VerifyToken } from '../../../model/verifyToken.js';
+} from '../../../model/repository.ts';
+import { VerifyToken } from '../../../model/verifyToken.ts';
 
 export class InMemoryAccountVerifyTokenRepository
   implements AccountVerifyTokenRepository

--- a/pkg/accounts/adaptor/repository/prisma/avatar.ts
+++ b/pkg/accounts/adaptor/repository/prisma/avatar.ts
@@ -1,14 +1,14 @@
 import { Ether, Option, Result } from '@mikuroxina/mini-fn';
-import type { PrismaClient } from '../../../../adaptors/prisma/client.js';
-import type { prismaClient } from '../../../../adaptors/prisma.js';
-import { Medium, type MediumID } from '../../../../drive/model/medium.js';
-import type { AccountID } from '../../../model/account.js';
-import { AccountInternalError } from '../../../model/errors.js';
+import type { PrismaClient } from '../../../../adaptors/prisma/client.ts';
+import type { prismaClient } from '../../../../adaptors/prisma.ts';
+import { Medium, type MediumID } from '../../../../drive/model/medium.ts';
+import type { AccountID } from '../../../model/account.ts';
+import { AccountInternalError } from '../../../model/errors.ts';
 import {
   type AccountAvatarRepository,
   accountAvatarRepoSymbol,
-} from '../../../model/repository.js';
-import { parsePrismaError } from './prisma.js';
+} from '../../../model/repository.ts';
+import { parsePrismaError } from './prisma.ts';
 
 type AccountAvatarData = Awaited<
   ReturnType<

--- a/pkg/accounts/adaptor/repository/prisma/header.ts
+++ b/pkg/accounts/adaptor/repository/prisma/header.ts
@@ -1,14 +1,14 @@
 import { Ether, Option, Result } from '@mikuroxina/mini-fn';
-import type { PrismaClient } from '../../../../adaptors/prisma/client.js';
-import type { prismaClient } from '../../../../adaptors/prisma.js';
-import { Medium, type MediumID } from '../../../../drive/model/medium.js';
-import type { AccountID } from '../../../model/account.js';
-import { AccountInternalError } from '../../../model/errors.js';
+import type { PrismaClient } from '../../../../adaptors/prisma/client.ts';
+import type { prismaClient } from '../../../../adaptors/prisma.ts';
+import { Medium, type MediumID } from '../../../../drive/model/medium.ts';
+import type { AccountID } from '../../../model/account.ts';
+import { AccountInternalError } from '../../../model/errors.ts';
 import {
   type AccountHeaderRepository,
   accountHeaderRepoSymbol,
-} from '../../../model/repository.js';
-import { parsePrismaError } from './prisma.js';
+} from '../../../model/repository.ts';
+import { parsePrismaError } from './prisma.ts';
 
 type AccountHeaderData = Awaited<
   ReturnType<

--- a/pkg/accounts/adaptor/repository/prisma/inactiveAccount.ts
+++ b/pkg/accounts/adaptor/repository/prisma/inactiveAccount.ts
@@ -1,18 +1,18 @@
 import { Ether, Option, Result } from '@mikuroxina/mini-fn';
-import type { PrismaClient } from '../../../../adaptors/prisma/client.js';
-import type { prismaClient } from '../../../../adaptors/prisma.js';
+import type { PrismaClient } from '../../../../adaptors/prisma/client.ts';
+import type { prismaClient } from '../../../../adaptors/prisma.ts';
 import type {
   AccountID,
   AccountName,
   AccountRole,
-} from '../../../model/account.js';
-import { InactiveAccount } from '../../../model/inactiveAccount.js';
+} from '../../../model/account.ts';
+import { InactiveAccount } from '../../../model/inactiveAccount.ts';
 import {
   type InactiveAccountRepository,
   inactiveAccountRepoSymbol,
-} from '../../../model/repository.js';
-import { accountModuleLogger } from '../../logger.js';
-import { parsePrismaError } from './prisma.js';
+} from '../../../model/repository.ts';
+import { accountModuleLogger } from '../../logger.ts';
+import { parsePrismaError } from './prisma.ts';
 
 type InactiveAccountPrismaArgs = Awaited<
   ReturnType<typeof prismaClient.inactiveAccount.findUnique>

--- a/pkg/accounts/adaptor/repository/prisma/prisma.ts
+++ b/pkg/accounts/adaptor/repository/prisma/prisma.ts
@@ -2,8 +2,8 @@ import { Ether, Option, Result } from '@mikuroxina/mini-fn';
 import {
   Prisma,
   type PrismaClient,
-} from '../../../../adaptors/prisma/client.js';
-import type { prismaClient } from '../../../../adaptors/prisma.js';
+} from '../../../../adaptors/prisma/client.ts';
+import type { prismaClient } from '../../../../adaptors/prisma.ts';
 import {
   Account,
   type AccountFrozen,
@@ -12,12 +12,12 @@ import {
   type AccountRole,
   type AccountSilenced,
   type AccountStatus,
-} from '../../../model/account.js';
+} from '../../../model/account.ts';
 import {
   AccountInternalError,
   AccountNotFoundError,
-} from '../../../model/errors.js';
-import { AccountFollow } from '../../../model/follow.js';
+} from '../../../model/errors.ts';
+import { AccountFollow } from '../../../model/follow.ts';
 import {
   type AccountFollowCount,
   type AccountFollowRepository,
@@ -26,8 +26,8 @@ import {
   accountRepoSymbol,
   followRepoSymbol,
   verifyTokenRepoSymbol,
-} from '../../../model/repository.js';
-import { VerifyToken } from '../../../model/verifyToken.js';
+} from '../../../model/repository.ts';
+import { VerifyToken } from '../../../model/verifyToken.ts';
 
 type AccountPrismaArgs = Awaited<
   ReturnType<typeof prismaClient.account.findUnique>

--- a/pkg/accounts/mod.ts
+++ b/pkg/accounts/mod.ts
@@ -3,34 +3,34 @@ import { Cat, Ether, Option, Promise, Result } from '@mikuroxina/mini-fn';
 import {
   AuthenticateMiddlewareService,
   type AuthMiddlewareVariable,
-} from '../adaptors/authenticateMiddleware.js';
-import { prismaClient } from '../adaptors/prisma.js';
-import { MediaNotFoundError } from '../drive/model/errors.js';
-import { mediaModuleFacadeEther } from '../intermodule/media.js';
+} from '../adaptors/authenticateMiddleware.ts';
+import { prismaClient } from '../adaptors/prisma.ts';
+import { MediaNotFoundError } from '../drive/model/errors.ts';
+import { mediaModuleFacadeEther } from '../intermodule/media.ts';
 import {
   notificationModule,
   notificationModuleFacadeSymbol,
-} from '../intermodule/notification.js';
-import { clockSymbol, snowflakeIDGenerator } from '../internal/id/mod.js';
-import { argon2idPasswordEncoder } from '../internal/password/mod.js';
-import { newTurnstileCaptchaValidator } from './adaptor/captcha/turnstile.js';
-import { AccountController } from './adaptor/controller/account.js';
-import { accountModuleLogger } from './adaptor/logger.js';
-import { captchaMiddleware } from './adaptor/middileware/captcha.js';
-import { InMemoryAccountRepository } from './adaptor/repository/dummy/account.js';
-import { inMemoryAccountAvatarRepo } from './adaptor/repository/dummy/avatar.js';
-import { newFollowRepo } from './adaptor/repository/dummy/follow.js';
-import { inMemoryAccountHeaderRepo } from './adaptor/repository/dummy/header.js';
-import { inactiveAccountRepo } from './adaptor/repository/dummy/inactiveAccount.js';
-import { verifyTokenRepo } from './adaptor/repository/dummy/verifyToken.js';
-import { prismaAccountAvatarRepo } from './adaptor/repository/prisma/avatar.js';
-import { prismaAccountHeaderRepo } from './adaptor/repository/prisma/header.js';
-import { prismaInactiveAccountRepo } from './adaptor/repository/prisma/inactiveAccount.js';
+} from '../intermodule/notification.ts';
+import { clockSymbol, snowflakeIDGenerator } from '../internal/id/mod.ts';
+import { argon2idPasswordEncoder } from '../internal/password/mod.ts';
+import { newTurnstileCaptchaValidator } from './adaptor/captcha/turnstile.ts';
+import { AccountController } from './adaptor/controller/account.ts';
+import { accountModuleLogger } from './adaptor/logger.ts';
+import { captchaMiddleware } from './adaptor/middileware/captcha.ts';
+import { InMemoryAccountRepository } from './adaptor/repository/dummy/account.ts';
+import { inMemoryAccountAvatarRepo } from './adaptor/repository/dummy/avatar.ts';
+import { newFollowRepo } from './adaptor/repository/dummy/follow.ts';
+import { inMemoryAccountHeaderRepo } from './adaptor/repository/dummy/header.ts';
+import { inactiveAccountRepo } from './adaptor/repository/dummy/inactiveAccount.ts';
+import { verifyTokenRepo } from './adaptor/repository/dummy/verifyToken.ts';
+import { prismaAccountAvatarRepo } from './adaptor/repository/prisma/avatar.ts';
+import { prismaAccountHeaderRepo } from './adaptor/repository/prisma/header.ts';
+import { prismaInactiveAccountRepo } from './adaptor/repository/prisma/inactiveAccount.ts';
 import {
   PrismaAccountRepository,
   prismaFollowRepo,
   prismaVerifyTokenRepo,
-} from './adaptor/repository/prisma/prisma.js';
+} from './adaptor/repository/prisma/prisma.ts';
 import {
   AccountAlreadyFollowingError,
   AccountAlreadyFrozenError,
@@ -53,8 +53,8 @@ import {
   AccountPassphraseRequirementsNotMetError,
   AccountRefreshTokenExpiredError,
   AccountRefreshTokenInvalidError,
-} from './model/errors.js';
-import { accountRepoSymbol } from './model/repository.js';
+} from './model/errors.ts';
+import { accountRepoSymbol } from './model/repository.ts';
 
 import {
   CreateAccountRoute,
@@ -77,26 +77,26 @@ import {
   UnsetAccountHeaderRoute,
   UpdateAccountRoute,
   VerifyEmailRoute,
-} from './router.js';
-import { authenticate } from './service/authenticate.js';
+} from './router.ts';
+import { authenticate } from './service/authenticate.ts';
 import {
   authenticateToken,
   authenticateTokenSymbol,
-} from './service/authenticationTokenService.js';
-import { accountAvatar } from './service/avatar.js';
-import { edit } from './service/edit.js';
-import { fetch } from './service/fetch.js';
-import { fetchFollow } from './service/fetchFollow.js';
-import { follow } from './service/follow.js';
-import { freeze } from './service/freeze.js';
-import { accountHeader } from './service/header.js';
-import { register } from './service/register.js';
-import { fetchRelationship } from './service/relationships.js';
-import { resendToken } from './service/resendToken.js';
-import { silence } from './service/silence.js';
-import { unfollow } from './service/unfollow.js';
-import { verifyAccountToken } from './service/verifyToken.js';
-import { dummyAccounts } from './testData/testData.js';
+} from './service/authenticationTokenService.ts';
+import { accountAvatar } from './service/avatar.ts';
+import { edit } from './service/edit.ts';
+import { fetch } from './service/fetch.ts';
+import { fetchFollow } from './service/fetchFollow.ts';
+import { follow } from './service/follow.ts';
+import { freeze } from './service/freeze.ts';
+import { accountHeader } from './service/header.ts';
+import { register } from './service/register.ts';
+import { fetchRelationship } from './service/relationships.ts';
+import { resendToken } from './service/resendToken.ts';
+import { silence } from './service/silence.ts';
+import { unfollow } from './service/unfollow.ts';
+import { verifyAccountToken } from './service/verifyToken.ts';
+import { dummyAccounts } from './testData/testData.ts';
 
 const isProduction = process.env.NODE_ENV === 'production';
 

--- a/pkg/accounts/model/account.test.ts
+++ b/pkg/accounts/model/account.test.ts
@@ -7,7 +7,7 @@ import {
   type AccountID,
   accountNameSchema,
   type CreateAccountArgs,
-} from './account.js';
+} from './account.ts';
 
 const exampleInput: CreateAccountArgs = {
   id: '1' as AccountID,

--- a/pkg/accounts/model/account.ts
+++ b/pkg/accounts/model/account.ts
@@ -1,7 +1,7 @@
 import { Result } from '@mikuroxina/mini-fn';
 import * as v from 'valibot';
 
-import type { ID } from '../../internal/id/type.js';
+import type { ID } from '../../internal/id/type.ts';
 import {
   AccountAlreadyDeletedError,
   AccountAlreadyFrozenError,
@@ -10,7 +10,7 @@ import {
   AccountMailAddressLengthError,
   AccountNickNameLengthError,
   AccountPassphraseRequirementsNotMetError,
-} from './account.errors.js';
+} from './account.errors.ts';
 
 export type AccountID = ID<Account>;
 export type AccountName = `@${string}@${string}`;

--- a/pkg/accounts/model/follow.test.ts
+++ b/pkg/accounts/model/follow.test.ts
@@ -1,8 +1,8 @@
 import { Option, Result } from '@mikuroxina/mini-fn';
 import { describe, expect, it } from 'vitest';
 
-import type { AccountID } from './account.js';
-import { AccountFollow } from './follow.js';
+import type { AccountID } from './account.ts';
+import { AccountFollow } from './follow.ts';
 
 describe('AccountFollow', () => {
   it('generate new instance', () => {

--- a/pkg/accounts/model/follow.ts
+++ b/pkg/accounts/model/follow.ts
@@ -1,6 +1,6 @@
 import { Option, Result } from '@mikuroxina/mini-fn';
 
-import type { AccountID } from './account.js';
+import type { AccountID } from './account.ts';
 
 export interface AccountFollowConstructorArgs {
   fromID: AccountID;

--- a/pkg/accounts/model/followDomainService.ts
+++ b/pkg/accounts/model/followDomainService.ts
@@ -1,5 +1,5 @@
-import type { AccountID } from './account.js';
-import type { AccountFollow } from './follow.js';
+import type { AccountID } from './account.ts';
+import type { AccountFollow } from './follow.ts';
 
 /**
  * Returns true if `fromID` is in the followers list (i.e., fromID follows the account that owns `followers`).

--- a/pkg/accounts/model/inactiveAccount.test.ts
+++ b/pkg/accounts/model/inactiveAccount.test.ts
@@ -1,12 +1,12 @@
 import { Result } from '@mikuroxina/mini-fn';
 import { describe, expect, it } from 'vitest';
 
-import type { AccountID } from './account.js';
+import type { AccountID } from './account.ts';
 import {
   type ActivateArgs,
   type CreateInactiveAccountArgs,
   InactiveAccount,
-} from './inactiveAccount.js';
+} from './inactiveAccount.ts';
 
 const exampleInput: CreateInactiveAccountArgs = {
   id: '1' as AccountID,

--- a/pkg/accounts/model/inactiveAccount.ts
+++ b/pkg/accounts/model/inactiveAccount.ts
@@ -1,13 +1,13 @@
 import { Result } from '@mikuroxina/mini-fn';
 import * as v from 'valibot';
-import { AccountMailAddressLengthError } from './account.errors.js';
+import { AccountMailAddressLengthError } from './account.errors.ts';
 import {
   Account,
   type AccountID,
   type AccountName,
   type AccountRole,
   mailSchema,
-} from './account.js';
+} from './account.ts';
 
 export interface CreateInactiveAccountArgs {
   id: AccountID;

--- a/pkg/accounts/model/repository.ts
+++ b/pkg/accounts/model/repository.ts
@@ -1,10 +1,10 @@
 import { Ether, type Option, type Result } from '@mikuroxina/mini-fn';
 
-import type { Medium, MediumID } from '../../drive/model/medium.js';
-import type { Account, AccountID } from './account.js';
-import type { AccountFollow } from './follow.js';
-import type { InactiveAccount } from './inactiveAccount.js';
-import type { VerifyToken } from './verifyToken.js';
+import type { Medium, MediumID } from '../../drive/model/medium.ts';
+import type { Account, AccountID } from './account.ts';
+import type { AccountFollow } from './follow.ts';
+import type { InactiveAccount } from './inactiveAccount.ts';
+import type { VerifyToken } from './verifyToken.ts';
 
 export interface AccountRepository {
   create(account: Account): Promise<Result.Result<Error, void>>;

--- a/pkg/accounts/model/verifyToken.test.ts
+++ b/pkg/accounts/model/verifyToken.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import type { AccountID } from './account.js';
-import { VerifyToken } from './verifyToken.js';
+import type { AccountID } from './account.ts';
+import { VerifyToken } from './verifyToken.ts';
 
 const accountID = '1' as AccountID;
 const future = new Date('2099-01-01T00:00:00Z');

--- a/pkg/accounts/model/verifyToken.ts
+++ b/pkg/accounts/model/verifyToken.ts
@@ -1,4 +1,4 @@
-import type { AccountID } from './account.js';
+import type { AccountID } from './account.ts';
 
 export interface VerifyTokenArgs {
   accountID: AccountID;

--- a/pkg/accounts/policy/accountPolicy.ts
+++ b/pkg/accounts/policy/accountPolicy.ts
@@ -3,11 +3,11 @@ import type {
   Policy,
   PolicyArgs,
   PolicyAuthorizedActionFunc,
-} from '../../internal/policy/policy.js';
-import { accountModuleLogger } from '../adaptor/logger.js';
-import { AccountAlreadyFrozenError } from '../model/account.errors.js';
-import type { Account } from '../model/account.js';
-import { AccountInsufficientPermissionError } from '../model/errors.js';
+} from '../../internal/policy/policy.ts';
+import { accountModuleLogger } from '../adaptor/logger.ts';
+import { AccountAlreadyFrozenError } from '../model/account.errors.ts';
+import type { Account } from '../model/account.ts';
+import { AccountInsufficientPermissionError } from '../model/errors.ts';
 
 export type AccountPolicyActionModelName =
   | 'account'

--- a/pkg/accounts/router.ts
+++ b/pkg/accounts/router.ts
@@ -1,6 +1,6 @@
 import { createRoute, z } from '@hono/zod-openapi';
 
-import { FileNotFound } from '../drive/adaptor/presenter/errors.js';
+import { FileNotFound } from '../drive/adaptor/presenter/errors.ts';
 import {
   bearerAuth,
   errorResponse,
@@ -8,7 +8,7 @@ import {
   jsonBody,
   noContentResponse,
   okResponse,
-} from '../internal/router/helper.js';
+} from '../internal/router/helper.ts';
 import {
   AccountAlreadyVerified,
   AccountNameInUse,
@@ -30,7 +30,7 @@ import {
   YouAreBot,
   YouAreFrozen,
   YouAreNotFollowing,
-} from './adaptor/presenter/errors.js';
+} from './adaptor/presenter/errors.ts';
 import {
   CreateAccountRequestSchema,
   CreateAccountResponseSchema,
@@ -45,7 +45,7 @@ import {
   UpdateAccountRequestSchema,
   UpdateAccountResponseSchema,
   VerifyEmailRequestSchema,
-} from './adaptor/validator/schema.js';
+} from './adaptor/validator/schema.ts';
 
 const accountInternalErrorSchema = z
   .object({ error: InternalError })

--- a/pkg/accounts/service/authenticate.test.ts
+++ b/pkg/accounts/service/authenticate.test.ts
@@ -1,11 +1,11 @@
 import { Result } from '@mikuroxina/mini-fn';
 import { describe, expect, it } from 'vitest';
-import { MockClock } from '../../internal/id/mod.js';
-import { Argon2idPasswordEncoder } from '../../internal/password/mod.js';
-import { InMemoryAccountRepository } from '../adaptor/repository/dummy/account.js';
-import { Account, type AccountID } from '../model/account.js';
-import { AuthenticateService } from './authenticate.js';
-import { AuthenticationTokenService } from './authenticationTokenService.js';
+import { MockClock } from '../../internal/id/mod.ts';
+import { Argon2idPasswordEncoder } from '../../internal/password/mod.ts';
+import { InMemoryAccountRepository } from '../adaptor/repository/dummy/account.ts';
+import { Account, type AccountID } from '../model/account.ts';
+import { AuthenticateService } from './authenticate.ts';
+import { AuthenticationTokenService } from './authenticationTokenService.ts';
 
 describe('AuthenticateService', () => {
   it('Generate valid token', async () => {

--- a/pkg/accounts/service/authenticate.ts
+++ b/pkg/accounts/service/authenticate.ts
@@ -3,21 +3,21 @@ import { Cat, Ether, Option, Promise, Result } from '@mikuroxina/mini-fn';
 import {
   type PasswordEncoder,
   passwordEncoderSymbol,
-} from '../../internal/password/mod.js';
+} from '../../internal/password/mod.ts';
 import {
   AccountAuthenticationFailedError,
   AccountInternalError,
   AccountNotFoundError,
-} from '../model/errors.js';
+} from '../model/errors.ts';
 import {
   type AccountRepository,
   accountRepoSymbol,
-} from '../model/repository.js';
+} from '../model/repository.ts';
 import {
   type AuthenticationToken,
   type AuthenticationTokenService,
   authenticateTokenSymbol,
-} from './authenticationTokenService.js';
+} from './authenticationTokenService.ts';
 
 export class AuthenticateService {
   readonly #accountRepository: AccountRepository;

--- a/pkg/accounts/service/authenticationTokenService.test.ts
+++ b/pkg/accounts/service/authenticationTokenService.test.ts
@@ -2,8 +2,8 @@ import { Option, Result } from '@mikuroxina/mini-fn';
 import * as jose from 'jose';
 import { describe, expect, it } from 'vitest';
 
-import { MockClock } from '../../internal/id/mod.js';
-import { AuthenticationTokenService } from './authenticationTokenService.js';
+import { MockClock } from '../../internal/id/mod.ts';
+import { AuthenticationTokenService } from './authenticationTokenService.ts';
 
 describe('AuthenticationTokenService', () => {
   it('verify JWT Token', async () => {

--- a/pkg/accounts/service/authenticationTokenService.ts
+++ b/pkg/accounts/service/authenticationTokenService.ts
@@ -1,11 +1,11 @@
 import { Ether, Option, type Promise, Result } from '@mikuroxina/mini-fn';
 import * as jose from 'jose';
 
-import { type Clock, clockSymbol } from '../../internal/id/mod.js';
+import { type Clock, clockSymbol } from '../../internal/id/mod.ts';
 import {
   AccountAuthenticationTokenExpiredError,
   AccountAuthenticationTokenInvalidError,
-} from '../model/errors.js';
+} from '../model/errors.ts';
 
 declare const authenticationTokenNominal: unique symbol;
 export type AuthenticationToken = string & {

--- a/pkg/accounts/service/avatar.test.ts
+++ b/pkg/accounts/service/avatar.test.ts
@@ -1,17 +1,17 @@
 import { Result } from '@mikuroxina/mini-fn';
 import { beforeEach, describe, expect, it } from 'vitest';
-import { InMemoryMediaRepository } from '../../drive/adaptor/repository/dummy.js';
-import type { MediumID } from '../../drive/model/medium.js';
+import { InMemoryMediaRepository } from '../../drive/adaptor/repository/dummy.ts';
+import type { MediumID } from '../../drive/model/medium.ts';
 import {
   testMedium,
   testNSFWMedium,
   testOtherMedium,
-} from '../../drive/testData/testData.js';
-import { dummyMediaModuleFacade } from '../../intermodule/media.js';
-import { InMemoryAccountAvatarRepository } from '../adaptor/repository/dummy/avatar.js';
-import type { AccountID } from '../model/account.js';
-import { AccountInsufficientPermissionError } from '../model/errors.js';
-import { AccountAvatarService } from './avatar.js';
+} from '../../drive/testData/testData.ts';
+import { dummyMediaModuleFacade } from '../../intermodule/media.ts';
+import { InMemoryAccountAvatarRepository } from '../adaptor/repository/dummy/avatar.ts';
+import type { AccountID } from '../model/account.ts';
+import { AccountInsufficientPermissionError } from '../model/errors.ts';
+import { AccountAvatarService } from './avatar.ts';
 
 describe('AccountAvatarService', () => {
   const avatarRepository = new InMemoryAccountAvatarRepository();

--- a/pkg/accounts/service/avatar.ts
+++ b/pkg/accounts/service/avatar.ts
@@ -1,15 +1,15 @@
 import { Cat, Ether, Promise, Result } from '@mikuroxina/mini-fn';
-import type { Medium, MediumID } from '../../drive/model/medium.js';
+import type { Medium, MediumID } from '../../drive/model/medium.ts';
 import {
   type MediaModuleFacade,
   mediaModuleFacadeSymbol,
-} from '../../intermodule/media.js';
-import type { AccountID } from '../model/account.js';
-import { AccountInsufficientPermissionError } from '../model/errors.js';
+} from '../../intermodule/media.ts';
+import type { AccountID } from '../model/account.ts';
+import { AccountInsufficientPermissionError } from '../model/errors.ts';
 import {
   type AccountAvatarRepository,
   accountAvatarRepoSymbol,
-} from '../model/repository.js';
+} from '../model/repository.ts';
 
 export class AccountAvatarService {
   readonly #avatarRepository: AccountAvatarRepository;

--- a/pkg/accounts/service/edit.test.ts
+++ b/pkg/accounts/service/edit.test.ts
@@ -1,10 +1,10 @@
 import { Option, Result } from '@mikuroxina/mini-fn';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { Argon2idPasswordEncoder } from '../../internal/password/mod.js';
-import { InMemoryAccountRepository } from '../adaptor/repository/dummy/account.js';
-import { Account, type AccountID } from '../model/account.js';
-import { EditService } from './edit.js';
+import { Argon2idPasswordEncoder } from '../../internal/password/mod.ts';
+import { InMemoryAccountRepository } from '../adaptor/repository/dummy/account.ts';
+import { Account, type AccountID } from '../model/account.ts';
+import { EditService } from './edit.ts';
 
 const passwordEncoder = new Argon2idPasswordEncoder();
 const repository = new InMemoryAccountRepository();

--- a/pkg/accounts/service/edit.ts
+++ b/pkg/accounts/service/edit.ts
@@ -3,13 +3,13 @@ import { Cat, Ether, Option, Promise, Result } from '@mikuroxina/mini-fn';
 import {
   type PasswordEncoder,
   passwordEncoderSymbol,
-} from '../../internal/password/mod.js';
-import { Account, type AccountName } from '../model/account.js';
-import { AccountInternalError, AccountNotFoundError } from '../model/errors.js';
+} from '../../internal/password/mod.ts';
+import { Account, type AccountName } from '../model/account.ts';
+import { AccountInternalError, AccountNotFoundError } from '../model/errors.ts';
 import {
   type AccountRepository,
   accountRepoSymbol,
-} from '../model/repository.js';
+} from '../model/repository.ts';
 
 export class EditService {
   #accountRepository: AccountRepository;

--- a/pkg/accounts/service/fetch.test.ts
+++ b/pkg/accounts/service/fetch.test.ts
@@ -1,9 +1,9 @@
 import { Result } from '@mikuroxina/mini-fn';
 import { afterEach, describe, expect, it } from 'vitest';
 
-import { InMemoryAccountRepository } from '../adaptor/repository/dummy/account.js';
-import { Account, type AccountID } from '../model/account.js';
-import { FetchService } from './fetch.js';
+import { InMemoryAccountRepository } from '../adaptor/repository/dummy/account.ts';
+import { Account, type AccountID } from '../model/account.ts';
+import { FetchService } from './fetch.ts';
 
 const testAccounts = [
   Account.new({

--- a/pkg/accounts/service/fetch.ts
+++ b/pkg/accounts/service/fetch.ts
@@ -1,11 +1,11 @@
 import { Ether, Option, Result } from '@mikuroxina/mini-fn';
 
-import type { Account, AccountID } from '../model/account.js';
-import { AccountNotFoundError } from '../model/errors.js';
+import type { Account, AccountID } from '../model/account.ts';
+import { AccountNotFoundError } from '../model/errors.ts';
 import {
   type AccountRepository,
   accountRepoSymbol,
-} from '../model/repository.js';
+} from '../model/repository.ts';
 
 export class FetchService {
   #accountRepository: AccountRepository;

--- a/pkg/accounts/service/fetchFollow.test.ts
+++ b/pkg/accounts/service/fetchFollow.test.ts
@@ -1,11 +1,11 @@
 import { Result } from '@mikuroxina/mini-fn';
 import { describe, expect, it } from 'vitest';
 
-import { InMemoryAccountRepository } from '../adaptor/repository/dummy/account.js';
-import { InMemoryAccountFollowRepository } from '../adaptor/repository/dummy/follow.js';
-import { Account, type AccountID } from '../model/account.js';
-import { AccountFollow } from '../model/follow.js';
-import { FetchFollowService } from './fetchFollow.js';
+import { InMemoryAccountRepository } from '../adaptor/repository/dummy/account.ts';
+import { InMemoryAccountFollowRepository } from '../adaptor/repository/dummy/follow.ts';
+import { Account, type AccountID } from '../model/account.ts';
+import { AccountFollow } from '../model/follow.ts';
+import { FetchFollowService } from './fetchFollow.ts';
 
 const accountRepository = new InMemoryAccountRepository();
 

--- a/pkg/accounts/service/fetchFollow.ts
+++ b/pkg/accounts/service/fetchFollow.ts
@@ -1,15 +1,15 @@
 import { Cat, Ether, Option, Promise, type Result } from '@mikuroxina/mini-fn';
 
-import type { AccountID, AccountName } from '../model/account.js';
-import { AccountNotFoundError } from '../model/errors.js';
-import type { AccountFollow } from '../model/follow.js';
+import type { AccountID, AccountName } from '../model/account.ts';
+import { AccountNotFoundError } from '../model/errors.ts';
+import type { AccountFollow } from '../model/follow.ts';
 import {
   type AccountFollowCount,
   type AccountFollowRepository,
   type AccountRepository,
   accountRepoSymbol,
   followRepoSymbol,
-} from '../model/repository.js';
+} from '../model/repository.ts';
 
 export class FetchFollowService {
   readonly #accountFollowRepository: AccountFollowRepository;

--- a/pkg/accounts/service/follow.test.ts
+++ b/pkg/accounts/service/follow.test.ts
@@ -1,10 +1,10 @@
 import { Option, Result } from '@mikuroxina/mini-fn';
 import { describe, expect, it } from 'vitest';
-import { MockClock } from '../../internal/id/mod.js';
-import { InMemoryAccountRepository } from '../adaptor/repository/dummy/account.js';
-import { InMemoryAccountFollowRepository } from '../adaptor/repository/dummy/follow.js';
-import { Account, type AccountID } from '../model/account.js';
-import { FollowService } from './follow.js';
+import { MockClock } from '../../internal/id/mod.ts';
+import { InMemoryAccountRepository } from '../adaptor/repository/dummy/account.ts';
+import { InMemoryAccountFollowRepository } from '../adaptor/repository/dummy/follow.ts';
+import { Account, type AccountID } from '../model/account.ts';
+import { FollowService } from './follow.ts';
 
 const accountRepository = new InMemoryAccountRepository();
 await accountRepository.create(

--- a/pkg/accounts/service/follow.ts
+++ b/pkg/accounts/service/follow.ts
@@ -1,15 +1,15 @@
 import { Cat, Ether, Option, Promise, Result } from '@mikuroxina/mini-fn';
 
-import { type Clock, clockSymbol } from '../../internal/id/mod.js';
-import type { AccountName } from '../model/account.js';
-import { AccountNotFoundError } from '../model/errors.js';
-import { AccountFollow } from '../model/follow.js';
+import { type Clock, clockSymbol } from '../../internal/id/mod.ts';
+import type { AccountName } from '../model/account.ts';
+import { AccountNotFoundError } from '../model/errors.ts';
+import { AccountFollow } from '../model/follow.ts';
 import {
   type AccountFollowRepository,
   type AccountRepository,
   accountRepoSymbol,
   followRepoSymbol,
-} from '../model/repository.js';
+} from '../model/repository.ts';
 
 export class FollowService {
   readonly #followRepository: AccountFollowRepository;

--- a/pkg/accounts/service/freeze.test.ts
+++ b/pkg/accounts/service/freeze.test.ts
@@ -1,9 +1,9 @@
 import { Option, Result } from '@mikuroxina/mini-fn';
 import { beforeEach, describe, expect, it } from 'vitest';
 
-import { InMemoryAccountRepository } from '../adaptor/repository/dummy/account.js';
-import { Account, type AccountID } from '../model/account.js';
-import { FreezeService } from './freeze.js';
+import { InMemoryAccountRepository } from '../adaptor/repository/dummy/account.ts';
+import { Account, type AccountID } from '../model/account.ts';
+import { FreezeService } from './freeze.ts';
 
 const testAccounts = [
   // NOTE: target account

--- a/pkg/accounts/service/freeze.ts
+++ b/pkg/accounts/service/freeze.ts
@@ -1,11 +1,11 @@
 import { Cat, Ether, Option, Promise, Result } from '@mikuroxina/mini-fn';
 
-import type { Account, AccountName } from '../model/account.js';
-import { AccountNotFoundError } from '../model/errors.js';
+import type { Account, AccountName } from '../model/account.ts';
+import { AccountNotFoundError } from '../model/errors.ts';
 import {
   type AccountRepository,
   accountRepoSymbol,
-} from '../model/repository.js';
+} from '../model/repository.ts';
 
 export class FreezeService {
   readonly #accountRepository: AccountRepository;

--- a/pkg/accounts/service/header.test.ts
+++ b/pkg/accounts/service/header.test.ts
@@ -1,17 +1,17 @@
 import { Result } from '@mikuroxina/mini-fn';
 import { beforeEach, describe, expect, it } from 'vitest';
-import { InMemoryMediaRepository } from '../../drive/adaptor/repository/dummy.js';
-import type { MediumID } from '../../drive/model/medium.js';
+import { InMemoryMediaRepository } from '../../drive/adaptor/repository/dummy.ts';
+import type { MediumID } from '../../drive/model/medium.ts';
 import {
   testMedium,
   testNSFWMedium,
   testOtherMedium,
-} from '../../drive/testData/testData.js';
-import { dummyMediaModuleFacade } from '../../intermodule/media.js';
-import { InMemoryAccountHeaderRepository } from '../adaptor/repository/dummy/header.js';
-import type { AccountID } from '../model/account.js';
-import { AccountInsufficientPermissionError } from '../model/errors.js';
-import { AccountHeaderService } from './header.js';
+} from '../../drive/testData/testData.ts';
+import { dummyMediaModuleFacade } from '../../intermodule/media.ts';
+import { InMemoryAccountHeaderRepository } from '../adaptor/repository/dummy/header.ts';
+import type { AccountID } from '../model/account.ts';
+import { AccountInsufficientPermissionError } from '../model/errors.ts';
+import { AccountHeaderService } from './header.ts';
 
 describe('AccountHeaderService', () => {
   const headerRepository = new InMemoryAccountHeaderRepository();

--- a/pkg/accounts/service/header.ts
+++ b/pkg/accounts/service/header.ts
@@ -1,15 +1,15 @@
 import { Cat, Ether, Promise, Result } from '@mikuroxina/mini-fn';
-import type { Medium, MediumID } from '../../drive/model/medium.js';
+import type { Medium, MediumID } from '../../drive/model/medium.ts';
 import {
   type MediaModuleFacade,
   mediaModuleFacadeSymbol,
-} from '../../intermodule/media.js';
-import type { AccountID } from '../model/account.js';
-import { AccountInsufficientPermissionError } from '../model/errors.js';
+} from '../../intermodule/media.ts';
+import type { AccountID } from '../model/account.ts';
+import { AccountInsufficientPermissionError } from '../model/errors.ts';
 import {
   type AccountHeaderRepository,
   accountHeaderRepoSymbol,
-} from '../model/repository.js';
+} from '../model/repository.ts';
 
 export class AccountHeaderService {
   readonly #headerRepository: AccountHeaderRepository;

--- a/pkg/accounts/service/register.test.ts
+++ b/pkg/accounts/service/register.test.ts
@@ -1,14 +1,14 @@
 import { Result } from '@mikuroxina/mini-fn';
 import { afterEach, describe, expect, it } from 'vitest';
-import { notificationModule } from '../../intermodule/notification.js';
-import { MockClock, SnowflakeIDGenerator } from '../../internal/id/mod.js';
-import { Argon2idPasswordEncoder } from '../../internal/password/mod.js';
-import { InMemoryAccountRepository } from '../adaptor/repository/dummy/account.js';
-import { InMemoryInactiveAccountRepository } from '../adaptor/repository/dummy/inactiveAccount.js';
-import { InMemoryAccountVerifyTokenRepository } from '../adaptor/repository/dummy/verifyToken.js';
-import type { AccountName, AccountRole } from '../model/account.js';
-import { RegisterService } from './register.js';
-import { VerifyAccountTokenService } from './verifyToken.js';
+import { notificationModule } from '../../intermodule/notification.ts';
+import { MockClock, SnowflakeIDGenerator } from '../../internal/id/mod.ts';
+import { Argon2idPasswordEncoder } from '../../internal/password/mod.ts';
+import { InMemoryAccountRepository } from '../adaptor/repository/dummy/account.ts';
+import { InMemoryInactiveAccountRepository } from '../adaptor/repository/dummy/inactiveAccount.ts';
+import { InMemoryAccountVerifyTokenRepository } from '../adaptor/repository/dummy/verifyToken.ts';
+import type { AccountName, AccountRole } from '../model/account.ts';
+import { RegisterService } from './register.ts';
+import { VerifyAccountTokenService } from './verifyToken.ts';
 
 const inactiveAccountRepository = new InMemoryInactiveAccountRepository();
 const accountRepository = new InMemoryAccountRepository();

--- a/pkg/accounts/service/register.ts
+++ b/pkg/accounts/service/register.ts
@@ -2,29 +2,29 @@ import { Cat, Ether, Option, Promise, Result } from '@mikuroxina/mini-fn';
 import {
   type NotificationModuleFacade,
   notificationModuleFacadeSymbol,
-} from '../../intermodule/notification.js';
+} from '../../intermodule/notification.ts';
 import {
   type SnowflakeIDGenerator,
   snowflakeIDGeneratorSymbol,
-} from '../../internal/id/mod.js';
+} from '../../internal/id/mod.ts';
 import {
   type PasswordEncoder,
   passwordEncoderSymbol,
-} from '../../internal/password/mod.js';
+} from '../../internal/password/mod.ts';
 import {
   Account,
   type AccountName,
   type AccountRole,
-} from '../model/account.js';
-import { InactiveAccount } from '../model/inactiveAccount.js';
+} from '../model/account.ts';
+import { InactiveAccount } from '../model/inactiveAccount.ts';
 import {
   type InactiveAccountRepository,
   inactiveAccountRepoSymbol,
-} from '../model/repository.js';
+} from '../model/repository.ts';
 import {
   type VerifyAccountTokenService,
   verifyAccountTokenSymbol,
-} from './verifyToken.js';
+} from './verifyToken.ts';
 
 export class AccountAlreadyExistsError extends Error {
   override readonly name = 'AccountAlreadyExistsError' as const;

--- a/pkg/accounts/service/relationships.test.ts
+++ b/pkg/accounts/service/relationships.test.ts
@@ -1,7 +1,7 @@
 import { Result } from '@mikuroxina/mini-fn';
 import { describe, expect, it } from 'vitest';
-import { InMemoryAccountRepository } from '../adaptor/repository/dummy/account.js';
-import { InMemoryAccountFollowRepository } from '../adaptor/repository/dummy/follow.js';
+import { InMemoryAccountRepository } from '../adaptor/repository/dummy/account.ts';
+import { InMemoryAccountFollowRepository } from '../adaptor/repository/dummy/follow.ts';
 import {
   Account,
   type AccountFrozen,
@@ -9,10 +9,10 @@ import {
   type AccountRole,
   type AccountSilenced,
   type AccountStatus,
-} from '../model/account.js';
-import { AccountNotFoundError } from '../model/errors.js';
-import { AccountFollow } from '../model/follow.js';
-import { FetchRelationshipService } from './relationships.js';
+} from '../model/account.ts';
+import { AccountNotFoundError } from '../model/errors.ts';
+import { AccountFollow } from '../model/follow.ts';
+import { FetchRelationshipService } from './relationships.ts';
 
 // Test factories
 const createMockAccount = (id: string, name: string): Account => {

--- a/pkg/accounts/service/relationships.ts
+++ b/pkg/accounts/service/relationships.ts
@@ -1,14 +1,14 @@
 import { Cat, Ether, Option, Promise, type Result } from '@mikuroxina/mini-fn';
 
-import type { AccountID } from '../model/account.js';
-import { AccountNotFoundError } from '../model/errors.js';
-import { isFollowedBy, isFollowing } from '../model/followDomainService.js';
+import type { AccountID } from '../model/account.ts';
+import { AccountNotFoundError } from '../model/errors.ts';
+import { isFollowedBy, isFollowing } from '../model/followDomainService.ts';
 import {
   type AccountFollowRepository,
   type AccountRepository,
   accountRepoSymbol,
   followRepoSymbol,
-} from '../model/repository.js';
+} from '../model/repository.ts';
 
 export interface AccountRelationships {
   id: AccountID;

--- a/pkg/accounts/service/resendToken.test.ts
+++ b/pkg/accounts/service/resendToken.test.ts
@@ -1,15 +1,15 @@
 import { Option } from '@mikuroxina/mini-fn';
 import { afterEach, describe, expect, it } from 'vitest';
-import { notificationModule } from '../../intermodule/notification.js';
-import { MockClock } from '../../internal/id/mod.js';
-import { InMemoryAccountRepository } from '../adaptor/repository/dummy/account.js';
-import { InMemoryInactiveAccountRepository } from '../adaptor/repository/dummy/inactiveAccount.js';
-import { InMemoryAccountVerifyTokenRepository } from '../adaptor/repository/dummy/verifyToken.js';
-import type { AccountID } from '../model/account.js';
-import { AccountNotFoundError } from '../model/errors.js';
-import { InactiveAccount } from '../model/inactiveAccount.js';
-import { ResendVerifyTokenService } from './resendToken.js';
-import { VerifyAccountTokenService } from './verifyToken.js';
+import { notificationModule } from '../../intermodule/notification.ts';
+import { MockClock } from '../../internal/id/mod.ts';
+import { InMemoryAccountRepository } from '../adaptor/repository/dummy/account.ts';
+import { InMemoryInactiveAccountRepository } from '../adaptor/repository/dummy/inactiveAccount.ts';
+import { InMemoryAccountVerifyTokenRepository } from '../adaptor/repository/dummy/verifyToken.ts';
+import type { AccountID } from '../model/account.ts';
+import { AccountNotFoundError } from '../model/errors.ts';
+import { InactiveAccount } from '../model/inactiveAccount.ts';
+import { ResendVerifyTokenService } from './resendToken.ts';
+import { VerifyAccountTokenService } from './verifyToken.ts';
 
 const inactiveAccountRepository = new InMemoryInactiveAccountRepository();
 await inactiveAccountRepository.create(

--- a/pkg/accounts/service/resendToken.ts
+++ b/pkg/accounts/service/resendToken.ts
@@ -2,17 +2,17 @@ import { Cat, Ether, Option, Promise, Result } from '@mikuroxina/mini-fn';
 import {
   type NotificationModuleFacade,
   notificationModuleFacadeSymbol,
-} from '../../intermodule/notification.js';
-import type { AccountName } from '../model/account.js';
-import { AccountNotFoundError } from '../model/errors.js';
+} from '../../intermodule/notification.ts';
+import type { AccountName } from '../model/account.ts';
+import { AccountNotFoundError } from '../model/errors.ts';
 import {
   type InactiveAccountRepository,
   inactiveAccountRepoSymbol,
-} from '../model/repository.js';
+} from '../model/repository.ts';
 import {
   type VerifyAccountTokenService,
   verifyAccountTokenSymbol,
-} from './verifyToken.js';
+} from './verifyToken.ts';
 
 export class ResendVerifyTokenService {
   readonly #inactiveAccountRepository: InactiveAccountRepository;

--- a/pkg/accounts/service/silence.test.ts
+++ b/pkg/accounts/service/silence.test.ts
@@ -1,9 +1,9 @@
 import { Option } from '@mikuroxina/mini-fn';
 import { beforeEach, describe, expect, it } from 'vitest';
 
-import { InMemoryAccountRepository } from '../adaptor/repository/dummy/account.js';
-import { Account, type AccountID } from '../model/account.js';
-import { SilenceService } from './silence.js';
+import { InMemoryAccountRepository } from '../adaptor/repository/dummy/account.ts';
+import { Account, type AccountID } from '../model/account.ts';
+import { SilenceService } from './silence.ts';
 
 const repository = new InMemoryAccountRepository();
 const silenceService = new SilenceService(repository);

--- a/pkg/accounts/service/silence.ts
+++ b/pkg/accounts/service/silence.ts
@@ -1,11 +1,11 @@
 import { Cat, Ether, Option, Promise, Result } from '@mikuroxina/mini-fn';
 
-import type { Account, AccountName } from '../model/account.js';
-import { AccountNotFoundError } from '../model/errors.js';
+import type { Account, AccountName } from '../model/account.ts';
+import { AccountNotFoundError } from '../model/errors.ts';
 import {
   type AccountRepository,
   accountRepoSymbol,
-} from '../model/repository.js';
+} from '../model/repository.ts';
 
 export class SilenceService {
   readonly #accountRepository: AccountRepository;

--- a/pkg/accounts/service/unfollow.test.ts
+++ b/pkg/accounts/service/unfollow.test.ts
@@ -1,11 +1,11 @@
 import { Option, Result } from '@mikuroxina/mini-fn';
 import { describe, expect, it } from 'vitest';
 
-import { InMemoryAccountRepository } from '../adaptor/repository/dummy/account.js';
-import { InMemoryAccountFollowRepository } from '../adaptor/repository/dummy/follow.js';
-import { Account, type AccountID } from '../model/account.js';
-import { AccountFollow } from '../model/follow.js';
-import { UnfollowService } from './unfollow.js';
+import { InMemoryAccountRepository } from '../adaptor/repository/dummy/account.ts';
+import { InMemoryAccountFollowRepository } from '../adaptor/repository/dummy/follow.ts';
+import { Account, type AccountID } from '../model/account.ts';
+import { AccountFollow } from '../model/follow.ts';
+import { UnfollowService } from './unfollow.ts';
 
 const accountRepository = new InMemoryAccountRepository();
 await accountRepository.create(

--- a/pkg/accounts/service/unfollow.ts
+++ b/pkg/accounts/service/unfollow.ts
@@ -1,13 +1,13 @@
 import { Cat, Ether, Option, Promise, Result } from '@mikuroxina/mini-fn';
 
-import type { AccountName } from '../model/account.js';
-import { AccountNotFoundError } from '../model/errors.js';
+import type { AccountName } from '../model/account.ts';
+import { AccountNotFoundError } from '../model/errors.ts';
 import {
   type AccountFollowRepository,
   type AccountRepository,
   accountRepoSymbol,
   followRepoSymbol,
-} from '../model/repository.js';
+} from '../model/repository.ts';
 
 export class UnfollowService {
   readonly #followRepository: AccountFollowRepository;

--- a/pkg/accounts/service/verifyToken.test.ts
+++ b/pkg/accounts/service/verifyToken.test.ts
@@ -1,12 +1,12 @@
 import { Option, Result } from '@mikuroxina/mini-fn';
 import { describe, expect, it } from 'vitest';
-import { MockClock } from '../../internal/id/mod.js';
-import { InMemoryAccountRepository } from '../adaptor/repository/dummy/account.js';
-import { InMemoryInactiveAccountRepository } from '../adaptor/repository/dummy/inactiveAccount.js';
-import { InMemoryAccountVerifyTokenRepository } from '../adaptor/repository/dummy/verifyToken.js';
-import type { AccountID } from '../model/account.js';
-import { InactiveAccount } from '../model/inactiveAccount.js';
-import { VerifyAccountTokenService } from './verifyToken.js';
+import { MockClock } from '../../internal/id/mod.ts';
+import { InMemoryAccountRepository } from '../adaptor/repository/dummy/account.ts';
+import { InMemoryInactiveAccountRepository } from '../adaptor/repository/dummy/inactiveAccount.ts';
+import { InMemoryAccountVerifyTokenRepository } from '../adaptor/repository/dummy/verifyToken.ts';
+import type { AccountID } from '../model/account.ts';
+import { InactiveAccount } from '../model/inactiveAccount.ts';
+import { VerifyAccountTokenService } from './verifyToken.ts';
 
 const repository = new InMemoryAccountVerifyTokenRepository();
 const inactiveAccountRepository = new InMemoryInactiveAccountRepository();

--- a/pkg/accounts/service/verifyToken.ts
+++ b/pkg/accounts/service/verifyToken.ts
@@ -1,11 +1,11 @@
 import { Cat, Ether, Option, Promise, Result } from '@mikuroxina/mini-fn';
 
-import { type Clock, clockSymbol } from '../../internal/id/mod.js';
-import type { AccountName } from '../model/account.js';
+import { type Clock, clockSymbol } from '../../internal/id/mod.ts';
+import type { AccountName } from '../model/account.ts';
 import {
   AccountMailAddressVerificationTokenInvalidError,
   AccountNotFoundError,
-} from '../model/errors.js';
+} from '../model/errors.ts';
 import {
   type AccountRepository,
   type AccountVerifyTokenRepository,
@@ -13,8 +13,8 @@ import {
   type InactiveAccountRepository,
   inactiveAccountRepoSymbol,
   verifyTokenRepoSymbol,
-} from '../model/repository.js';
-import { VerifyToken } from '../model/verifyToken.js';
+} from '../model/repository.ts';
+import { VerifyToken } from '../model/verifyToken.ts';
 
 export class VerifyAccountTokenService {
   readonly #repository: AccountVerifyTokenRepository;

--- a/pkg/accounts/testData/testData.ts
+++ b/pkg/accounts/testData/testData.ts
@@ -1,6 +1,6 @@
 import { Result } from '@mikuroxina/mini-fn';
 
-import type { PartialAccount } from '../../intermodule/account.js';
+import type { PartialAccount } from '../../intermodule/account.ts';
 import {
   Account,
   type AccountFrozen,
@@ -9,8 +9,8 @@ import {
   type AccountRole,
   type AccountSilenced,
   type AccountStatus,
-} from '../model/account.js';
-import { AccountFollow } from '../model/follow.js';
+} from '../model/account.ts';
+import { AccountFollow } from '../model/follow.ts';
 
 /**
  * @description generate dummy account (factory function)

--- a/pkg/adaptors/authenticateMiddleware.ts
+++ b/pkg/adaptors/authenticateMiddleware.ts
@@ -2,7 +2,7 @@ import { z } from '@hono/zod-openapi';
 import { Ether, Option, Result } from '@mikuroxina/mini-fn';
 import type { MiddlewareHandler } from 'hono';
 import { createMiddleware } from 'hono/factory';
-import { controller } from '../accounts/mod.js';
+import { controller } from '../accounts/mod.ts';
 
 /* eslint-disable-next-line @typescript-eslint/consistent-type-definitions */
 export type AuthMiddlewareVariable = {

--- a/pkg/adaptors/prisma.ts
+++ b/pkg/adaptors/prisma.ts
@@ -1,5 +1,5 @@
 import { PrismaPg } from '@prisma/adapter-pg';
-import { PrismaClient } from './prisma/client.js';
+import { PrismaClient } from './prisma/client.ts';
 
 const adapter = new PrismaPg({
   connectionString: process.env.DATABASE_URL,

--- a/pkg/config/adaptor/dummy.test.ts
+++ b/pkg/config/adaptor/dummy.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
-import { Config } from '../model/config.js';
-import { DummyConfigStore } from './dummy.js';
+import { Config } from '../model/config.ts';
+import { DummyConfigStore } from './dummy.ts';
 
 const testConfig = Config.new({
   instanceName: 'Pulsate Demo Server',

--- a/pkg/config/adaptor/dummy.ts
+++ b/pkg/config/adaptor/dummy.ts
@@ -1,6 +1,6 @@
 import { Ether } from '@mikuroxina/mini-fn';
-import { type ConfigStore, configStoreSymbol } from '../mod.js';
-import type { Config } from '../model/config.js';
+import { type ConfigStore, configStoreSymbol } from '../mod.ts';
+import type { Config } from '../model/config.ts';
 
 export class DummyConfigStore implements ConfigStore {
   readonly #config: Config;

--- a/pkg/config/adaptor/local.test.ts
+++ b/pkg/config/adaptor/local.test.ts
@@ -4,8 +4,8 @@ import { join } from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
-import { ConfigInvalidError } from '../model/errors.js';
-import { LocalConfigStore } from './local.js';
+import { ConfigInvalidError } from '../model/errors.ts';
+import { LocalConfigStore } from './local.ts';
 
 describe('LocalConfigStore', () => {
   const createTempConfig = (content: string): string => {

--- a/pkg/config/adaptor/local.ts
+++ b/pkg/config/adaptor/local.ts
@@ -3,8 +3,8 @@ import { readFileSync } from 'node:fs';
 import { Ether } from '@mikuroxina/mini-fn';
 import { parse } from 'yaml';
 
-import { type ConfigStore, configStoreSymbol } from '../mod.js';
-import { type AccountName, Config } from '../model/config.js';
+import { type ConfigStore, configStoreSymbol } from '../mod.ts';
+import { type AccountName, Config } from '../model/config.ts';
 
 export class LocalConfigStore implements ConfigStore {
   readonly #config: Config;

--- a/pkg/config/mod.ts
+++ b/pkg/config/mod.ts
@@ -1,6 +1,6 @@
 import { Ether } from '@mikuroxina/mini-fn';
 
-import type { Config } from './model/config.js';
+import type { Config } from './model/config.ts';
 
 export interface ConfigStore {
   fetch(): Config;

--- a/pkg/config/model/config.test.ts
+++ b/pkg/config/model/config.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
-import { Config } from './config.js';
-import { ConfigInvalidError } from './errors.js';
+import { Config } from './config.ts';
+import { ConfigInvalidError } from './errors.ts';
 
 const validArgs = {
   instanceName: 'Pulsate Demo Server',

--- a/pkg/config/model/config.ts
+++ b/pkg/config/model/config.ts
@@ -1,4 +1,4 @@
-import { ConfigInvalidError } from './errors.js';
+import { ConfigInvalidError } from './errors.ts';
 
 export type AccountName = `@${string}@${string}`;
 

--- a/pkg/drive/adaptor/controller/drive.ts
+++ b/pkg/drive/adaptor/controller/drive.ts
@@ -1,9 +1,9 @@
 import type { z } from '@hono/zod-openapi';
 import { Option, Result } from '@mikuroxina/mini-fn';
 
-import type { AccountID } from '../../../accounts/model/account.js';
-import type { FetchMediaService } from '../../service/fetch.js';
-import type { GetDriveMediaResponseSchema } from '../validator/schema.js';
+import type { AccountID } from '../../../accounts/model/account.ts';
+import type { FetchMediaService } from '../../service/fetch.ts';
+import type { GetDriveMediaResponseSchema } from '../validator/schema.ts';
 
 export class DriveController {
   readonly #fetchService: FetchMediaService;

--- a/pkg/drive/adaptor/repository/dummy.ts
+++ b/pkg/drive/adaptor/repository/dummy.ts
@@ -1,11 +1,11 @@
 import { Ether, Option, Result } from '@mikuroxina/mini-fn';
 
-import type { AccountID } from '../../../accounts/model/account.js';
-import type { Medium, MediumID } from '../../model/medium.js';
+import type { AccountID } from '../../../accounts/model/account.ts';
+import type { Medium, MediumID } from '../../model/medium.ts';
 import {
   type MediaRepository,
   mediaRepoSymbol,
-} from '../../model/repository.js';
+} from '../../model/repository.ts';
 
 export class InMemoryMediaRepository implements MediaRepository {
   readonly #data: Map<string, Medium> = new Map();

--- a/pkg/drive/adaptor/repository/prisma.ts
+++ b/pkg/drive/adaptor/repository/prisma.ts
@@ -1,13 +1,13 @@
 import { Ether, Option, Result } from '@mikuroxina/mini-fn';
-import type { AccountID } from '../../../accounts/model/account.js';
-import { Prisma, type PrismaClient } from '../../../adaptors/prisma/client.js';
-import type { prismaClient } from '../../../adaptors/prisma.js';
-import { DriveInternalError, MediaNotFoundError } from '../../model/errors.js';
-import { Medium, type MediumID } from '../../model/medium.js';
+import type { AccountID } from '../../../accounts/model/account.ts';
+import { Prisma, type PrismaClient } from '../../../adaptors/prisma/client.ts';
+import type { prismaClient } from '../../../adaptors/prisma.ts';
+import { DriveInternalError, MediaNotFoundError } from '../../model/errors.ts';
+import { Medium, type MediumID } from '../../model/medium.ts';
 import {
   type MediaRepository,
   mediaRepoSymbol,
-} from '../../model/repository.js';
+} from '../../model/repository.ts';
 
 type MediumPrismaArgs = Awaited<
   ReturnType<typeof prismaClient.medium.findUnique>

--- a/pkg/drive/adaptor/storage/dummy.ts
+++ b/pkg/drive/adaptor/storage/dummy.ts
@@ -2,7 +2,7 @@ import * as fs from 'node:fs/promises';
 import { writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
-import type { Storage } from '../../model/storage.js';
+import type { Storage } from '../../model/storage.ts';
 
 export class LocalStorage implements Storage {
   readonly #basePath: string;

--- a/pkg/drive/mod.ts
+++ b/pkg/drive/mod.ts
@@ -1,21 +1,21 @@
 import { OpenAPIHono } from '@hono/zod-openapi';
 import { Cat, Ether, Option, Result } from '@mikuroxina/mini-fn';
 
-import type { AccountID } from '../accounts/model/account.js';
+import type { AccountID } from '../accounts/model/account.ts';
 
 import {
   AuthenticateMiddlewareService,
   type AuthMiddlewareVariable,
-} from '../adaptors/authenticateMiddleware.js';
-import { isProduction } from '../adaptors/env.js';
-import { prismaClient } from '../adaptors/prisma.js';
-import { DriveController } from './adaptor/controller/drive.js';
-import { driveModuleLogger } from './adaptor/logger.js';
-import { inMemoryMediaRepo } from './adaptor/repository/dummy.js';
-import { prismaMediaRepo } from './adaptor/repository/prisma.js';
-import { MediaNotFoundError } from './model/errors.js';
-import { GetMediaRoute } from './router.js';
-import { fetchMediaService } from './service/fetch.js';
+} from '../adaptors/authenticateMiddleware.ts';
+import { isProduction } from '../adaptors/env.ts';
+import { prismaClient } from '../adaptors/prisma.ts';
+import { DriveController } from './adaptor/controller/drive.ts';
+import { driveModuleLogger } from './adaptor/logger.ts';
+import { inMemoryMediaRepo } from './adaptor/repository/dummy.ts';
+import { prismaMediaRepo } from './adaptor/repository/prisma.ts';
+import { MediaNotFoundError } from './model/errors.ts';
+import { GetMediaRoute } from './router.ts';
+import { fetchMediaService } from './service/fetch.ts';
 
 const AuthMiddleware = new AuthenticateMiddlewareService();
 

--- a/pkg/drive/model/medium.test.ts
+++ b/pkg/drive/model/medium.test.ts
@@ -1,9 +1,9 @@
 import { Option, Result } from '@mikuroxina/mini-fn';
 import { describe, expect, it } from 'vitest';
 
-import type { AccountID } from '../../accounts/model/account.js';
-import { MediaSizeTooLargeError, MediaTypeInvalidError } from './errors.js';
-import { Medium, type MediumID } from './medium.js';
+import type { AccountID } from '../../accounts/model/account.ts';
+import { MediaSizeTooLargeError, MediaTypeInvalidError } from './errors.ts';
+import { Medium, type MediumID } from './medium.ts';
 
 const baseArgs = {
   id: '1' as MediumID,

--- a/pkg/drive/model/medium.ts
+++ b/pkg/drive/model/medium.ts
@@ -1,9 +1,9 @@
 import { type Option, Result } from '@mikuroxina/mini-fn';
 import * as v from 'valibot';
 
-import type { AccountID } from '../../accounts/model/account.js';
-import type { ID } from '../../internal/id/type.js';
-import { MediaSizeTooLargeError, MediaTypeInvalidError } from './errors.js';
+import type { AccountID } from '../../accounts/model/account.ts';
+import type { ID } from '../../internal/id/type.ts';
+import { MediaSizeTooLargeError, MediaTypeInvalidError } from './errors.ts';
 
 export type MediumID = ID<Medium>;
 

--- a/pkg/drive/model/repository.ts
+++ b/pkg/drive/model/repository.ts
@@ -1,7 +1,7 @@
 import { Ether, type Option, type Result } from '@mikuroxina/mini-fn';
 
-import type { AccountID } from '../../accounts/model/account.js';
-import type { Medium, MediumID } from './medium.js';
+import type { AccountID } from '../../accounts/model/account.ts';
+import type { Medium, MediumID } from './medium.ts';
 
 export interface MediaRepository {
   create(medium: Medium): Promise<Result.Result<Error, Medium>>;

--- a/pkg/drive/router.ts
+++ b/pkg/drive/router.ts
@@ -1,13 +1,13 @@
 import { createRoute, z } from '@hono/zod-openapi';
-import { InternalError } from '../accounts/adaptor/presenter/errors.js';
+import { InternalError } from '../accounts/adaptor/presenter/errors.ts';
 import {
   bearerAuth,
   errorResponse,
   internalErrorResponse,
   okResponse,
-} from '../internal/router/helper.js';
-import { FileNotFound } from './adaptor/presenter/errors.js';
-import { GetDriveMediaResponseSchema } from './adaptor/validator/schema.js';
+} from '../internal/router/helper.ts';
+import { FileNotFound } from './adaptor/presenter/errors.ts';
+import { GetDriveMediaResponseSchema } from './adaptor/validator/schema.ts';
 
 const driveInternalErrorSchema = z.object({ error: InternalError });
 

--- a/pkg/drive/service/fetch.test.ts
+++ b/pkg/drive/service/fetch.test.ts
@@ -1,10 +1,10 @@
 import { Option, Result } from '@mikuroxina/mini-fn';
 import { describe, expect, it } from 'vitest';
 
-import type { AccountID } from '../../accounts/model/account.js';
-import { InMemoryMediaRepository } from '../adaptor/repository/dummy.js';
-import { Medium, type MediumID } from '../model/medium.js';
-import { FetchMediaService } from './fetch.js';
+import type { AccountID } from '../../accounts/model/account.ts';
+import { InMemoryMediaRepository } from '../adaptor/repository/dummy.ts';
+import { Medium, type MediumID } from '../model/medium.ts';
+import { FetchMediaService } from './fetch.ts';
 
 describe('FetchMediaService', () => {
   const dummyMedium = Medium.reconstruct({

--- a/pkg/drive/service/fetch.ts
+++ b/pkg/drive/service/fetch.ts
@@ -1,9 +1,9 @@
 import { Ether, Option, type Result } from '@mikuroxina/mini-fn';
 
-import type { AccountID } from '../../accounts/model/account.js';
-import { MediaNotFoundError } from '../model/errors.js';
-import type { Medium, MediumID } from '../model/medium.js';
-import { type MediaRepository, mediaRepoSymbol } from '../model/repository.js';
+import type { AccountID } from '../../accounts/model/account.ts';
+import { MediaNotFoundError } from '../model/errors.ts';
+import type { Medium, MediumID } from '../model/medium.ts';
+import { type MediaRepository, mediaRepoSymbol } from '../model/repository.ts';
 
 export class FetchMediaService {
   readonly #mediaRepository: MediaRepository;

--- a/pkg/drive/service/upload.test.ts
+++ b/pkg/drive/service/upload.test.ts
@@ -2,15 +2,15 @@ import { readFile } from 'node:fs/promises';
 import { Result } from '@mikuroxina/mini-fn';
 import { describe, expect, it } from 'vitest';
 
-import type { AccountID } from '../../accounts/model/account.js';
-import { MockClock, SnowflakeIDGenerator } from '../../internal/id/mod.js';
-import { InMemoryMediaRepository } from '../adaptor/repository/dummy.js';
-import { LocalStorage } from '../adaptor/storage/dummy.js';
+import type { AccountID } from '../../accounts/model/account.ts';
+import { MockClock, SnowflakeIDGenerator } from '../../internal/id/mod.ts';
+import { InMemoryMediaRepository } from '../adaptor/repository/dummy.ts';
+import { LocalStorage } from '../adaptor/storage/dummy.ts';
 import {
   MediaSizeTooLargeError,
   MediaTypeInvalidError,
-} from '../model/errors.js';
-import { UploadMediaService } from './upload.js';
+} from '../model/errors.ts';
+import { UploadMediaService } from './upload.ts';
 
 describe('upload', () => {
   const idGenerator = new SnowflakeIDGenerator(0, new MockClock(new Date()));

--- a/pkg/drive/service/upload.ts
+++ b/pkg/drive/service/upload.ts
@@ -3,12 +3,12 @@ import { encode } from 'blurhash';
 import { fileTypeFromBuffer } from 'file-type';
 import sharp from 'sharp';
 
-import type { AccountID } from '../../accounts/model/account.js';
-import type { SnowflakeIDGenerator } from '../../internal/id/mod.js';
-import { DriveInternalError, MediaTypeInvalidError } from '../model/errors.js';
-import { Medium } from '../model/medium.js';
-import type { MediaRepository } from '../model/repository.js';
-import type { Storage } from '../model/storage.js';
+import type { AccountID } from '../../accounts/model/account.ts';
+import type { SnowflakeIDGenerator } from '../../internal/id/mod.ts';
+import { DriveInternalError, MediaTypeInvalidError } from '../model/errors.ts';
+import { Medium } from '../model/medium.ts';
+import type { MediaRepository } from '../model/repository.ts';
+import type { Storage } from '../model/storage.ts';
 
 type ProcessedImage = {
   resized: Uint8Array;

--- a/pkg/drive/testData/testData.ts
+++ b/pkg/drive/testData/testData.ts
@@ -1,7 +1,7 @@
 import { Option } from '@mikuroxina/mini-fn';
 
-import type { AccountID } from '../../accounts/model/account.js';
-import { Medium, type MediumID } from '../model/medium.js';
+import type { AccountID } from '../../accounts/model/account.ts';
+import { Medium, type MediumID } from '../model/medium.ts';
 
 export const testMedium = Medium.reconstruct({
   id: '300' as MediumID,

--- a/pkg/federation/model/actor.test.ts
+++ b/pkg/federation/model/actor.test.ts
@@ -1,9 +1,9 @@
 import { Option } from '@mikuroxina/mini-fn';
 import { describe, expect, it } from 'vitest';
-import type { AccountID } from '../../accounts/model/account.js';
-import { Actor, type ActorID } from './actor.js';
-import { ActorKeyPair, type ActorKeyPairID, type PEMKey } from './actorKey.js';
-import type { InstanceID } from './instance.js';
+import type { AccountID } from '../../accounts/model/account.ts';
+import { Actor, type ActorID } from './actor.ts';
+import { ActorKeyPair, type ActorKeyPairID, type PEMKey } from './actorKey.ts';
+import type { InstanceID } from './instance.ts';
 
 describe('Actor', () => {
   it('should create new instance', () => {

--- a/pkg/federation/model/actor.ts
+++ b/pkg/federation/model/actor.ts
@@ -1,7 +1,7 @@
-import type { AccountID } from '../../accounts/model/account.js';
-import type { ID } from '../../internal/id/type.js';
-import type { ActorKeyPair } from './actorKey.js';
-import type { InstanceID } from './instance.js';
+import type { AccountID } from '../../accounts/model/account.ts';
+import type { ID } from '../../internal/id/type.ts';
+import type { ActorKeyPair } from './actorKey.ts';
+import type { InstanceID } from './instance.ts';
 
 export type ActorID = ID<Actor>;
 

--- a/pkg/federation/model/actorKey.test.ts
+++ b/pkg/federation/model/actorKey.test.ts
@@ -1,7 +1,7 @@
 import { Option, Result } from '@mikuroxina/mini-fn';
 import { describe, expect, it } from 'vitest';
-import type { ActorID } from './actor.js';
-import { ActorKeyPair, type ActorKeyPairID, type PEMKey } from './actorKey.js';
+import type { ActorID } from './actor.ts';
+import { ActorKeyPair, type ActorKeyPairID, type PEMKey } from './actorKey.ts';
 
 describe('ActorKeyPair', () => {
   it('should create new instance', () => {

--- a/pkg/federation/model/actorKey.ts
+++ b/pkg/federation/model/actorKey.ts
@@ -1,7 +1,7 @@
 import { Option, Result } from '@mikuroxina/mini-fn';
-import type { ID } from '../../internal/id/type.js';
-import { importRSAKey } from '../cryptoLib.js';
-import type { ActorID } from './actor.js';
+import type { ID } from '../../internal/id/type.ts';
+import { importRSAKey } from '../cryptoLib.ts';
+import type { ActorID } from './actor.ts';
 
 export type ActorKeyPairID = ID<ActorKeyPair>;
 declare const PEMKeyNominal: unique symbol;

--- a/pkg/federation/model/instance.test.ts
+++ b/pkg/federation/model/instance.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { Instance, type InstanceID } from './instance.js';
+import { Instance, type InstanceID } from './instance.ts';
 
 describe('Instance', () => {
   it('should create new instance', () => {

--- a/pkg/federation/model/instance.ts
+++ b/pkg/federation/model/instance.ts
@@ -1,5 +1,5 @@
 import { Option } from '@mikuroxina/mini-fn';
-import type { ID } from '../../internal/id/type.js';
+import type { ID } from '../../internal/id/type.ts';
 
 export type InstanceID = ID<Instance>;
 /**

--- a/pkg/intermodule/account.ts
+++ b/pkg/intermodule/account.ts
@@ -1,40 +1,40 @@
 import { Cat, Ether, Option, Result } from '@mikuroxina/mini-fn';
-import { InMemoryAccountRepository } from '../accounts/adaptor/repository/dummy/account.js';
-import { inMemoryAccountAvatarRepo } from '../accounts/adaptor/repository/dummy/avatar.js';
-import { newFollowRepo } from '../accounts/adaptor/repository/dummy/follow.js';
-import { inMemoryAccountHeaderRepo } from '../accounts/adaptor/repository/dummy/header.js';
-import { prismaAccountAvatarRepo } from '../accounts/adaptor/repository/prisma/avatar.js';
-import { prismaAccountHeaderRepo } from '../accounts/adaptor/repository/prisma/header.js';
+import { InMemoryAccountRepository } from '../accounts/adaptor/repository/dummy/account.ts';
+import { inMemoryAccountAvatarRepo } from '../accounts/adaptor/repository/dummy/avatar.ts';
+import { newFollowRepo } from '../accounts/adaptor/repository/dummy/follow.ts';
+import { inMemoryAccountHeaderRepo } from '../accounts/adaptor/repository/dummy/header.ts';
+import { prismaAccountAvatarRepo } from '../accounts/adaptor/repository/prisma/avatar.ts';
+import { prismaAccountHeaderRepo } from '../accounts/adaptor/repository/prisma/header.ts';
 import {
   PrismaAccountRepository,
   prismaFollowRepo,
-} from '../accounts/adaptor/repository/prisma/prisma.js';
+} from '../accounts/adaptor/repository/prisma/prisma.ts';
 import type {
   Account,
   AccountID,
   AccountName,
-} from '../accounts/model/account.js';
-import type { AccountFollow } from '../accounts/model/follow.js';
-import { accountRepoSymbol } from '../accounts/model/repository.js';
+} from '../accounts/model/account.ts';
+import type { AccountFollow } from '../accounts/model/follow.ts';
+import { accountRepoSymbol } from '../accounts/model/repository.ts';
 import {
   type AccountAvatarService,
   accountAvatar,
-} from '../accounts/service/avatar.js';
-import type { FetchService } from '../accounts/service/fetch.js';
-import { fetch } from '../accounts/service/fetch.js';
-import type { FetchFollowService } from '../accounts/service/fetchFollow.js';
-import { fetchFollow } from '../accounts/service/fetchFollow.js';
+} from '../accounts/service/avatar.ts';
+import type { FetchService } from '../accounts/service/fetch.ts';
+import { fetch } from '../accounts/service/fetch.ts';
+import type { FetchFollowService } from '../accounts/service/fetchFollow.ts';
+import { fetchFollow } from '../accounts/service/fetchFollow.ts';
 import {
   type AccountHeaderService,
   accountHeader,
-} from '../accounts/service/header.js';
-import { dummyAccounts, dummyfollows } from '../accounts/testData/testData.js';
-import { isProduction } from '../adaptors/env.js';
-import { prismaClient } from '../adaptors/prisma.js';
-import type { Medium } from '../drive/model/medium.js';
-import { mediaModuleFacadeEther } from './media.js';
+} from '../accounts/service/header.ts';
+import { dummyAccounts, dummyfollows } from '../accounts/testData/testData.ts';
+import { isProduction } from '../adaptors/env.ts';
+import { prismaClient } from '../adaptors/prisma.ts';
+import type { Medium } from '../drive/model/medium.ts';
+import { mediaModuleFacadeEther } from './media.ts';
 
-export type { Account } from '../accounts/model/account.js';
+export type { Account } from '../accounts/model/account.ts';
 
 export interface PartialAccount {
   id: AccountID;

--- a/pkg/intermodule/media.ts
+++ b/pkg/intermodule/media.ts
@@ -1,10 +1,10 @@
 import { Ether, type Result } from '@mikuroxina/mini-fn';
-import { isProduction } from '../adaptors/env.js';
-import { prismaClient } from '../adaptors/prisma.js';
-import { InMemoryMediaRepository } from '../drive/adaptor/repository/dummy.js';
-import { PrismaMediaRepository } from '../drive/adaptor/repository/prisma.js';
-import type { Medium, MediumID } from '../drive/model/medium.js';
-import { FetchMediaService } from '../drive/service/fetch.js';
+import { isProduction } from '../adaptors/env.ts';
+import { prismaClient } from '../adaptors/prisma.ts';
+import { InMemoryMediaRepository } from '../drive/adaptor/repository/dummy.ts';
+import { PrismaMediaRepository } from '../drive/adaptor/repository/prisma.ts';
+import type { Medium, MediumID } from '../drive/model/medium.ts';
+import { FetchMediaService } from '../drive/service/fetch.ts';
 
 /**
  * Media Module facade.

--- a/pkg/intermodule/note.ts
+++ b/pkg/intermodule/note.ts
@@ -1,6 +1,6 @@
 import { Ether, type Result } from '@mikuroxina/mini-fn';
-import type { AccountID } from '../accounts/model/account.js';
-import type { Medium } from '../drive/model/medium.js';
+import type { AccountID } from '../accounts/model/account.ts';
+import type { Medium } from '../drive/model/medium.ts';
 import {
   noteAttachmentRepoEther,
   noteClockEther,
@@ -9,10 +9,10 @@ import {
   noteIdGeneratorEther,
   noteReactionRepoEther,
   noteRepoEther,
-} from '../notes/mod.js';
-import type { Note, NoteID } from '../notes/model/note.js';
-import type { Reaction } from '../notes/model/reaction.js';
-import type { RenoteStatus } from '../notes/model/renoteStatus.js';
+} from '../notes/mod.ts';
+import type { Note, NoteID } from '../notes/model/note.ts';
+import type { Reaction } from '../notes/model/reaction.ts';
+import type { RenoteStatus } from '../notes/model/renoteStatus.ts';
 
 export class NoteModuleFacade {
   readonly #fetchService: typeof noteFetchServiceInstance;

--- a/pkg/intermodule/notification.ts
+++ b/pkg/intermodule/notification.ts
@@ -1,24 +1,24 @@
 import { Cat, Ether } from '@mikuroxina/mini-fn';
-import type { AccountID } from '../accounts/model/account.js';
-import { isProduction } from '../adaptors/env.js';
-import { prismaClient } from '../adaptors/prisma.js';
-import { clockSymbol, snowflakeIDGenerator } from '../internal/id/mod.js';
-import type { NoteID } from '../notes/model/note.js';
-import type { ReactionID } from '../notes/model/reaction.js';
-import { DummyEmailSender } from '../notification/adaptor/email/dummySender.js';
-import { SmtpEmailSender } from '../notification/adaptor/email/genericSender.js';
-import { InMemoryNotificationRepository } from '../notification/adaptor/repository/dummy/notification.js';
-import { PrismaNotificationRepository } from '../notification/adaptor/repository/prisma/notification.js';
-import { emailSenderSymbol } from '../notification/model/emailSender.js';
-import { notificationRepoSymbol } from '../notification/model/repository/notification.js';
+import type { AccountID } from '../accounts/model/account.ts';
+import { isProduction } from '../adaptors/env.ts';
+import { prismaClient } from '../adaptors/prisma.ts';
+import { clockSymbol, snowflakeIDGenerator } from '../internal/id/mod.ts';
+import type { NoteID } from '../notes/model/note.ts';
+import type { ReactionID } from '../notes/model/reaction.ts';
+import { DummyEmailSender } from '../notification/adaptor/email/dummySender.ts';
+import { SmtpEmailSender } from '../notification/adaptor/email/genericSender.ts';
+import { InMemoryNotificationRepository } from '../notification/adaptor/repository/dummy/notification.ts';
+import { PrismaNotificationRepository } from '../notification/adaptor/repository/prisma/notification.ts';
+import { emailSenderSymbol } from '../notification/model/emailSender.ts';
+import { notificationRepoSymbol } from '../notification/model/repository/notification.ts';
 import {
   type CreateNotificationService,
   createNotificationService,
-} from '../notification/service/create.js';
+} from '../notification/service/create.ts';
 import {
   type SendEmailNotificationService,
   sendEmailNotificationService,
-} from '../notification/service/sendEmailNotification.js';
+} from '../notification/service/sendEmailNotification.ts';
 
 export class NotificationModuleFacade {
   readonly #createService: CreateNotificationService;

--- a/pkg/intermodule/timeline.ts
+++ b/pkg/intermodule/timeline.ts
@@ -1,16 +1,16 @@
 import { Ether, Result } from '@mikuroxina/mini-fn';
-import { isProduction } from '../adaptors/env.js';
-import { prismaClient } from '../adaptors/prisma.js';
-import { valkeyClient } from '../adaptors/valkey.js';
-import type { Note } from '../notes/model/note.js';
-import { InMemoryListRepository } from '../timeline/adaptor/repository/dummy.js';
-import { InMemoryTimelineCacheRepository } from '../timeline/adaptor/repository/dummyCache.js';
-import { PrismaListRepository } from '../timeline/adaptor/repository/prisma.js';
-import { ValkeyTimelineCacheRepository } from '../timeline/adaptor/repository/valkeyCache.js';
-import { FetchSubscribedListService } from '../timeline/service/fetchSubscribed.js';
-import { NoteVisibilityService } from '../timeline/service/noteVisibility.js';
-import { PushTimelineService } from '../timeline/service/push.js';
-import { accountModule, dummyAccountModuleFacade } from './account.js';
+import { isProduction } from '../adaptors/env.ts';
+import { prismaClient } from '../adaptors/prisma.ts';
+import { valkeyClient } from '../adaptors/valkey.ts';
+import type { Note } from '../notes/model/note.ts';
+import { InMemoryListRepository } from '../timeline/adaptor/repository/dummy.ts';
+import { InMemoryTimelineCacheRepository } from '../timeline/adaptor/repository/dummyCache.ts';
+import { PrismaListRepository } from '../timeline/adaptor/repository/prisma.ts';
+import { ValkeyTimelineCacheRepository } from '../timeline/adaptor/repository/valkeyCache.ts';
+import { FetchSubscribedListService } from '../timeline/service/fetchSubscribed.ts';
+import { NoteVisibilityService } from '../timeline/service/noteVisibility.ts';
+import { PushTimelineService } from '../timeline/service/push.ts';
+import { accountModule, dummyAccountModuleFacade } from './account.ts';
 
 export class TimelineModuleFacade {
   readonly #pushTimelineService: PushTimelineService;

--- a/pkg/internal/id/mod.test.ts
+++ b/pkg/internal/id/mod.test.ts
@@ -1,7 +1,7 @@
 import { Result } from '@mikuroxina/mini-fn';
 import { describe, expect, it } from 'vitest';
 
-import { type Clock, IDSchema, SnowflakeIDGenerator } from './mod.js';
+import { type Clock, IDSchema, SnowflakeIDGenerator } from './mod.ts';
 
 class DummyClock implements Clock {
   now(): bigint {

--- a/pkg/internal/id/mod.ts
+++ b/pkg/internal/id/mod.ts
@@ -1,8 +1,8 @@
 import { z } from '@hono/zod-openapi';
 import { Ether, Result } from '@mikuroxina/mini-fn';
 
-import { OFFSET_FROM_UNIX_EPOCH } from '../time/mod.js';
-import type { ID } from './type.js';
+import { OFFSET_FROM_UNIX_EPOCH } from '../time/mod.ts';
+import type { ID } from './type.ts';
 
 export interface Clock {
   /** @returns current time in milliseconds from Unix Epoch (1970 Jan 1st 00:00:00.000 UTC) */

--- a/pkg/internal/password/mod.test.ts
+++ b/pkg/internal/password/mod.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { Argon2idPasswordEncoder, type PasswordEncoder } from './mod.js';
+import { Argon2idPasswordEncoder, type PasswordEncoder } from './mod.ts';
 
 const encoder: PasswordEncoder = new Argon2idPasswordEncoder();
 const raw = 'じゃすた・いぐざんぽぅ';

--- a/pkg/internal/policy/policy.ts
+++ b/pkg/internal/policy/policy.ts
@@ -1,5 +1,5 @@
 import type { Result } from '@mikuroxina/mini-fn';
-import type { Account } from '../../accounts/model/account.js';
+import type { Account } from '../../accounts/model/account.ts';
 
 export type PolicyAuthorizedActionFunc<T, R> = (
   target: T,

--- a/pkg/internal/router/index.ts
+++ b/pkg/internal/router/index.ts
@@ -1,1 +1,1 @@
-export * from './helper.js';
+export * from './helper.ts';

--- a/pkg/notes/adaptor/controller/bookmark.ts
+++ b/pkg/notes/adaptor/controller/bookmark.ts
@@ -1,12 +1,12 @@
 import type { z } from '@hono/zod-openapi';
 import { Option, Result } from '@mikuroxina/mini-fn';
 
-import type { AccountID } from '../../../accounts/model/account.js';
-import type { NoteID } from '../../model/note.js';
-import type { CreateBookmarkService } from '../../service/createBookmark.js';
-import type { DeleteBookmarkService } from '../../service/deleteBookmark.js';
-import type { FetchService } from '../../service/fetch.js';
-import type { CreateBookmarkResponseSchema } from '../validator/schema.js';
+import type { AccountID } from '../../../accounts/model/account.ts';
+import type { NoteID } from '../../model/note.ts';
+import type { CreateBookmarkService } from '../../service/createBookmark.ts';
+import type { DeleteBookmarkService } from '../../service/deleteBookmark.ts';
+import type { FetchService } from '../../service/fetch.ts';
+import type { CreateBookmarkResponseSchema } from '../validator/schema.ts';
 
 export class BookmarkController {
   readonly #createBookmarkService: CreateBookmarkService;

--- a/pkg/notes/adaptor/controller/note.ts
+++ b/pkg/notes/adaptor/controller/note.ts
@@ -1,18 +1,18 @@
 import type { z } from '@hono/zod-openapi';
 import { Option, Result } from '@mikuroxina/mini-fn';
 
-import type { AccountID } from '../../../accounts/model/account.js';
-import type { MediumID } from '../../../drive/model/medium.js';
-import type { AccountModuleFacade } from '../../../intermodule/account.js';
-import type { NoteID, NoteVisibility } from '../../model/note.js';
-import type { CreateService } from '../../service/create.js';
-import type { FetchService } from '../../service/fetch.js';
-import type { RenoteService } from '../../service/renote.js';
+import type { AccountID } from '../../../accounts/model/account.ts';
+import type { MediumID } from '../../../drive/model/medium.ts';
+import type { AccountModuleFacade } from '../../../intermodule/account.ts';
+import type { NoteID, NoteVisibility } from '../../model/note.ts';
+import type { CreateService } from '../../service/create.ts';
+import type { FetchService } from '../../service/fetch.ts';
+import type { RenoteService } from '../../service/renote.ts';
 import type {
   CreateNoteResponseSchema,
   GetNoteResponseSchema,
   RenoteResponseSchema,
-} from '../validator/schema.js';
+} from '../validator/schema.ts';
 
 export class NoteController {
   readonly #createService: CreateService;

--- a/pkg/notes/adaptor/controller/reaction.ts
+++ b/pkg/notes/adaptor/controller/reaction.ts
@@ -1,11 +1,11 @@
 import type { z } from '@hono/zod-openapi';
 import { Option, Result } from '@mikuroxina/mini-fn';
-import type { AccountID } from '../../../accounts/model/account.js';
-import type { NoteID } from '../../model/note.js';
-import type { CreateReactionService } from '../../service/createReaction.js';
-import type { DeleteReactionService } from '../../service/deleteReaction.js';
-import type { FetchService } from '../../service/fetch.js';
-import type { CreateReactionResponseSchema } from '../validator/schema.js';
+import type { AccountID } from '../../../accounts/model/account.ts';
+import type { NoteID } from '../../model/note.ts';
+import type { CreateReactionService } from '../../service/createReaction.ts';
+import type { DeleteReactionService } from '../../service/deleteReaction.ts';
+import type { FetchService } from '../../service/fetch.ts';
+import type { CreateReactionResponseSchema } from '../validator/schema.ts';
 
 export class ReactionController {
   readonly #createReactionService: CreateReactionService;

--- a/pkg/notes/adaptor/repository/dummy.ts
+++ b/pkg/notes/adaptor/repository/dummy.ts
@@ -1,12 +1,12 @@
 import { Ether, Option, Result } from '@mikuroxina/mini-fn';
 
-import type { AccountID } from '../../../accounts/model/account.js';
-import type { Medium, MediumID } from '../../../drive/model/medium.js';
-import { Bookmark } from '../../model/bookmark.js';
-import { NoteNotReactedYetError } from '../../model/errors.js';
-import type { Note, NoteID } from '../../model/note.js';
-import type { Reaction, ReactionID } from '../../model/reaction.js';
-import { RenoteStatus } from '../../model/renoteStatus.js';
+import type { AccountID } from '../../../accounts/model/account.ts';
+import type { Medium, MediumID } from '../../../drive/model/medium.ts';
+import { Bookmark } from '../../model/bookmark.ts';
+import { NoteNotReactedYetError } from '../../model/errors.ts';
+import type { Note, NoteID } from '../../model/note.ts';
+import type { Reaction, ReactionID } from '../../model/reaction.ts';
+import { RenoteStatus } from '../../model/renoteStatus.ts';
 import {
   type BookmarkRepository,
   bookmarkRepoSymbol,
@@ -16,7 +16,7 @@ import {
   noteRepoSymbol,
   type ReactionRepository,
   reactionRepoSymbol,
-} from '../../model/repository.js';
+} from '../../model/repository.ts';
 
 export class InMemoryNoteRepository implements NoteRepository {
   readonly #notes: Map<NoteID, Note>;

--- a/pkg/notes/adaptor/repository/prisma/directNote.ts
+++ b/pkg/notes/adaptor/repository/prisma/directNote.ts
@@ -1,16 +1,16 @@
 import { Ether, Option, Result } from '@mikuroxina/mini-fn';
 
-import type { AccountID } from '../../../../accounts/model/account.js';
-import type { PrismaClient } from '../../../../adaptors/prisma/client.js';
-import type { prismaClient } from '../../../../adaptors/prisma.js';
-import { Medium, type MediumID } from '../../../../drive/model/medium.js';
-import { DirectNote, type DirectNoteID } from '../../../model/directNote.js';
+import type { AccountID } from '../../../../accounts/model/account.ts';
+import type { PrismaClient } from '../../../../adaptors/prisma/client.ts';
+import type { prismaClient } from '../../../../adaptors/prisma.ts';
+import { Medium, type MediumID } from '../../../../drive/model/medium.ts';
+import { DirectNote, type DirectNoteID } from '../../../model/directNote.ts';
 import {
   type DirectNoteAttachmentRepository,
   type DirectNoteRepository,
   directNoteAttachmentRepoSymbol,
   directNoteRepoSymbol,
-} from '../../../model/repository.js';
+} from '../../../model/repository.ts';
 
 type RawDirectNote = Awaited<
   ReturnType<typeof prismaClient.directNote.findUnique>

--- a/pkg/notes/adaptor/repository/prisma/note.ts
+++ b/pkg/notes/adaptor/repository/prisma/note.ts
@@ -1,15 +1,15 @@
 import { Ether, Option, Result } from '@mikuroxina/mini-fn';
-import type { AccountID } from '../../../../accounts/model/account.js';
+import type { AccountID } from '../../../../accounts/model/account.ts';
 import type {
   Prisma,
   PrismaClient,
-} from '../../../../adaptors/prisma/client.js';
-import type { prismaClient } from '../../../../adaptors/prisma.js';
-import { Medium, type MediumID } from '../../../../drive/model/medium.js';
-import { Bookmark } from '../../../model/bookmark.js';
-import { Note, type NoteID, type NoteVisibility } from '../../../model/note.js';
-import { Reaction, type ReactionID } from '../../../model/reaction.js';
-import { RenoteStatus } from '../../../model/renoteStatus.js';
+} from '../../../../adaptors/prisma/client.ts';
+import type { prismaClient } from '../../../../adaptors/prisma.ts';
+import { Medium, type MediumID } from '../../../../drive/model/medium.ts';
+import { Bookmark } from '../../../model/bookmark.ts';
+import { Note, type NoteID, type NoteVisibility } from '../../../model/note.ts';
+import { Reaction, type ReactionID } from '../../../model/reaction.ts';
+import { RenoteStatus } from '../../../model/renoteStatus.ts';
 import {
   type BookmarkRepository,
   bookmarkRepoSymbol,
@@ -19,8 +19,8 @@ import {
   noteRepoSymbol,
   type ReactionRepository,
   reactionRepoSymbol,
-} from '../../../model/repository.js';
-import { noteModuleLogger } from '../../logger.js';
+} from '../../../model/repository.ts';
+import { noteModuleLogger } from '../../logger.ts';
 
 type DeserializeNoteArgs = Awaited<
   ReturnType<typeof prismaClient.note.findUnique>

--- a/pkg/notes/mod.ts
+++ b/pkg/notes/mod.ts
@@ -1,39 +1,39 @@
 import { OpenAPIHono } from '@hono/zod-openapi';
 import { Cat, Ether, Option, Result } from '@mikuroxina/mini-fn';
 
-import type { AccountID } from '../accounts/model/account.js';
-import { AccountNotFoundError } from '../accounts/model/errors.js';
+import type { AccountID } from '../accounts/model/account.ts';
+import { AccountNotFoundError } from '../accounts/model/errors.ts';
 import {
   AuthenticateMiddlewareService,
   type AuthMiddlewareVariable,
-} from '../adaptors/authenticateMiddleware.js';
-import { isProduction } from '../adaptors/env.js';
-import { prismaClient } from '../adaptors/prisma.js';
+} from '../adaptors/authenticateMiddleware.ts';
+import { isProduction } from '../adaptors/env.ts';
+import { prismaClient } from '../adaptors/prisma.ts';
 import {
   accountModule,
   accountModuleEther,
   accountModuleFacadeSymbol,
   dummyAccountModuleFacade,
-} from '../intermodule/account.js';
-import { timelineModuleFacadeEther } from '../intermodule/timeline.js';
-import { clockSymbol, snowflakeIDGenerator } from '../internal/id/mod.js';
-import { BookmarkController } from './adaptor/controller/bookmark.js';
-import { NoteController } from './adaptor/controller/note.js';
-import { ReactionController } from './adaptor/controller/reaction.js';
-import { noteModuleLogger } from './adaptor/logger.js';
+} from '../intermodule/account.ts';
+import { timelineModuleFacadeEther } from '../intermodule/timeline.ts';
+import { clockSymbol, snowflakeIDGenerator } from '../internal/id/mod.ts';
+import { BookmarkController } from './adaptor/controller/bookmark.ts';
+import { NoteController } from './adaptor/controller/note.ts';
+import { ReactionController } from './adaptor/controller/reaction.ts';
+import { noteModuleLogger } from './adaptor/logger.ts';
 import {
   inMemoryBookmarkRepo,
   inMemoryNoteAttachmentRepo,
   inMemoryNoteRepo,
   inMemoryReactionRepo,
-} from './adaptor/repository/dummy.js';
-import { prismaDirectNoteRepo } from './adaptor/repository/prisma/directNote.js';
+} from './adaptor/repository/dummy.ts';
+import { prismaDirectNoteRepo } from './adaptor/repository/prisma/directNote.ts';
 import {
   prismaBookmarkRepo,
   prismaNoteAttachmentRepo,
   prismaNoteRepo,
   prismaReactionRepo,
-} from './adaptor/repository/prisma/note.js';
+} from './adaptor/repository/prisma/note.ts';
 import {
   NoteAccountSilencedError,
   NoteAlreadyReactedError,
@@ -44,7 +44,7 @@ import {
   NoteNotReactedYetError,
   NoteTooManyAttachmentsError,
   NoteVisibilityInvalidError,
-} from './model/errors.js';
+} from './model/errors.ts';
 import {
   CreateBookmarkRoute,
   CreateNoteRoute,
@@ -53,14 +53,14 @@ import {
   DeleteReactionRoute,
   GetNoteRoute,
   RenoteRoute,
-} from './router.js';
-import { createService } from './service/create.js';
-import { createBookmark } from './service/createBookmark.js';
-import { createReactionService } from './service/createReaction.js';
-import { deleteBookmarkService } from './service/deleteBookmark.js';
-import { deleteReaction } from './service/deleteReaction.js';
-import { fetch } from './service/fetch.js';
-import { renote } from './service/renote.js';
+} from './router.ts';
+import { createService } from './service/create.ts';
+import { createBookmark } from './service/createBookmark.ts';
+import { createReactionService } from './service/createReaction.ts';
+import { deleteBookmarkService } from './service/deleteBookmark.ts';
+import { deleteReaction } from './service/deleteReaction.ts';
+import { fetch } from './service/fetch.ts';
+import { renote } from './service/renote.ts';
 
 // NOTE: These dependency Ethers are shared between intermodule and notes module to ensure the same instances are used
 // NOTE: No in-memory fallback — DirectNote repo is Prisma-only until a dev-mode stub is introduced

--- a/pkg/notes/model/bookmark.test.ts
+++ b/pkg/notes/model/bookmark.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
-import type { AccountID } from '../../accounts/model/account.js';
-import { Bookmark, type CreateBookmarkArgs } from './bookmark.js';
-import type { NoteID } from './note.js';
+import type { AccountID } from '../../accounts/model/account.ts';
+import { Bookmark, type CreateBookmarkArgs } from './bookmark.ts';
+import type { NoteID } from './note.ts';
 
 const exampleInput: CreateBookmarkArgs = {
   noteID: '1' as NoteID,

--- a/pkg/notes/model/bookmark.ts
+++ b/pkg/notes/model/bookmark.ts
@@ -1,5 +1,5 @@
-import type { AccountID } from '../../accounts/model/account.js';
-import type { NoteID } from './note.js';
+import type { AccountID } from '../../accounts/model/account.ts';
+import type { NoteID } from './note.ts';
 
 export interface CreateBookmarkArgs {
   noteID: NoteID;

--- a/pkg/notes/model/createDomainService.test.ts
+++ b/pkg/notes/model/createDomainService.test.ts
@@ -1,8 +1,8 @@
 import { Result } from '@mikuroxina/mini-fn';
 import { describe, expect, it } from 'vitest';
 
-import { checkVisibilityForSilencedActor } from './createDomainService.js';
-import { NoteAccountSilencedError } from './errors.js';
+import { checkVisibilityForSilencedActor } from './createDomainService.ts';
+import { NoteAccountSilencedError } from './errors.ts';
 
 describe('checkVisibilityForSilencedActor', () => {
   it('rejects PUBLIC visibility for a silenced actor', () => {

--- a/pkg/notes/model/createDomainService.ts
+++ b/pkg/notes/model/createDomainService.ts
@@ -1,7 +1,7 @@
 import { Result } from '@mikuroxina/mini-fn';
 
-import { NoteAccountSilencedError } from './errors.js';
-import type { NoteVisibility } from './note.js';
+import { NoteAccountSilencedError } from './errors.ts';
+import type { NoteVisibility } from './note.ts';
 
 /**
  * Silenced accounts may still post notes, but not with PUBLIC visibility.

--- a/pkg/notes/model/directNote.test.ts
+++ b/pkg/notes/model/directNote.test.ts
@@ -1,17 +1,17 @@
 import { Option, Result } from '@mikuroxina/mini-fn';
 import { describe, expect, it } from 'vitest';
 
-import type { AccountID } from '../../accounts/model/account.js';
-import type { MediumID } from '../../drive/model/medium.js';
+import type { AccountID } from '../../accounts/model/account.ts';
+import type { MediumID } from '../../drive/model/medium.ts';
 import {
   type CreateDirectNoteArgs,
   DirectNote,
   type DirectNoteID,
-} from './directNote.js';
+} from './directNote.ts';
 import {
   DirectNoteContentLengthError,
   DirectNoteTooManyAttachmentsError,
-} from './errors.js';
+} from './errors.ts';
 
 const exampleInput: Omit<CreateDirectNoteArgs, 'deletedAt'> = {
   id: '1' as DirectNoteID,

--- a/pkg/notes/model/directNote.ts
+++ b/pkg/notes/model/directNote.ts
@@ -1,16 +1,16 @@
 import { Option, Result } from '@mikuroxina/mini-fn';
 import * as v from 'valibot';
 
-import type { AccountID } from '../../accounts/model/account.js';
-import type { MediumID } from '../../drive/model/medium.js';
-import type { ID } from '../../internal/id/type.js';
+import type { AccountID } from '../../accounts/model/account.ts';
+import type { MediumID } from '../../drive/model/medium.ts';
+import type { ID } from '../../internal/id/type.ts';
 import {
   DirectNoteContentLengthError,
   DirectNoteDateInvalidError,
   DirectNoteSelfSendError,
   DirectNoteTooManyAttachmentsError,
-} from './errors.js';
-import { cwCommentSchema, noteContentSchema } from './note.js';
+} from './errors.ts';
+import { cwCommentSchema, noteContentSchema } from './note.ts';
 
 export type DirectNoteID = ID<DirectNote>;
 

--- a/pkg/notes/model/note.test.ts
+++ b/pkg/notes/model/note.test.ts
@@ -1,14 +1,14 @@
 import { Option, Result } from '@mikuroxina/mini-fn';
 import { describe, expect, it } from 'vitest';
 
-import type { AccountID } from '../../accounts/model/account.js';
-import type { MediumID } from '../../drive/model/medium.js';
+import type { AccountID } from '../../accounts/model/account.ts';
+import type { MediumID } from '../../drive/model/medium.ts';
 import {
   NoteContentLengthError,
   NoteNoDestinationError,
   NoteTooManyAttachmentsError,
-} from './errors.js';
-import { type CreateNoteArgs, Note, type NoteID } from './note.js';
+} from './errors.ts';
+import { type CreateNoteArgs, Note, type NoteID } from './note.ts';
 
 const exampleInput: CreateNoteArgs = {
   id: '1' as NoteID,

--- a/pkg/notes/model/note.ts
+++ b/pkg/notes/model/note.ts
@@ -1,16 +1,16 @@
 import { Option, Result } from '@mikuroxina/mini-fn';
 import * as v from 'valibot';
 
-import type { AccountID } from '../../accounts/model/account.js';
-import type { MediumID } from '../../drive/model/medium.js';
-import type { ID } from '../../internal/id/type.js';
+import type { AccountID } from '../../accounts/model/account.ts';
+import type { MediumID } from '../../drive/model/medium.ts';
+import type { ID } from '../../internal/id/type.ts';
 import {
   NoteContentLengthError,
   NoteDateInvalidError,
   NoteNoDestinationError,
   NoteTooManyAttachmentsError,
   NoteVisibilityInvalidError,
-} from './errors.js';
+} from './errors.ts';
 
 export type NoteID = ID<Note>;
 export type NoteVisibility = 'PUBLIC' | 'HOME' | 'FOLLOWERS' | 'DIRECT';

--- a/pkg/notes/model/reaction.test.ts
+++ b/pkg/notes/model/reaction.test.ts
@@ -1,14 +1,14 @@
 import { Option, Result } from '@mikuroxina/mini-fn';
 import { describe, expect, it } from 'vitest';
 
-import type { AccountID } from '../../accounts/model/account.js';
-import { NoteInvalidReactionError } from './errors.js';
-import { Note, type NoteID } from './note.js';
+import type { AccountID } from '../../accounts/model/account.ts';
+import { NoteInvalidReactionError } from './errors.ts';
+import { Note, type NoteID } from './note.ts';
 import {
   type CreateReactionArgs,
   Reaction,
   type ReactionID,
-} from './reaction.js';
+} from './reaction.ts';
 
 const noteFactory = (
   id: NoteID,

--- a/pkg/notes/model/reaction.ts
+++ b/pkg/notes/model/reaction.ts
@@ -1,10 +1,10 @@
 import { Result } from '@mikuroxina/mini-fn';
 import * as v from 'valibot';
 
-import type { AccountID } from '../../accounts/model/account.js';
-import type { ID } from '../../internal/id/type.js';
-import { NoteInvalidReactionError } from './errors.js';
-import type { Note, NoteID } from './note.js';
+import type { AccountID } from '../../accounts/model/account.ts';
+import type { ID } from '../../internal/id/type.ts';
+import { NoteInvalidReactionError } from './errors.ts';
+import type { Note, NoteID } from './note.ts';
 
 const unicodeEmojiSchema = v.pipe(
   v.string(),

--- a/pkg/notes/model/reactionDomainService.ts
+++ b/pkg/notes/model/reactionDomainService.ts
@@ -1,6 +1,6 @@
 import { Option } from '@mikuroxina/mini-fn';
 
-import type { Note, NoteID } from './note.js';
+import type { Note, NoteID } from './note.ts';
 
 /**
  * Reactions on a pure renote (not a quote) are attributed to the original

--- a/pkg/notes/model/renoteDomainService.test.ts
+++ b/pkg/notes/model/renoteDomainService.test.ts
@@ -1,10 +1,10 @@
 import { Option } from '@mikuroxina/mini-fn';
 import { describe, expect, it } from 'vitest';
 
-import type { AccountID } from '../../accounts/model/account.js';
-import type { MediumID } from '../../drive/model/medium.js';
-import { Note, type NoteID } from './note.js';
-import { getRenoteChainRootID } from './renoteDomainService.js';
+import type { AccountID } from '../../accounts/model/account.ts';
+import type { MediumID } from '../../drive/model/medium.ts';
+import { Note, type NoteID } from './note.ts';
+import { getRenoteChainRootID } from './renoteDomainService.ts';
 
 const baseNoteArgs = {
   authorID: '101' as AccountID,

--- a/pkg/notes/model/renoteDomainService.ts
+++ b/pkg/notes/model/renoteDomainService.ts
@@ -1,6 +1,6 @@
 import { Option } from '@mikuroxina/mini-fn';
 
-import type { Note, NoteID } from './note.js';
+import type { Note, NoteID } from './note.ts';
 
 /**
  * Decides which Note a renote/quote targeting {@link note} should ultimately

--- a/pkg/notes/model/renoteStatus.test.ts
+++ b/pkg/notes/model/renoteStatus.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
-import type { AccountID } from '../../accounts/model/account.js';
-import type { NoteID } from './note.js';
-import { RenoteStatus } from './renoteStatus.js';
+import type { AccountID } from '../../accounts/model/account.ts';
+import type { NoteID } from './note.ts';
+import { RenoteStatus } from './renoteStatus.ts';
 
 describe('RenoteStatus', () => {
   it('create renote status with isRenoted true', () => {

--- a/pkg/notes/model/renoteStatus.ts
+++ b/pkg/notes/model/renoteStatus.ts
@@ -1,5 +1,5 @@
-import type { AccountID } from '../../accounts/model/account.js';
-import type { NoteID } from './note.js';
+import type { AccountID } from '../../accounts/model/account.ts';
+import type { NoteID } from './note.ts';
 
 export class RenoteStatus {
   readonly #actorId: AccountID;

--- a/pkg/notes/model/repository.ts
+++ b/pkg/notes/model/repository.ts
@@ -1,12 +1,12 @@
 import { Ether, type Option, type Result } from '@mikuroxina/mini-fn';
 
-import type { AccountID } from '../../accounts/model/account.js';
-import type { Medium, MediumID } from '../../drive/model/medium.js';
-import type { Bookmark } from './bookmark.js';
-import type { DirectNote, DirectNoteID } from './directNote.js';
-import type { Note, NoteID } from './note.js';
-import type { Reaction, ReactionID } from './reaction.js';
-import type { RenoteStatus } from './renoteStatus.js';
+import type { AccountID } from '../../accounts/model/account.ts';
+import type { Medium, MediumID } from '../../drive/model/medium.ts';
+import type { Bookmark } from './bookmark.ts';
+import type { DirectNote, DirectNoteID } from './directNote.ts';
+import type { Note, NoteID } from './note.ts';
+import type { Reaction, ReactionID } from './reaction.ts';
+import type { RenoteStatus } from './renoteStatus.ts';
 
 export interface NoteRepository {
   create(note: Note): Promise<Result.Result<Error, void>>;

--- a/pkg/notes/router.ts
+++ b/pkg/notes/router.ts
@@ -1,6 +1,6 @@
 import { createRoute, z } from '@hono/zod-openapi';
 
-import { AccountNotFound } from '../accounts/adaptor/presenter/errors.js';
+import { AccountNotFound } from '../accounts/adaptor/presenter/errors.ts';
 import {
   bearerAuth,
   errorResponse,
@@ -8,7 +8,7 @@ import {
   jsonBody,
   noContentResponse,
   okResponse,
-} from '../internal/router/helper.js';
+} from '../internal/router/helper.ts';
 import {
   AlreadyReacted,
   AttachmentNotFound,
@@ -21,7 +21,7 @@ import {
   TooManyAttachments,
   TooManyContent,
   YouAreSilenced,
-} from './adaptor/presenter/errors.js';
+} from './adaptor/presenter/errors.ts';
 import {
   CreateBookmarkResponseSchema,
   CreateNoteRequestSchema,
@@ -31,7 +31,7 @@ import {
   GetNoteResponseSchema,
   RenoteRequestSchema,
   RenoteResponseSchema,
-} from './adaptor/validator/schema.js';
+} from './adaptor/validator/schema.ts';
 
 const noteInternalErrorSchema = z
   .object({ error: NoteInternal })

--- a/pkg/notes/service/create.test.ts
+++ b/pkg/notes/service/create.test.ts
@@ -1,18 +1,18 @@
 import { Option, Result } from '@mikuroxina/mini-fn';
 import { describe, expect, it, vi } from 'vitest';
 
-import type { AccountID } from '../../accounts/model/account.js';
-import { Medium, type MediumID } from '../../drive/model/medium.js';
-import { dummyAccountModuleFacade } from '../../intermodule/account.js';
-import { dummyTimelineModuleFacade } from '../../intermodule/timeline.js';
-import { MockClock, SnowflakeIDGenerator } from '../../internal/id/mod.js';
-import { InMemoryTimelineCacheRepository } from '../../timeline/adaptor/repository/dummyCache.js';
+import type { AccountID } from '../../accounts/model/account.ts';
+import { Medium, type MediumID } from '../../drive/model/medium.ts';
+import { dummyAccountModuleFacade } from '../../intermodule/account.ts';
+import { dummyTimelineModuleFacade } from '../../intermodule/timeline.ts';
+import { MockClock, SnowflakeIDGenerator } from '../../internal/id/mod.ts';
+import { InMemoryTimelineCacheRepository } from '../../timeline/adaptor/repository/dummyCache.ts';
 import {
   InMemoryNoteAttachmentRepository,
   InMemoryNoteRepository,
-} from '../adaptor/repository/dummy.js';
-import { NoteAccountSilencedError } from '../model/errors.js';
-import { CreateService } from './create.js';
+} from '../adaptor/repository/dummy.ts';
+import { NoteAccountSilencedError } from '../model/errors.ts';
+import { CreateService } from './create.ts';
 
 const noteRepository = new InMemoryNoteRepository();
 const attachmentRepository = new InMemoryNoteAttachmentRepository(

--- a/pkg/notes/service/create.ts
+++ b/pkg/notes/service/create.ts
@@ -1,31 +1,31 @@
 import { Cat, Ether, Option, Promise, Result } from '@mikuroxina/mini-fn';
 
-import type { AccountID } from '../../accounts/model/account.js';
-import type { MediumID } from '../../drive/model/medium.js';
+import type { AccountID } from '../../accounts/model/account.ts';
+import type { MediumID } from '../../drive/model/medium.ts';
 import {
   type AccountModuleFacade,
   accountModuleFacadeSymbol,
-} from '../../intermodule/account.js';
+} from '../../intermodule/account.ts';
 import {
   type TimelineModuleFacade,
   timelineModuleFacadeSymbol,
-} from '../../intermodule/timeline.js';
+} from '../../intermodule/timeline.ts';
 import {
   type Clock,
   clockSymbol,
   type SnowflakeIDGenerator,
   snowflakeIDGeneratorSymbol,
-} from '../../internal/id/mod.js';
-import { checkVisibilityForSilencedActor } from '../model/createDomainService.js';
-import { NoteVisibilityInvalidError } from '../model/errors.js';
-import { Note, type NoteID, type NoteVisibility } from '../model/note.js';
+} from '../../internal/id/mod.ts';
+import { checkVisibilityForSilencedActor } from '../model/createDomainService.ts';
+import { NoteVisibilityInvalidError } from '../model/errors.ts';
+import { Note, type NoteID, type NoteVisibility } from '../model/note.ts';
 import {
   type NoteAttachmentRepository,
   type NoteRepository,
   noteAttachmentRepoSymbol,
   noteRepoSymbol,
-} from '../model/repository.js';
-import { fetchActor } from './fetchActor.js';
+} from '../model/repository.ts';
+import { fetchActor } from './fetchActor.ts';
 
 export class CreateService {
   async handle(

--- a/pkg/notes/service/createBookmark.test.ts
+++ b/pkg/notes/service/createBookmark.test.ts
@@ -1,13 +1,13 @@
 import { Option, Result } from '@mikuroxina/mini-fn';
 import { describe, expect, it } from 'vitest';
 
-import type { AccountID } from '../../accounts/model/account.js';
+import type { AccountID } from '../../accounts/model/account.ts';
 import {
   InMemoryBookmarkRepository,
   InMemoryNoteRepository,
-} from '../adaptor/repository/dummy.js';
-import { Note, type NoteID } from '../model/note.js';
-import { CreateBookmarkService } from './createBookmark.js';
+} from '../adaptor/repository/dummy.ts';
+import { Note, type NoteID } from '../model/note.ts';
+import { CreateBookmarkService } from './createBookmark.ts';
 
 const noteID = 'noteID_1' as NoteID;
 const anotherNoteID = 'noteID_2' as NoteID;

--- a/pkg/notes/service/createBookmark.ts
+++ b/pkg/notes/service/createBookmark.ts
@@ -1,17 +1,17 @@
 import { Cat, Ether, Option, Promise, Result } from '@mikuroxina/mini-fn';
 
-import type { AccountID } from '../../accounts/model/account.js';
+import type { AccountID } from '../../accounts/model/account.ts';
 import {
   NoteBookmarkAlreadyCreatedError,
   NoteNotFoundError,
-} from '../model/errors.js';
-import type { Note, NoteID } from '../model/note.js';
+} from '../model/errors.ts';
+import type { Note, NoteID } from '../model/note.ts';
 import {
   type BookmarkRepository,
   bookmarkRepoSymbol,
   type NoteRepository,
   noteRepoSymbol,
-} from '../model/repository.js';
+} from '../model/repository.ts';
 
 export class CreateBookmarkService {
   readonly #bookmarkRepository: BookmarkRepository;

--- a/pkg/notes/service/createDirect.test.ts
+++ b/pkg/notes/service/createDirect.test.ts
@@ -1,16 +1,16 @@
 import { Result } from '@mikuroxina/mini-fn';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import type { Account, AccountID } from '../../accounts/model/account.js';
-import { generateDummyAccount } from '../../accounts/testData/testData.js';
-import type { MediumID } from '../../drive/model/medium.js';
-import type { AccountModuleFacade } from '../../intermodule/account.js';
-import { MockClock, SnowflakeIDGenerator } from '../../internal/id/mod.js';
+import type { Account, AccountID } from '../../accounts/model/account.ts';
+import { generateDummyAccount } from '../../accounts/testData/testData.ts';
+import type { MediumID } from '../../drive/model/medium.ts';
+import type { AccountModuleFacade } from '../../intermodule/account.ts';
+import { MockClock, SnowflakeIDGenerator } from '../../internal/id/mod.ts';
 import type {
   DirectNoteAttachmentRepository,
   DirectNoteRepository,
-} from '../model/repository.js';
-import { CreateDirectNoteService } from './createDirect.js';
+} from '../model/repository.ts';
+import { CreateDirectNoteService } from './createDirect.ts';
 
 const author: Account = generateDummyAccount({
   id: '1' as AccountID,

--- a/pkg/notes/service/createDirect.ts
+++ b/pkg/notes/service/createDirect.ts
@@ -1,25 +1,25 @@
 import { Cat, Ether, Promise, Result } from '@mikuroxina/mini-fn';
 
-import type { AccountID } from '../../accounts/model/account.js';
-import { AccountNotFoundError } from '../../accounts/model/errors.js';
-import type { MediumID } from '../../drive/model/medium.js';
+import type { AccountID } from '../../accounts/model/account.ts';
+import { AccountNotFoundError } from '../../accounts/model/errors.ts';
+import type { MediumID } from '../../drive/model/medium.ts';
 import {
   type AccountModuleFacade,
   accountModuleFacadeSymbol,
-} from '../../intermodule/account.js';
+} from '../../intermodule/account.ts';
 import {
   type Clock,
   clockSymbol,
   type SnowflakeIDGenerator,
   snowflakeIDGeneratorSymbol,
-} from '../../internal/id/mod.js';
-import { DirectNote, type DirectNoteID } from '../model/directNote.js';
+} from '../../internal/id/mod.ts';
+import { DirectNote, type DirectNoteID } from '../model/directNote.ts';
 import {
   type DirectNoteAttachmentRepository,
   type DirectNoteRepository,
   directNoteAttachmentRepoSymbol,
   directNoteRepoSymbol,
-} from '../model/repository.js';
+} from '../model/repository.ts';
 
 export class CreateDirectNoteService {
   readonly #deps: {

--- a/pkg/notes/service/createReaction.test.ts
+++ b/pkg/notes/service/createReaction.test.ts
@@ -1,13 +1,13 @@
 import { Option, Result } from '@mikuroxina/mini-fn';
 import { afterEach, describe, expect, it } from 'vitest';
-import type { AccountID } from '../../accounts/model/account.js';
-import { MockClock, SnowflakeIDGenerator } from '../../internal/id/mod.js';
+import type { AccountID } from '../../accounts/model/account.ts';
+import { MockClock, SnowflakeIDGenerator } from '../../internal/id/mod.ts';
 import {
   InMemoryNoteRepository,
   InMemoryReactionRepository,
-} from '../adaptor/repository/dummy.js';
-import { Note, type NoteID } from '../model/note.js';
-import { CreateReactionService } from './createReaction.js';
+} from '../adaptor/repository/dummy.ts';
+import { Note, type NoteID } from '../model/note.ts';
+import { CreateReactionService } from './createReaction.ts';
 
 const idGenerator = new SnowflakeIDGenerator(1, new MockClock(new Date()));
 

--- a/pkg/notes/service/createReaction.ts
+++ b/pkg/notes/service/createReaction.ts
@@ -1,19 +1,19 @@
 import { Cat, Ether, Option, Promise, Result } from '@mikuroxina/mini-fn';
-import type { AccountID } from '../../accounts/model/account.js';
+import type { AccountID } from '../../accounts/model/account.ts';
 import {
   type SnowflakeIDGenerator,
   snowflakeIDGeneratorSymbol,
-} from '../../internal/id/mod.js';
-import { NoteNotFoundError } from '../model/errors.js';
-import type { Note, NoteID } from '../model/note.js';
-import { Reaction } from '../model/reaction.js';
-import { getReactionRedirectTargetID } from '../model/reactionDomainService.js';
+} from '../../internal/id/mod.ts';
+import { NoteNotFoundError } from '../model/errors.ts';
+import type { Note, NoteID } from '../model/note.ts';
+import { Reaction } from '../model/reaction.ts';
+import { getReactionRedirectTargetID } from '../model/reactionDomainService.ts';
 import {
   type NoteRepository,
   noteRepoSymbol,
   type ReactionRepository,
   reactionRepoSymbol,
-} from '../model/repository.js';
+} from '../model/repository.ts';
 
 export class CreateReactionService {
   readonly #idGenerator: SnowflakeIDGenerator;

--- a/pkg/notes/service/deleteBookmark.test.ts
+++ b/pkg/notes/service/deleteBookmark.test.ts
@@ -1,11 +1,11 @@
 import { Result } from '@mikuroxina/mini-fn';
 import { describe, expect, it } from 'vitest';
 
-import type { AccountID } from '../../accounts/model/account.js';
-import { InMemoryBookmarkRepository } from '../adaptor/repository/dummy.js';
-import { Bookmark } from '../model/bookmark.js';
-import type { NoteID } from '../model/note.js';
-import { DeleteBookmarkService } from './deleteBookmark.js';
+import type { AccountID } from '../../accounts/model/account.ts';
+import { InMemoryBookmarkRepository } from '../adaptor/repository/dummy.ts';
+import { Bookmark } from '../model/bookmark.ts';
+import type { NoteID } from '../model/note.ts';
+import { DeleteBookmarkService } from './deleteBookmark.ts';
 
 const noteID = '1' as NoteID;
 const accountID = '1' as AccountID;

--- a/pkg/notes/service/deleteBookmark.ts
+++ b/pkg/notes/service/deleteBookmark.ts
@@ -1,11 +1,11 @@
 import { Ether, type Result } from '@mikuroxina/mini-fn';
 
-import type { AccountID } from '../../accounts/model/account.js';
-import type { NoteID } from '../model/note.js';
+import type { AccountID } from '../../accounts/model/account.ts';
+import type { NoteID } from '../model/note.ts';
 import {
   type BookmarkRepository,
   bookmarkRepoSymbol,
-} from '../model/repository.js';
+} from '../model/repository.ts';
 
 export class DeleteBookmarkService {
   readonly #bookmarkRepository: BookmarkRepository;

--- a/pkg/notes/service/deleteReaction.test.ts
+++ b/pkg/notes/service/deleteReaction.test.ts
@@ -1,14 +1,14 @@
 import { Option, Result } from '@mikuroxina/mini-fn';
 import { describe, expect, it } from 'vitest';
-import type { AccountID } from '../../accounts/model/account.js';
+import type { AccountID } from '../../accounts/model/account.ts';
 import {
   InMemoryNoteRepository,
   InMemoryReactionRepository,
-} from '../adaptor/repository/dummy.js';
-import { NoteNotFoundError, NoteNotReactedYetError } from '../model/errors.js';
-import { Note, type NoteID } from '../model/note.js';
-import { Reaction, type ReactionID } from '../model/reaction.js';
-import { DeleteReactionService } from './deleteReaction.js';
+} from '../adaptor/repository/dummy.ts';
+import { NoteNotFoundError, NoteNotReactedYetError } from '../model/errors.ts';
+import { Note, type NoteID } from '../model/note.ts';
+import { Reaction, type ReactionID } from '../model/reaction.ts';
+import { DeleteReactionService } from './deleteReaction.ts';
 
 const noteFactory = (
   id: NoteID,

--- a/pkg/notes/service/deleteReaction.ts
+++ b/pkg/notes/service/deleteReaction.ts
@@ -1,13 +1,13 @@
 import { Cat, Ether, Option, Promise, type Result } from '@mikuroxina/mini-fn';
-import type { AccountID } from '../../accounts/model/account.js';
-import { NoteNotFoundError } from '../model/errors.js';
-import type { NoteID } from '../model/note.js';
+import type { AccountID } from '../../accounts/model/account.ts';
+import { NoteNotFoundError } from '../model/errors.ts';
+import type { NoteID } from '../model/note.ts';
 import {
   type NoteRepository,
   noteRepoSymbol,
   type ReactionRepository,
   reactionRepoSymbol,
-} from '../model/repository.js';
+} from '../model/repository.ts';
 
 export class DeleteReactionService {
   readonly #reactionRepository: ReactionRepository;

--- a/pkg/notes/service/fetch.test.ts
+++ b/pkg/notes/service/fetch.test.ts
@@ -1,18 +1,18 @@
 import { Option, Result } from '@mikuroxina/mini-fn';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { InMemoryAccountRepository } from '../../accounts/adaptor/repository/dummy/account.js';
-import { Account, type AccountID } from '../../accounts/model/account.js';
-import type { MediumID } from '../../drive/model/medium.js';
-import { testMedium, testNSFWMedium } from '../../drive/testData/testData.js';
-import { dummyAccountModuleFacade } from '../../intermodule/account.js';
+import { InMemoryAccountRepository } from '../../accounts/adaptor/repository/dummy/account.ts';
+import { Account, type AccountID } from '../../accounts/model/account.ts';
+import type { MediumID } from '../../drive/model/medium.ts';
+import { testMedium, testNSFWMedium } from '../../drive/testData/testData.ts';
+import { dummyAccountModuleFacade } from '../../intermodule/account.ts';
 import {
   InMemoryNoteAttachmentRepository,
   InMemoryNoteRepository,
   InMemoryReactionRepository,
-} from '../adaptor/repository/dummy.js';
-import { Note, type NoteID } from '../model/note.js';
-import { FetchService } from './fetch.js';
+} from '../adaptor/repository/dummy.ts';
+import { Note, type NoteID } from '../model/note.ts';
+import { FetchService } from './fetch.ts';
 
 const testNote = Result.unwrap(
   Note.new({

--- a/pkg/notes/service/fetch.ts
+++ b/pkg/notes/service/fetch.ts
@@ -1,14 +1,14 @@
 import { Cat, Ether, Option, Promise, Result } from '@mikuroxina/mini-fn';
 
-import type { AccountID } from '../../accounts/model/account.js';
-import type { Medium } from '../../drive/model/medium.js';
+import type { AccountID } from '../../accounts/model/account.ts';
+import type { Medium } from '../../drive/model/medium.ts';
 import {
   type AccountModuleFacade,
   accountModuleFacadeSymbol,
-} from '../../intermodule/account.js';
-import type { Note, NoteID } from '../model/note.js';
-import type { Reaction } from '../model/reaction.js';
-import type { RenoteStatus } from '../model/renoteStatus.js';
+} from '../../intermodule/account.ts';
+import type { Note, NoteID } from '../model/note.ts';
+import type { Reaction } from '../model/reaction.ts';
+import type { RenoteStatus } from '../model/renoteStatus.ts';
 import {
   type NoteAttachmentRepository,
   type NoteRepository,
@@ -16,7 +16,7 @@ import {
   noteRepoSymbol,
   type ReactionRepository,
   reactionRepoSymbol,
-} from '../model/repository.js';
+} from '../model/repository.ts';
 
 export class FetchService {
   readonly #noteRepository: NoteRepository;

--- a/pkg/notes/service/fetchActor.test.ts
+++ b/pkg/notes/service/fetchActor.test.ts
@@ -1,10 +1,10 @@
 import { Result } from '@mikuroxina/mini-fn';
 import { describe, expect, it } from 'vitest';
 
-import type { AccountID } from '../../accounts/model/account.js';
-import { AccountNotFoundError } from '../../accounts/model/errors.js';
-import { dummyAccountModuleFacade } from '../../intermodule/account.js';
-import { fetchActor } from './fetchActor.js';
+import type { AccountID } from '../../accounts/model/account.ts';
+import { AccountNotFoundError } from '../../accounts/model/errors.ts';
+import { dummyAccountModuleFacade } from '../../intermodule/account.ts';
+import { fetchActor } from './fetchActor.ts';
 
 describe('fetchActor', () => {
   it('returns the account when found', async () => {

--- a/pkg/notes/service/fetchActor.ts
+++ b/pkg/notes/service/fetchActor.ts
@@ -1,8 +1,8 @@
 import { Result } from '@mikuroxina/mini-fn';
 
-import type { Account, AccountID } from '../../accounts/model/account.js';
-import { AccountNotFoundError } from '../../accounts/model/errors.js';
-import type { AccountModuleFacade } from '../../intermodule/account.js';
+import type { Account, AccountID } from '../../accounts/model/account.ts';
+import { AccountNotFoundError } from '../../accounts/model/errors.ts';
+import type { AccountModuleFacade } from '../../intermodule/account.ts';
 
 /**
  * Fetches the actor account, preserving the underlying fetch failure as

--- a/pkg/notes/service/renote.test.ts
+++ b/pkg/notes/service/renote.test.ts
@@ -1,22 +1,22 @@
 import { Option, Result } from '@mikuroxina/mini-fn';
 import { describe, expect, it, vi } from 'vitest';
 
-import type { AccountID } from '../../accounts/model/account.js';
-import { Medium, type MediumID } from '../../drive/model/medium.js';
-import { dummyAccountModuleFacade } from '../../intermodule/account.js';
-import { dummyTimelineModuleFacade } from '../../intermodule/timeline.js';
-import { MockClock, SnowflakeIDGenerator } from '../../internal/id/mod.js';
-import { InMemoryTimelineCacheRepository } from '../../timeline/adaptor/repository/dummyCache.js';
+import type { AccountID } from '../../accounts/model/account.ts';
+import { Medium, type MediumID } from '../../drive/model/medium.ts';
+import { dummyAccountModuleFacade } from '../../intermodule/account.ts';
+import { dummyTimelineModuleFacade } from '../../intermodule/timeline.ts';
+import { MockClock, SnowflakeIDGenerator } from '../../internal/id/mod.ts';
+import { InMemoryTimelineCacheRepository } from '../../timeline/adaptor/repository/dummyCache.ts';
 import {
   InMemoryNoteAttachmentRepository,
   InMemoryNoteRepository,
-} from '../adaptor/repository/dummy.js';
+} from '../adaptor/repository/dummy.ts';
 import {
   NoteInsufficientPermissionError,
   NoteVisibilityInvalidError,
-} from '../model/errors.js';
-import { Note, type NoteID } from '../model/note.js';
-import { RenoteService } from './renote.js';
+} from '../model/errors.ts';
+import { Note, type NoteID } from '../model/note.ts';
+import { RenoteService } from './renote.ts';
 
 const originalNote = Note.reconstruct({
   id: '2' as NoteID,

--- a/pkg/notes/service/renote.ts
+++ b/pkg/notes/service/renote.ts
@@ -1,35 +1,35 @@
 import { Cat, Ether, Option, Promise, Result } from '@mikuroxina/mini-fn';
 
-import type { Account, AccountID } from '../../accounts/model/account.js';
-import type { MediumID } from '../../drive/model/medium.js';
+import type { Account, AccountID } from '../../accounts/model/account.ts';
+import type { MediumID } from '../../drive/model/medium.ts';
 import {
   type AccountModuleFacade,
   accountModuleFacadeSymbol,
-} from '../../intermodule/account.js';
+} from '../../intermodule/account.ts';
 import {
   type TimelineModuleFacade,
   timelineModuleFacadeSymbol,
-} from '../../intermodule/timeline.js';
+} from '../../intermodule/timeline.ts';
 import {
   type Clock,
   clockSymbol,
   type SnowflakeIDGenerator,
   snowflakeIDGeneratorSymbol,
-} from '../../internal/id/mod.js';
-import { checkVisibilityForSilencedActor } from '../model/createDomainService.js';
+} from '../../internal/id/mod.ts';
+import { checkVisibilityForSilencedActor } from '../model/createDomainService.ts';
 import {
   NoteInsufficientPermissionError,
   NoteNotFoundError,
-} from '../model/errors.js';
-import { Note, type NoteID, type NoteVisibility } from '../model/note.js';
-import { getRenoteChainRootID } from '../model/renoteDomainService.js';
+} from '../model/errors.ts';
+import { Note, type NoteID, type NoteVisibility } from '../model/note.ts';
+import { getRenoteChainRootID } from '../model/renoteDomainService.ts';
 import {
   type NoteAttachmentRepository,
   type NoteRepository,
   noteAttachmentRepoSymbol,
   noteRepoSymbol,
-} from '../model/repository.js';
-import { fetchActor } from './fetchActor.js';
+} from '../model/repository.ts';
+import { fetchActor } from './fetchActor.ts';
 
 export class RenoteService {
   readonly #deps: {

--- a/pkg/notification/adaptor/controller/notification.ts
+++ b/pkg/notification/adaptor/controller/notification.ts
@@ -1,24 +1,24 @@
 import type { z } from '@hono/zod-openapi';
 import { Option, Result } from '@mikuroxina/mini-fn';
-import type { Account, AccountID } from '../../../accounts/model/account.js';
-import type { AccountModuleFacade } from '../../../intermodule/account.js';
+import type { Account, AccountID } from '../../../accounts/model/account.ts';
+import type { AccountModuleFacade } from '../../../intermodule/account.ts';
 import type {
   MentionedNotification,
   ReactedNotification,
   RenotedNotification,
-} from '../../model/notification.js';
+} from '../../model/notification.ts';
 import type {
   Notification,
   NotificationID,
-} from '../../model/notificationBase.js';
-import type { NotificationCursor } from '../../model/repository/notification.js';
-import type { FetchNotificationService } from '../../service/fetch.js';
-import type { MarkAsReadNotificationService } from '../../service/markAsRead.js';
+} from '../../model/notificationBase.ts';
+import type { NotificationCursor } from '../../model/repository/notification.ts';
+import type { FetchNotificationService } from '../../service/fetch.ts';
+import type { MarkAsReadNotificationService } from '../../service/markAsRead.ts';
 import type {
   GetNotificationsResponseSchema,
   notificationBaseSchema,
   notificationSchema,
-} from '../validator/schemas.js';
+} from '../validator/schemas.ts';
 
 export class NotificationController {
   readonly #markAsReadService: MarkAsReadNotificationService;

--- a/pkg/notification/adaptor/email/dummySender.ts
+++ b/pkg/notification/adaptor/email/dummySender.ts
@@ -2,7 +2,7 @@ import { Ether, Result } from '@mikuroxina/mini-fn';
 import {
   type EmailSender,
   emailSenderSymbol,
-} from '../../model/emailSender.js';
+} from '../../model/emailSender.ts';
 
 export class DummyEmailSender implements EmailSender {
   async send(

--- a/pkg/notification/adaptor/email/genericSender.ts
+++ b/pkg/notification/adaptor/email/genericSender.ts
@@ -4,7 +4,7 @@ import { SmtpTransport } from '@upyo/smtp';
 import {
   type EmailSender,
   emailSenderSymbol,
-} from '../../model/emailSender.js';
+} from '../../model/emailSender.ts';
 
 export interface SmtpConfig {
   host: string;

--- a/pkg/notification/adaptor/repository/dummy/notification.test.ts
+++ b/pkg/notification/adaptor/repository/dummy/notification.test.ts
@@ -1,17 +1,17 @@
 import { Option, Result } from '@mikuroxina/mini-fn';
 import { describe, expect, it } from 'vitest';
-import type { AccountID } from '../../../../accounts/model/account.js';
-import type { NoteID } from '../../../../notes/model/note.js';
-import type { ReactionID } from '../../../../notes/model/reaction.js';
+import type { AccountID } from '../../../../accounts/model/account.ts';
+import type { NoteID } from '../../../../notes/model/note.ts';
+import type { ReactionID } from '../../../../notes/model/reaction.ts';
 import {
   FollowedNotification,
   FollowRequestedNotification,
   MentionedNotification,
   ReactedNotification,
   RenotedNotification,
-} from '../../../model/notification.js';
-import type { NotificationID } from '../../../model/notificationBase.js';
-import { InMemoryNotificationRepository } from './notification.js';
+} from '../../../model/notification.ts';
+import type { NotificationID } from '../../../model/notificationBase.ts';
+import { InMemoryNotificationRepository } from './notification.ts';
 
 describe('InMemoryNotificationRepository', () => {
   const dummyNotification1 = FollowedNotification.new({

--- a/pkg/notification/adaptor/repository/dummy/notification.ts
+++ b/pkg/notification/adaptor/repository/dummy/notification.ts
@@ -1,16 +1,16 @@
 import { Ether, Option, Result } from '@mikuroxina/mini-fn';
-import type { AccountID } from '../../../../accounts/model/account.js';
+import type { AccountID } from '../../../../accounts/model/account.ts';
 import type {
   Notification,
   NotificationID,
-} from '../../../model/notificationBase.js';
+} from '../../../model/notificationBase.ts';
 import {
   NOTIFICATION_DEFAULT_LIMIT,
   NOTIFICATION_MAX_LIMIT,
   type NotificationFilter,
   type NotificationRepository,
   notificationRepoSymbol,
-} from '../../../model/repository/notification.js';
+} from '../../../model/repository/notification.ts';
 
 export class InMemoryNotificationRepository implements NotificationRepository {
   readonly #data: Map<NotificationID, Notification>;

--- a/pkg/notification/adaptor/repository/prisma/notification.ts
+++ b/pkg/notification/adaptor/repository/prisma/notification.ts
@@ -1,11 +1,11 @@
 import { Ether, Option, Result } from '@mikuroxina/mini-fn';
-import type { AccountID } from '../../../../accounts/model/account.js';
+import type { AccountID } from '../../../../accounts/model/account.ts';
 import type {
   Prisma,
   PrismaClient,
-} from '../../../../adaptors/prisma/client.js';
-import type { NoteID } from '../../../../notes/model/note.js';
-import type { ReactionID } from '../../../../notes/model/reaction.js';
+} from '../../../../adaptors/prisma/client.ts';
+import type { NoteID } from '../../../../notes/model/note.ts';
+import type { ReactionID } from '../../../../notes/model/reaction.ts';
 import {
   FollowAcceptedNotification,
   FollowedNotification,
@@ -13,21 +13,21 @@ import {
   MentionedNotification,
   ReactedNotification,
   RenotedNotification,
-} from '../../../model/notification.js';
+} from '../../../model/notification.ts';
 import type {
   Notification,
   NotificationActorType,
   NotificationBase,
   NotificationID,
   NotificationType,
-} from '../../../model/notificationBase.js';
+} from '../../../model/notificationBase.ts';
 import {
   NOTIFICATION_DEFAULT_LIMIT,
   NOTIFICATION_MAX_LIMIT,
   type NotificationFilter,
   type NotificationRepository,
   notificationRepoSymbol,
-} from '../../../model/repository/notification.js';
+} from '../../../model/repository/notification.ts';
 
 /**
  * NOTE:

--- a/pkg/notification/mod.ts
+++ b/pkg/notification/mod.ts
@@ -3,20 +3,20 @@ import { Cat, Ether, Option, Result } from '@mikuroxina/mini-fn';
 import {
   AuthenticateMiddlewareService,
   type AuthMiddlewareVariable,
-} from '../adaptors/authenticateMiddleware.js';
-import { isProduction } from '../adaptors/env.js';
-import { prismaClient } from '../adaptors/prisma.js';
-import { accountModuleEther } from '../intermodule/account.js';
-import { clockSymbol } from '../internal/id/mod.js';
-import { NotificationController } from './adaptor/controller/notification.js';
-import { inMemoryNotificationRepo } from './adaptor/repository/dummy/notification.js';
-import { prismaNotificationRepo } from './adaptor/repository/prisma/notification.js';
+} from '../adaptors/authenticateMiddleware.ts';
+import { isProduction } from '../adaptors/env.ts';
+import { prismaClient } from '../adaptors/prisma.ts';
+import { accountModuleEther } from '../intermodule/account.ts';
+import { clockSymbol } from '../internal/id/mod.ts';
+import { NotificationController } from './adaptor/controller/notification.ts';
+import { inMemoryNotificationRepo } from './adaptor/repository/dummy/notification.ts';
+import { prismaNotificationRepo } from './adaptor/repository/prisma/notification.ts';
 import {
   GetNotificationsRoute,
   PostMakeAsReadNotificationRoute,
-} from './routes.js';
-import { fetchNotification } from './service/fetch.js';
-import { markAsReadNotification } from './service/markAsRead.js';
+} from './routes.ts';
+import { fetchNotification } from './service/fetch.ts';
+import { markAsReadNotification } from './service/markAsRead.ts';
 
 class Clock {
   now() {

--- a/pkg/notification/model/notification.test.ts
+++ b/pkg/notification/model/notification.test.ts
@@ -1,8 +1,8 @@
 import { Option } from '@mikuroxina/mini-fn';
 import { describe, expect, it } from 'vitest';
-import type { AccountID } from '../../accounts/model/account.js';
-import type { NoteID } from '../../notes/model/note.js';
-import type { ReactionID } from '../../notes/model/reaction.js';
+import type { AccountID } from '../../accounts/model/account.ts';
+import type { NoteID } from '../../notes/model/note.ts';
+import type { ReactionID } from '../../notes/model/reaction.ts';
 import {
   FollowAcceptedNotification,
   FollowedNotification,
@@ -10,8 +10,8 @@ import {
   MentionedNotification,
   ReactedNotification,
   RenotedNotification,
-} from './notification.js';
-import type { NotificationID } from './notificationBase.js';
+} from './notification.ts';
+import type { NotificationID } from './notificationBase.ts';
 
 describe('Followed', () => {
   it('should create new instance', () => {

--- a/pkg/notification/model/notification.ts
+++ b/pkg/notification/model/notification.ts
@@ -1,7 +1,7 @@
 import { Option, type Result } from '@mikuroxina/mini-fn';
-import type { AccountID } from '../../accounts/model/account.js';
-import type { NoteID } from '../../notes/model/note.js';
-import type { ReactionID } from '../../notes/model/reaction.js';
+import type { AccountID } from '../../accounts/model/account.ts';
+import type { NoteID } from '../../notes/model/note.ts';
+import type { ReactionID } from '../../notes/model/reaction.ts';
 import {
   type CreateNotificationBaseArgs,
   type Notification,
@@ -9,7 +9,7 @@ import {
   NotificationBase,
   type NotificationID,
   type NotificationType,
-} from './notificationBase.js';
+} from './notificationBase.ts';
 
 export interface CreateFollowedNotificationArgs
   extends CreateNotificationBaseArgs {

--- a/pkg/notification/model/notificationBase.ts
+++ b/pkg/notification/model/notificationBase.ts
@@ -1,6 +1,6 @@
 import { Option, Result } from '@mikuroxina/mini-fn';
-import type { AccountID } from '../../accounts/model/account.js';
-import type { ID } from '../../internal/id/type.js';
+import type { AccountID } from '../../accounts/model/account.ts';
+import type { ID } from '../../internal/id/type.ts';
 
 export type NotificationID = ID<NotificationBase>;
 export type NotificationType =

--- a/pkg/notification/model/repository/notification.ts
+++ b/pkg/notification/model/repository/notification.ts
@@ -1,6 +1,6 @@
 import { Ether, type Option, type Result } from '@mikuroxina/mini-fn';
-import type { AccountID } from '../../../accounts/model/account.js';
-import type { Notification, NotificationID } from '../notificationBase.js';
+import type { AccountID } from '../../../accounts/model/account.ts';
+import type { Notification, NotificationID } from '../notificationBase.ts';
 
 export interface NotificationFilter {
   /**

--- a/pkg/notification/routes.ts
+++ b/pkg/notification/routes.ts
@@ -2,8 +2,8 @@ import { createRoute, z } from '@hono/zod-openapi';
 import {
   NothingLeft,
   TimelineInternalError,
-} from '../timeline/adaptor/presenter/errors.js';
-import { GetNotificationsResponseSchema } from './adaptor/validator/schemas.js';
+} from '../timeline/adaptor/presenter/errors.ts';
+import { GetNotificationsResponseSchema } from './adaptor/validator/schemas.ts';
 
 export const GetNotificationsRoute = createRoute({
   method: 'get',

--- a/pkg/notification/service/create.test.ts
+++ b/pkg/notification/service/create.test.ts
@@ -1,11 +1,11 @@
 import { Result } from '@mikuroxina/mini-fn';
 import { describe, expect, it } from 'vitest';
-import type { AccountID } from '../../accounts/model/account.js';
-import { MockClock, SnowflakeIDGenerator } from '../../internal/id/mod.js';
-import type { NoteID } from '../../notes/model/note.js';
-import type { ReactionID } from '../../notes/model/reaction.js';
-import { InMemoryNotificationRepository } from '../adaptor/repository/dummy/notification.js';
-import { CreateNotificationService } from './create.js';
+import type { AccountID } from '../../accounts/model/account.ts';
+import { MockClock, SnowflakeIDGenerator } from '../../internal/id/mod.ts';
+import type { NoteID } from '../../notes/model/note.ts';
+import type { ReactionID } from '../../notes/model/reaction.ts';
+import { InMemoryNotificationRepository } from '../adaptor/repository/dummy/notification.ts';
+import { CreateNotificationService } from './create.ts';
 
 describe('CreateNotificationService', () => {
   const notificationRepository = new InMemoryNotificationRepository();

--- a/pkg/notification/service/create.ts
+++ b/pkg/notification/service/create.ts
@@ -1,13 +1,13 @@
 import { Cat, Ether, Promise, Result } from '@mikuroxina/mini-fn';
-import type { AccountID } from '../../accounts/model/account.js';
+import type { AccountID } from '../../accounts/model/account.ts';
 import {
   type Clock,
   clockSymbol,
   type SnowflakeIDGenerator,
   snowflakeIDGeneratorSymbol,
-} from '../../internal/id/mod.js';
-import type { NoteID } from '../../notes/model/note.js';
-import type { ReactionID } from '../../notes/model/reaction.js';
+} from '../../internal/id/mod.ts';
+import type { NoteID } from '../../notes/model/note.ts';
+import type { ReactionID } from '../../notes/model/reaction.ts';
 import {
   FollowAcceptedNotification,
   FollowedNotification,
@@ -15,12 +15,12 @@ import {
   MentionedNotification,
   ReactedNotification,
   RenotedNotification,
-} from '../model/notification.js';
-import type { NotificationBase } from '../model/notificationBase.js';
+} from '../model/notification.ts';
+import type { NotificationBase } from '../model/notificationBase.ts';
 import {
   type NotificationRepository,
   notificationRepoSymbol,
-} from '../model/repository/notification.js';
+} from '../model/repository/notification.ts';
 
 export class CreateNotificationService {
   readonly #idGenerator: SnowflakeIDGenerator;

--- a/pkg/notification/service/fetch.test.ts
+++ b/pkg/notification/service/fetch.test.ts
@@ -1,13 +1,13 @@
 import { Option, Result } from '@mikuroxina/mini-fn';
 import { describe, expect, it } from 'vitest';
-import type { AccountID } from '../../accounts/model/account.js';
-import { InMemoryNotificationRepository } from '../adaptor/repository/dummy/notification.js';
+import type { AccountID } from '../../accounts/model/account.ts';
+import { InMemoryNotificationRepository } from '../adaptor/repository/dummy/notification.ts';
 import {
   FollowedNotification,
   FollowRequestedNotification,
-} from '../model/notification.js';
-import type { NotificationID } from '../model/notificationBase.js';
-import { FetchNotificationService } from './fetch.js';
+} from '../model/notification.ts';
+import type { NotificationID } from '../model/notificationBase.ts';
+import { FetchNotificationService } from './fetch.ts';
 
 describe('FetchNotificationService', () => {
   const notifications = [

--- a/pkg/notification/service/fetch.ts
+++ b/pkg/notification/service/fetch.ts
@@ -1,14 +1,14 @@
 import { Cat, Ether, Promise, Result } from '@mikuroxina/mini-fn';
-import type { AccountID } from '../../accounts/model/account.js';
+import type { AccountID } from '../../accounts/model/account.ts';
 import type {
   Notification,
   NotificationID,
-} from '../model/notificationBase.js';
+} from '../model/notificationBase.ts';
 import {
   type NotificationFilter,
   type NotificationRepository,
   notificationRepoSymbol,
-} from '../model/repository/notification.js';
+} from '../model/repository/notification.ts';
 
 export class FetchNotificationService {
   readonly #notificationRepository: NotificationRepository;

--- a/pkg/notification/service/markAsRead.test.ts
+++ b/pkg/notification/service/markAsRead.test.ts
@@ -1,14 +1,14 @@
 import { Option, Result } from '@mikuroxina/mini-fn';
 import { describe, expect, it } from 'vitest';
-import type { AccountID } from '../../accounts/model/account.js';
-import { MockClock } from '../../internal/id/mod.js';
-import { InMemoryNotificationRepository } from '../adaptor/repository/dummy/notification.js';
+import type { AccountID } from '../../accounts/model/account.ts';
+import { MockClock } from '../../internal/id/mod.ts';
+import { InMemoryNotificationRepository } from '../adaptor/repository/dummy/notification.ts';
 import {
   type CreateFollowedNotificationArgs,
   FollowedNotification,
-} from '../model/notification.js';
-import type { NotificationID } from '../model/notificationBase.js';
-import { MarkAsReadNotificationService } from './markAsRead.js';
+} from '../model/notification.ts';
+import type { NotificationID } from '../model/notificationBase.ts';
+import { MarkAsReadNotificationService } from './markAsRead.ts';
 
 describe('MarkAsReadNotificationService', () => {
   const testNotificationArgs = {

--- a/pkg/notification/service/markAsRead.ts
+++ b/pkg/notification/service/markAsRead.ts
@@ -1,14 +1,14 @@
 import { Cat, Ether, Promise, Result } from '@mikuroxina/mini-fn';
-import type { AccountID } from '../../accounts/model/account.js';
-import { type Clock, clockSymbol } from '../../internal/id/mod.js';
+import type { AccountID } from '../../accounts/model/account.ts';
+import { type Clock, clockSymbol } from '../../internal/id/mod.ts';
 import type {
   Notification,
   NotificationID,
-} from '../model/notificationBase.js';
+} from '../model/notificationBase.ts';
 import {
   type NotificationRepository,
   notificationRepoSymbol,
-} from '../model/repository/notification.js';
+} from '../model/repository/notification.ts';
 
 export class MarkAsReadNotificationService {
   readonly #notificationRepository: NotificationRepository;

--- a/pkg/notification/service/sendEmailNotification.ts
+++ b/pkg/notification/service/sendEmailNotification.ts
@@ -1,5 +1,5 @@
 import { Ether, type Result } from '@mikuroxina/mini-fn';
-import { type EmailSender, emailSenderSymbol } from '../model/emailSender.js';
+import { type EmailSender, emailSenderSymbol } from '../model/emailSender.ts';
 
 export class SendEmailNotificationService {
   readonly #emailSender: EmailSender;

--- a/pkg/timeline/adaptor/controller/timeline.ts
+++ b/pkg/timeline/adaptor/controller/timeline.ts
@@ -1,30 +1,30 @@
 import type { z } from '@hono/zod-openapi';
 import { Option, Result } from '@mikuroxina/mini-fn';
 
-import type { Account, AccountID } from '../../../accounts/model/account.js';
-import type { Medium } from '../../../drive/model/medium.js';
-import type { AccountModuleFacade } from '../../../intermodule/account.js';
-import type { NoteModuleFacade } from '../../../intermodule/note.js';
-import type { Note, NoteID } from '../../../notes/model/note.js';
-import type { Reaction } from '../../../notes/model/reaction.js';
+import type { Account, AccountID } from '../../../accounts/model/account.ts';
+import type { Medium } from '../../../drive/model/medium.ts';
+import type { AccountModuleFacade } from '../../../intermodule/account.ts';
+import type { NoteModuleFacade } from '../../../intermodule/note.ts';
+import type { Note, NoteID } from '../../../notes/model/note.ts';
+import type { Reaction } from '../../../notes/model/reaction.ts';
 import {
   findRenoteStatusByNoteID,
   type RenoteStatus,
-} from '../../../notes/model/renoteStatus.js';
-import type { ListID } from '../../model/list.js';
-import type { AccountTimelineService } from '../../service/account.js';
-import type { AppendListMemberService } from '../../service/appendMember.js';
-import type { CreateListService } from '../../service/createList.js';
-import type { DeleteListService } from '../../service/deleteList.js';
-import type { EditListService } from '../../service/editList.js';
-import type { FetchBookmarkService } from '../../service/fetchBookmark.js';
-import type { FetchConversationService } from '../../service/fetchConversation.js';
-import type { FetchListService } from '../../service/fetchList.js';
-import type { FetchListMemberService } from '../../service/fetchMember.js';
-import type { HomeTimelineService } from '../../service/home.js';
-import type { ListTimelineService } from '../../service/list.js';
-import type { PublicTimelineService } from '../../service/public.js';
-import type { RemoveListMemberService } from '../../service/removeMember.js';
+} from '../../../notes/model/renoteStatus.ts';
+import type { ListID } from '../../model/list.ts';
+import type { AccountTimelineService } from '../../service/account.ts';
+import type { AppendListMemberService } from '../../service/appendMember.ts';
+import type { CreateListService } from '../../service/createList.ts';
+import type { DeleteListService } from '../../service/deleteList.ts';
+import type { EditListService } from '../../service/editList.ts';
+import type { FetchBookmarkService } from '../../service/fetchBookmark.ts';
+import type { FetchConversationService } from '../../service/fetchConversation.ts';
+import type { FetchListService } from '../../service/fetchList.ts';
+import type { FetchListMemberService } from '../../service/fetchMember.ts';
+import type { HomeTimelineService } from '../../service/home.ts';
+import type { ListTimelineService } from '../../service/list.ts';
+import type { PublicTimelineService } from '../../service/public.ts';
+import type { RemoveListMemberService } from '../../service/removeMember.ts';
 import type {
   CreateListResponseSchema,
   EditListRequestSchema,
@@ -36,7 +36,7 @@ import type {
   GetListMemberResponseSchema,
   GetListTimelineResponseSchema,
   GetPublicTimelineResponseSchema,
-} from '../validator/timeline.js';
+} from '../validator/timeline.ts';
 
 export class TimelineController {
   readonly #accountTimelineService: AccountTimelineService;

--- a/pkg/timeline/adaptor/repository/dummy.test.ts
+++ b/pkg/timeline/adaptor/repository/dummy.test.ts
@@ -1,19 +1,19 @@
 import { Option, Result } from '@mikuroxina/mini-fn';
 import { afterEach, describe, expect, it } from 'vitest';
 
-import type { AccountID } from '../../../accounts/model/account.js';
+import type { AccountID } from '../../../accounts/model/account.ts';
 import {
   DirectNote,
   type DirectNoteID,
-} from '../../../notes/model/directNote.js';
-import { Note, type NoteID } from '../../../notes/model/note.js';
-import { TimelineInvalidFilterRangeError } from '../../model/errors.js';
-import { List, type ListID } from '../../model/list.js';
+} from '../../../notes/model/directNote.ts';
+import { Note, type NoteID } from '../../../notes/model/note.ts';
+import { TimelineInvalidFilterRangeError } from '../../model/errors.ts';
+import { List, type ListID } from '../../model/list.ts';
 import {
   InMemoryConversationRepository,
   InMemoryListRepository,
   InMemoryTimelineRepository,
-} from './dummy.js';
+} from './dummy.ts';
 
 describe('InMemoryTimelineRepository', () => {
   const dummyPublicNote = Result.unwrap(

--- a/pkg/timeline/adaptor/repository/dummy.ts
+++ b/pkg/timeline/adaptor/repository/dummy.ts
@@ -1,17 +1,17 @@
 import { Ether, Result } from '@mikuroxina/mini-fn';
 
-import type { AccountID } from '../../../accounts/model/account.js';
-import { AccountNotFoundError } from '../../../accounts/model/errors.js';
-import type { NoteModuleFacade } from '../../../intermodule/note.js';
-import type { Bookmark } from '../../../notes/model/bookmark.js';
-import type { DirectNote } from '../../../notes/model/directNote.js';
-import type { Note, NoteID } from '../../../notes/model/note.js';
+import type { AccountID } from '../../../accounts/model/account.ts';
+import { AccountNotFoundError } from '../../../accounts/model/errors.ts';
+import type { NoteModuleFacade } from '../../../intermodule/note.ts';
+import type { Bookmark } from '../../../notes/model/bookmark.ts';
+import type { DirectNote } from '../../../notes/model/directNote.ts';
+import type { Note, NoteID } from '../../../notes/model/note.ts';
 import {
   ListInternalError,
   ListNotFoundError,
   TimelineInvalidFilterRangeError,
-} from '../../model/errors.js';
-import type { List, ListID } from '../../model/list.js';
+} from '../../model/errors.ts';
+import type { List, ListID } from '../../model/list.ts';
 import {
   type BookmarkTimelineFilter,
   type BookmarkTimelineRepository,
@@ -27,7 +27,7 @@ import {
   listRepoSymbol,
   type TimelineRepository,
   timelineRepoSymbol,
-} from '../../model/repository.js';
+} from '../../model/repository.ts';
 
 export class InMemoryTimelineRepository implements TimelineRepository {
   #data: Map<NoteID, Note>;

--- a/pkg/timeline/adaptor/repository/dummyCache.ts
+++ b/pkg/timeline/adaptor/repository/dummyCache.ts
@@ -1,15 +1,15 @@
 import { Ether, Result } from '@mikuroxina/mini-fn';
 
-import type { AccountID } from '../../../accounts/model/account.js';
-import { compareID } from '../../../internal/id/mod.js';
-import type { Note, NoteID } from '../../../notes/model/note.js';
-import { TimelineCacheNotFoundError } from '../../model/errors.js';
-import type { ListID } from '../../model/list.js';
+import type { AccountID } from '../../../accounts/model/account.ts';
+import { compareID } from '../../../internal/id/mod.ts';
+import type { Note, NoteID } from '../../../notes/model/note.ts';
+import { TimelineCacheNotFoundError } from '../../model/errors.ts';
+import type { ListID } from '../../model/list.ts';
 import {
   type CacheObjectKey,
   type TimelineNotesCacheRepository,
   timelineNotesCacheRepoSymbol,
-} from '../../model/repository.js';
+} from '../../model/repository.ts';
 
 export class InMemoryTimelineCacheRepository
   implements TimelineNotesCacheRepository

--- a/pkg/timeline/adaptor/repository/prisma.ts
+++ b/pkg/timeline/adaptor/repository/prisma.ts
@@ -1,22 +1,22 @@
 import { Ether, Option, Result } from '@mikuroxina/mini-fn';
-import type { AccountID } from '../../../accounts/model/account.js';
-import { Prisma, type PrismaClient } from '../../../adaptors/prisma/client.js';
-import type { prismaClient } from '../../../adaptors/prisma.js';
+import type { AccountID } from '../../../accounts/model/account.ts';
+import { Prisma, type PrismaClient } from '../../../adaptors/prisma/client.ts';
+import type { prismaClient } from '../../../adaptors/prisma.ts';
 import {
   DirectNote,
   type DirectNoteID,
-} from '../../../notes/model/directNote.js';
+} from '../../../notes/model/directNote.ts';
 import {
   Note,
   type NoteID,
   type NoteVisibility,
-} from '../../../notes/model/note.js';
+} from '../../../notes/model/note.ts';
 import {
   ListNotFoundError,
   TimelineInternalError,
   TimelineInvalidFilterRangeError,
-} from '../../model/errors.js';
-import { List, type ListID } from '../../model/list.js';
+} from '../../model/errors.ts';
+import { List, type ListID } from '../../model/list.ts';
 import {
   type BookmarkTimelineFilter,
   type BookmarkTimelineRepository,
@@ -32,7 +32,7 @@ import {
   listRepoSymbol,
   type TimelineRepository,
   timelineRepoSymbol,
-} from '../../model/repository.js';
+} from '../../model/repository.ts';
 
 export class PrismaTimelineRepository implements TimelineRepository {
   readonly #TIMELINE_NOTE_LIMIT = 20;

--- a/pkg/timeline/adaptor/repository/valkeyCache.ts
+++ b/pkg/timeline/adaptor/repository/valkeyCache.ts
@@ -1,18 +1,18 @@
 import { Ether, Result } from '@mikuroxina/mini-fn';
 import type { Redis } from 'ioredis';
 
-import type { AccountID } from '../../../accounts/model/account.js';
-import type { Note, NoteID } from '../../../notes/model/note.js';
+import type { AccountID } from '../../../accounts/model/account.ts';
+import type { Note, NoteID } from '../../../notes/model/note.ts';
 import {
   TimelineCacheNotFoundError,
   TimelineInternalError,
-} from '../../model/errors.js';
-import type { ListID } from '../../model/list.js';
+} from '../../model/errors.ts';
+import type { ListID } from '../../model/list.ts';
 import {
   type CacheObjectKey,
   type TimelineNotesCacheRepository,
   timelineNotesCacheRepoSymbol,
-} from '../../model/repository.js';
+} from '../../model/repository.ts';
 
 export class ValkeyTimelineCacheRepository
   implements TimelineNotesCacheRepository

--- a/pkg/timeline/adaptor/validator/timeline.ts
+++ b/pkg/timeline/adaptor/validator/timeline.ts
@@ -2,7 +2,7 @@ import { z } from '@hono/zod-openapi';
 import {
   noteAttachmentSchema,
   reactionSchema,
-} from '../../../notes/adaptor/validator/schema.js';
+} from '../../../notes/adaptor/validator/schema.ts';
 
 const TimelineNoteBaseSchema = z.object({
   id: z.string().openapi({

--- a/pkg/timeline/mod.ts
+++ b/pkg/timeline/mod.ts
@@ -1,37 +1,37 @@
 import { OpenAPIHono } from '@hono/zod-openapi';
 import { Cat, Ether, Option, Result } from '@mikuroxina/mini-fn';
-import type { AccountID } from '../accounts/model/account.js';
-import { AccountNotFoundError } from '../accounts/model/errors.js';
+import type { AccountID } from '../accounts/model/account.ts';
+import { AccountNotFoundError } from '../accounts/model/errors.ts';
 import {
   AuthenticateMiddlewareService,
   type AuthMiddlewareVariable,
-} from '../adaptors/authenticateMiddleware.js';
-import { prismaClient } from '../adaptors/prisma.js';
-import { valkeyClient } from '../adaptors/valkey.js';
+} from '../adaptors/authenticateMiddleware.ts';
+import { prismaClient } from '../adaptors/prisma.ts';
+import { valkeyClient } from '../adaptors/valkey.ts';
 import {
   accountModule,
   accountModuleEther,
   dummyAccountModuleFacade,
-} from '../intermodule/account.js';
-import { noteModule } from '../intermodule/note.js';
+} from '../intermodule/account.ts';
+import { noteModule } from '../intermodule/note.ts';
 import {
   listRepositoryInstance,
   timelineCacheRepositoryInstance,
-} from '../intermodule/timeline.js';
-import { clockSymbol, snowflakeIDGenerator } from '../internal/id/mod.js';
-import { TimelineController } from './adaptor/controller/timeline.js';
-import { timelineModuleLogger } from './adaptor/logger.js';
+} from '../intermodule/timeline.ts';
+import { clockSymbol, snowflakeIDGenerator } from '../internal/id/mod.ts';
+import { TimelineController } from './adaptor/controller/timeline.ts';
+import { timelineModuleLogger } from './adaptor/logger.ts';
 import {
   inMemoryBookmarkTimelineRepo,
   inMemoryConversationRepo,
   inMemoryTimelineRepo,
-} from './adaptor/repository/dummy.js';
+} from './adaptor/repository/dummy.ts';
 import {
   prismaBookmarkTimelineRepo,
   prismaConversationRepo,
   prismaTimelineRepo,
-} from './adaptor/repository/prisma.js';
-import { valkeyTimelineCacheRepo } from './adaptor/repository/valkeyCache.js';
+} from './adaptor/repository/prisma.ts';
+import { valkeyTimelineCacheRepo } from './adaptor/repository/valkeyCache.ts';
 import {
   ListNotFoundError,
   ListTitleLengthInvalidError,
@@ -39,12 +39,12 @@ import {
   TimelineBlockedByAccountError,
   TimelineInsufficientPermissionError,
   TimelineNoMoreNotesError,
-} from './model/errors.js';
+} from './model/errors.ts';
 import {
   listRepoSymbol,
   timelineNotesCacheRepoSymbol,
   timelineRepoSymbol,
-} from './model/repository.js';
+} from './model/repository.ts';
 import {
   AppendListMemberRoute,
   CreateListRoute,
@@ -59,21 +59,21 @@ import {
   GetListMemberRoute,
   GetListTimelineRoute,
   GetPublicTimelineRoute,
-} from './router.js';
-import { accountTimeline } from './service/account.js';
-import { appendListMember } from './service/appendMember.js';
-import { createList } from './service/createList.js';
-import { deleteList } from './service/deleteList.js';
-import { editList } from './service/editList.js';
-import { fetchBookmark } from './service/fetchBookmark.js';
-import { fetchConversation } from './service/fetchConversation.js';
-import { fetchList } from './service/fetchList.js';
-import { fetchListMember } from './service/fetchMember.js';
-import { homeTimeline } from './service/home.js';
-import { listTimeline } from './service/list.js';
-import { noteVisibility } from './service/noteVisibility.js';
-import { publicTimeline } from './service/public.js';
-import { removeListMember } from './service/removeMember.js';
+} from './router.ts';
+import { accountTimeline } from './service/account.ts';
+import { appendListMember } from './service/appendMember.ts';
+import { createList } from './service/createList.ts';
+import { deleteList } from './service/deleteList.ts';
+import { editList } from './service/editList.ts';
+import { fetchBookmark } from './service/fetchBookmark.ts';
+import { fetchConversation } from './service/fetchConversation.ts';
+import { fetchList } from './service/fetchList.ts';
+import { fetchListMember } from './service/fetchMember.ts';
+import { homeTimeline } from './service/home.ts';
+import { listTimeline } from './service/list.ts';
+import { noteVisibility } from './service/noteVisibility.ts';
+import { publicTimeline } from './service/public.ts';
+import { removeListMember } from './service/removeMember.ts';
 
 const isProduction = process.env.NODE_ENV === 'production';
 

--- a/pkg/timeline/model/list.test.ts
+++ b/pkg/timeline/model/list.test.ts
@@ -1,13 +1,13 @@
 import { Result } from '@mikuroxina/mini-fn';
 import { describe, expect, it } from 'vitest';
 
-import type { AccountID } from '../../accounts/model/account.js';
+import type { AccountID } from '../../accounts/model/account.ts';
 import {
   ListMemberAlreadyExistsError,
   ListTitleLengthInvalidError,
   ListTooManyMembersError,
-} from './errors.js';
-import { type CreateListArgs, List, type ListID } from './list.js';
+} from './errors.ts';
+import { type CreateListArgs, List, type ListID } from './list.ts';
 
 describe('List', () => {
   const args: CreateListArgs = {

--- a/pkg/timeline/model/list.ts
+++ b/pkg/timeline/model/list.ts
@@ -1,13 +1,13 @@
 import { Result } from '@mikuroxina/mini-fn';
 import * as v from 'valibot';
 
-import type { AccountID } from '../../accounts/model/account.js';
-import type { ID } from '../../internal/id/type.js';
+import type { AccountID } from '../../accounts/model/account.ts';
+import type { ID } from '../../internal/id/type.ts';
 import {
   ListMemberAlreadyExistsError,
   ListTitleLengthInvalidError,
   ListTooManyMembersError,
-} from './errors.js';
+} from './errors.ts';
 
 export type ListID = ID<List>;
 export type CreateListArgs = Readonly<{

--- a/pkg/timeline/model/repository.ts
+++ b/pkg/timeline/model/repository.ts
@@ -1,9 +1,9 @@
 import { Ether, type Result } from '@mikuroxina/mini-fn';
 
-import type { AccountID } from '../../accounts/model/account.js';
-import type { DirectNote, DirectNoteID } from '../../notes/model/directNote.js';
-import type { Note, NoteID } from '../../notes/model/note.js';
-import type { List, ListID } from './list.js';
+import type { AccountID } from '../../accounts/model/account.ts';
+import type { DirectNote, DirectNoteID } from '../../notes/model/directNote.ts';
+import type { Note, NoteID } from '../../notes/model/note.ts';
+import type { List, ListID } from './list.ts';
 
 export interface FetchAccountTimelineFilter {
   id: AccountID;

--- a/pkg/timeline/router.ts
+++ b/pkg/timeline/router.ts
@@ -1,6 +1,6 @@
 import { createRoute, z } from '@hono/zod-openapi';
 
-import { AccountNotFound } from '../accounts/adaptor/presenter/errors.js';
+import { AccountNotFound } from '../accounts/adaptor/presenter/errors.ts';
 import {
   bearerAuth,
   errorResponse,
@@ -8,7 +8,7 @@ import {
   jsonBody,
   noContentResponse,
   okResponse,
-} from '../internal/router/helper.js';
+} from '../internal/router/helper.ts';
 import {
   ListNotFound,
   NoPermission,
@@ -17,7 +17,7 @@ import {
   TitleTooLong,
   TooManyMembers,
   YouAreBlocked,
-} from './adaptor/presenter/errors.js';
+} from './adaptor/presenter/errors.ts';
 import {
   CreateListRequestSchema,
   CreateListResponseSchema,
@@ -30,7 +30,7 @@ import {
   GetListMemberResponseSchema,
   GetListTimelineResponseSchema,
   GetPublicTimelineResponseSchema,
-} from './adaptor/validator/timeline.js';
+} from './adaptor/validator/timeline.ts';
 
 /* NOTE: query params must use z.string() \
  cf. https://zenn.dev/loglass/articles/c237d89e238d42 (Japanese)\

--- a/pkg/timeline/service/account.test.ts
+++ b/pkg/timeline/service/account.test.ts
@@ -1,13 +1,13 @@
 import { Option, Result } from '@mikuroxina/mini-fn';
 import { describe, expect, it, vi } from 'vitest';
 
-import { Account, type AccountID } from '../../accounts/model/account.js';
-import type { PartialAccount } from '../../intermodule/account.js';
-import { dummyAccountModuleFacade } from '../../intermodule/account.js';
-import { Note, type NoteID } from '../../notes/model/note.js';
-import { InMemoryTimelineRepository } from '../adaptor/repository/dummy.js';
-import { AccountTimelineService } from './account.js';
-import { NoteVisibilityService } from './noteVisibility.js';
+import { Account, type AccountID } from '../../accounts/model/account.ts';
+import type { PartialAccount } from '../../intermodule/account.ts';
+import { dummyAccountModuleFacade } from '../../intermodule/account.ts';
+import { Note, type NoteID } from '../../notes/model/note.ts';
+import { InMemoryTimelineRepository } from '../adaptor/repository/dummy.ts';
+import { AccountTimelineService } from './account.ts';
+import { NoteVisibilityService } from './noteVisibility.ts';
 
 describe('AccountTimelineService', () => {
   const noteVisibilityService = new NoteVisibilityService(

--- a/pkg/timeline/service/account.ts
+++ b/pkg/timeline/service/account.ts
@@ -1,16 +1,16 @@
 import { Ether, Result } from '@mikuroxina/mini-fn';
 
-import type { AccountID } from '../../accounts/model/account.js';
-import type { Note } from '../../notes/model/note.js';
+import type { AccountID } from '../../accounts/model/account.ts';
+import type { Note } from '../../notes/model/note.ts';
 import {
   type FetchAccountTimelineFilter,
   type TimelineRepository,
   timelineRepoSymbol,
-} from '../model/repository.js';
+} from '../model/repository.ts';
 import {
   type NoteVisibilityService,
   noteVisibilitySymbol,
-} from './noteVisibility.js';
+} from './noteVisibility.ts';
 
 export class AccountTimelineService {
   readonly #noteVisibilityService: NoteVisibilityService;

--- a/pkg/timeline/service/appendMember.test.ts
+++ b/pkg/timeline/service/appendMember.test.ts
@@ -1,14 +1,14 @@
 import { Result } from '@mikuroxina/mini-fn';
 import { beforeEach, describe, expect, it } from 'vitest';
-import type { AccountID } from '../../accounts/model/account.js';
-import { InMemoryListRepository } from '../adaptor/repository/dummy.js';
+import type { AccountID } from '../../accounts/model/account.ts';
+import { InMemoryListRepository } from '../adaptor/repository/dummy.ts';
 import {
   ListNotFoundError,
   ListTooManyMembersError,
   TimelineInsufficientPermissionError,
-} from '../model/errors.js';
-import { List, type ListID } from '../model/list.js';
-import { AppendListMemberService } from './appendMember.js';
+} from '../model/errors.ts';
+import { List, type ListID } from '../model/list.ts';
+import { AppendListMemberService } from './appendMember.ts';
 
 describe('AppendListMemberService', () => {
   const listData = [

--- a/pkg/timeline/service/appendMember.ts
+++ b/pkg/timeline/service/appendMember.ts
@@ -1,11 +1,11 @@
 import { Cat, Ether, Promise, Result } from '@mikuroxina/mini-fn';
-import type { AccountID } from '../../accounts/model/account.js';
+import type { AccountID } from '../../accounts/model/account.ts';
 import {
   ListNotFoundError,
   TimelineInsufficientPermissionError,
-} from '../model/errors.js';
-import type { List, ListID } from '../model/list.js';
-import { type ListRepository, listRepoSymbol } from '../model/repository.js';
+} from '../model/errors.ts';
+import type { List, ListID } from '../model/list.ts';
+import { type ListRepository, listRepoSymbol } from '../model/repository.ts';
 
 export class AppendListMemberService {
   readonly #listRepository: ListRepository;

--- a/pkg/timeline/service/createList.test.ts
+++ b/pkg/timeline/service/createList.test.ts
@@ -1,10 +1,10 @@
 import { Result } from '@mikuroxina/mini-fn';
 import { describe, expect, it } from 'vitest';
 
-import type { AccountID } from '../../accounts/model/account.js';
-import { MockClock, SnowflakeIDGenerator } from '../../internal/id/mod.js';
-import { InMemoryListRepository } from '../adaptor/repository/dummy.js';
-import { CreateListService } from './createList.js';
+import type { AccountID } from '../../accounts/model/account.ts';
+import { MockClock, SnowflakeIDGenerator } from '../../internal/id/mod.ts';
+import { InMemoryListRepository } from '../adaptor/repository/dummy.ts';
+import { CreateListService } from './createList.ts';
 
 describe('CreateListService', () => {
   const repository = new InMemoryListRepository();

--- a/pkg/timeline/service/createList.ts
+++ b/pkg/timeline/service/createList.ts
@@ -1,14 +1,14 @@
 import { Cat, Ether, Promise, type Result } from '@mikuroxina/mini-fn';
 
-import type { AccountID } from '../../accounts/model/account.js';
+import type { AccountID } from '../../accounts/model/account.ts';
 import {
   type Clock,
   clockSymbol,
   type SnowflakeIDGenerator,
   snowflakeIDGeneratorSymbol,
-} from '../../internal/id/mod.js';
-import { List } from '../model/list.js';
-import { type ListRepository, listRepoSymbol } from '../model/repository.js';
+} from '../../internal/id/mod.ts';
+import { List } from '../model/list.ts';
+import { type ListRepository, listRepoSymbol } from '../model/repository.ts';
 
 export class CreateListService {
   readonly #idGenerator: SnowflakeIDGenerator;

--- a/pkg/timeline/service/deleteList.test.ts
+++ b/pkg/timeline/service/deleteList.test.ts
@@ -1,9 +1,9 @@
 import { Result } from '@mikuroxina/mini-fn';
 import { describe, expect, it } from 'vitest';
-import type { AccountID } from '../../accounts/model/account.js';
-import { InMemoryListRepository } from '../adaptor/repository/dummy.js';
-import { List, type ListID } from '../model/list.js';
-import { DeleteListService } from './deleteList.js';
+import type { AccountID } from '../../accounts/model/account.ts';
+import { InMemoryListRepository } from '../adaptor/repository/dummy.ts';
+import { List, type ListID } from '../model/list.ts';
+import { DeleteListService } from './deleteList.ts';
 
 const testList = List.reconstruct({
   id: '1' as ListID,

--- a/pkg/timeline/service/deleteList.ts
+++ b/pkg/timeline/service/deleteList.ts
@@ -1,7 +1,7 @@
 import { Ether, Result } from '@mikuroxina/mini-fn';
-import type { ID } from '../../internal/id/type.js';
-import type { List } from '../model/list.js';
-import { type ListRepository, listRepoSymbol } from '../model/repository.js';
+import type { ID } from '../../internal/id/type.ts';
+import type { List } from '../model/list.ts';
+import { type ListRepository, listRepoSymbol } from '../model/repository.ts';
 
 export class DeleteListService {
   readonly #listRepository: ListRepository;

--- a/pkg/timeline/service/editList.test.ts
+++ b/pkg/timeline/service/editList.test.ts
@@ -1,10 +1,10 @@
 import { Result } from '@mikuroxina/mini-fn';
 import { beforeEach, describe, expect, it } from 'vitest';
-import type { AccountID } from '../../accounts/model/account.js';
-import { InMemoryListRepository } from '../adaptor/repository/dummy.js';
-import { ListTitleLengthInvalidError } from '../model/errors.js';
-import { type CreateListArgs, List, type ListID } from '../model/list.js';
-import { EditListService } from './editList.js';
+import type { AccountID } from '../../accounts/model/account.ts';
+import { InMemoryListRepository } from '../adaptor/repository/dummy.ts';
+import { ListTitleLengthInvalidError } from '../model/errors.ts';
+import { type CreateListArgs, List, type ListID } from '../model/list.ts';
+import { EditListService } from './editList.ts';
 
 const testListData: CreateListArgs = {
   id: '1' as ListID,

--- a/pkg/timeline/service/editList.ts
+++ b/pkg/timeline/service/editList.ts
@@ -1,7 +1,7 @@
 import { Cat, Ether, Promise, type Result } from '@mikuroxina/mini-fn';
-import type { ID } from '../../internal/id/type.js';
-import type { List } from '../model/list.js';
-import { type ListRepository, listRepoSymbol } from '../model/repository.js';
+import type { ID } from '../../internal/id/type.ts';
+import type { List } from '../model/list.ts';
+import { type ListRepository, listRepoSymbol } from '../model/repository.ts';
 
 export class EditListService {
   readonly #listRepository: ListRepository;

--- a/pkg/timeline/service/fetchBookmark.test.ts
+++ b/pkg/timeline/service/fetchBookmark.test.ts
@@ -1,14 +1,14 @@
 import { Result } from '@mikuroxina/mini-fn';
 import { describe, expect, it } from 'vitest';
 
-import type { AccountID } from '../../accounts/model/account.js';
-import { Bookmark } from '../../notes/model/bookmark.js';
-import type { NoteID } from '../../notes/model/note.js';
+import type { AccountID } from '../../accounts/model/account.ts';
+import { Bookmark } from '../../notes/model/bookmark.ts';
+import type { NoteID } from '../../notes/model/note.ts';
 import {
   InMemoryBookmarkTimelineRepository,
   InMemoryTimelineRepository,
-} from '../adaptor/repository/dummy.js';
-import { FetchBookmarkService } from './fetchBookmark.js';
+} from '../adaptor/repository/dummy.ts';
+import { FetchBookmarkService } from './fetchBookmark.ts';
 
 const bookmarks = [
   Bookmark.new({

--- a/pkg/timeline/service/fetchBookmark.ts
+++ b/pkg/timeline/service/fetchBookmark.ts
@@ -1,14 +1,14 @@
 import { Ether, type Result } from '@mikuroxina/mini-fn';
 
-import type { AccountID } from '../../accounts/model/account.js';
-import type { Note, NoteID } from '../../notes/model/note.js';
+import type { AccountID } from '../../accounts/model/account.ts';
+import type { Note, NoteID } from '../../notes/model/note.ts';
 import {
   type BookmarkTimelineFilter,
   type BookmarkTimelineRepository,
   bookmarkTimelineRepoSymbol,
   type TimelineRepository,
   timelineRepoSymbol,
-} from '../model/repository.js';
+} from '../model/repository.ts';
 
 export class FetchBookmarkService {
   readonly #bookmarkRepository: BookmarkTimelineRepository;

--- a/pkg/timeline/service/fetchConversation.test.ts
+++ b/pkg/timeline/service/fetchConversation.test.ts
@@ -1,10 +1,10 @@
 import { Option, Result } from '@mikuroxina/mini-fn';
 import { describe, expect, it } from 'vitest';
 
-import type { AccountID } from '../../accounts/model/account.js';
-import { DirectNote, type DirectNoteID } from '../../notes/model/directNote.js';
-import { InMemoryConversationRepository } from '../adaptor/repository/dummy.js';
-import { FetchConversationService } from './fetchConversation.js';
+import type { AccountID } from '../../accounts/model/account.ts';
+import { DirectNote, type DirectNoteID } from '../../notes/model/directNote.ts';
+import { InMemoryConversationRepository } from '../adaptor/repository/dummy.ts';
+import { FetchConversationService } from './fetchConversation.ts';
 
 const directNoteFactory = (
   id: DirectNoteID,

--- a/pkg/timeline/service/fetchConversation.ts
+++ b/pkg/timeline/service/fetchConversation.ts
@@ -1,14 +1,14 @@
 import { Ether, Option, Result } from '@mikuroxina/mini-fn';
 
-import type { AccountID } from '../../accounts/model/account.js';
-import type { DirectNote, DirectNoteID } from '../../notes/model/directNote.js';
-import { TimelineInvalidFilterRangeError } from '../model/errors.js';
+import type { AccountID } from '../../accounts/model/account.ts';
+import type { DirectNote, DirectNoteID } from '../../notes/model/directNote.ts';
+import { TimelineInvalidFilterRangeError } from '../model/errors.ts';
 import {
   type ConversationNotesFilter,
   type ConversationRecipient,
   type ConversationRepository,
   conversationRepoSymbol,
-} from '../model/repository.js';
+} from '../model/repository.ts';
 
 export interface FetchConversationNotesArgs {
   limit: Option.Option<number>;

--- a/pkg/timeline/service/fetchList.test.ts
+++ b/pkg/timeline/service/fetchList.test.ts
@@ -1,9 +1,9 @@
 import { Result } from '@mikuroxina/mini-fn';
 import { describe, expect, it } from 'vitest';
-import type { AccountID } from '../../accounts/model/account.js';
-import { InMemoryListRepository } from '../adaptor/repository/dummy.js';
-import { List, type ListID } from '../model/list.js';
-import { FetchListService } from './fetchList.js';
+import type { AccountID } from '../../accounts/model/account.ts';
+import { InMemoryListRepository } from '../adaptor/repository/dummy.ts';
+import { List, type ListID } from '../model/list.ts';
+import { FetchListService } from './fetchList.ts';
 
 const repository = new InMemoryListRepository([
   List.reconstruct({

--- a/pkg/timeline/service/fetchList.ts
+++ b/pkg/timeline/service/fetchList.ts
@@ -1,6 +1,6 @@
 import { Ether, type Result } from '@mikuroxina/mini-fn';
-import type { List, ListID } from '../model/list.js';
-import { type ListRepository, listRepoSymbol } from '../model/repository.js';
+import type { List, ListID } from '../model/list.ts';
+import { type ListRepository, listRepoSymbol } from '../model/repository.ts';
 
 export class FetchListService {
   readonly #listRepository: ListRepository;

--- a/pkg/timeline/service/fetchMember.test.ts
+++ b/pkg/timeline/service/fetchMember.test.ts
@@ -1,11 +1,11 @@
 import { Result } from '@mikuroxina/mini-fn';
 import { describe, expect, it, vi } from 'vitest';
-import type { AccountID } from '../../accounts/model/account.js';
-import { dummyAccounts } from '../../accounts/testData/testData.js';
-import { dummyAccountModuleFacade } from '../../intermodule/account.js';
-import { InMemoryListRepository } from '../adaptor/repository/dummy.js';
-import { List, type ListID } from '../model/list.js';
-import { FetchListMemberService } from './fetchMember.js';
+import type { AccountID } from '../../accounts/model/account.ts';
+import { dummyAccounts } from '../../accounts/testData/testData.ts';
+import { dummyAccountModuleFacade } from '../../intermodule/account.ts';
+import { InMemoryListRepository } from '../adaptor/repository/dummy.ts';
+import { List, type ListID } from '../model/list.ts';
+import { FetchListMemberService } from './fetchMember.ts';
 
 describe('FetchListMemberService', () => {
   const dummyListData = List.reconstruct({

--- a/pkg/timeline/service/fetchMember.ts
+++ b/pkg/timeline/service/fetchMember.ts
@@ -3,9 +3,9 @@ import {
   type Account,
   type AccountModuleFacade,
   accountModuleFacadeSymbol,
-} from '../../intermodule/account.js';
-import type { ListID } from '../model/list.js';
-import { type ListRepository, listRepoSymbol } from '../model/repository.js';
+} from '../../intermodule/account.ts';
+import type { ListID } from '../model/list.ts';
+import { type ListRepository, listRepoSymbol } from '../model/repository.ts';
 
 export class FetchListMemberService {
   readonly #listRepository: ListRepository;

--- a/pkg/timeline/service/fetchSubscribed.test.ts
+++ b/pkg/timeline/service/fetchSubscribed.test.ts
@@ -1,9 +1,9 @@
 import { Result } from '@mikuroxina/mini-fn';
 import { describe, expect, it } from 'vitest';
-import type { AccountID } from '../../accounts/model/account.js';
-import { InMemoryListRepository } from '../adaptor/repository/dummy.js';
-import { List, type ListID } from '../model/list.js';
-import { FetchSubscribedListService } from './fetchSubscribed.js';
+import type { AccountID } from '../../accounts/model/account.ts';
+import { InMemoryListRepository } from '../adaptor/repository/dummy.ts';
+import { List, type ListID } from '../model/list.ts';
+import { FetchSubscribedListService } from './fetchSubscribed.ts';
 
 describe('FetchSubscribedListService', () => {
   const dummyList = List.reconstruct({

--- a/pkg/timeline/service/fetchSubscribed.ts
+++ b/pkg/timeline/service/fetchSubscribed.ts
@@ -1,7 +1,7 @@
 import { Promise, type Result } from '@mikuroxina/mini-fn';
-import type { AccountID } from '../../accounts/model/account.js';
-import type { List, ListID } from '../model/list.js';
-import type { ListRepository } from '../model/repository.js';
+import type { AccountID } from '../../accounts/model/account.ts';
+import type { List, ListID } from '../model/list.ts';
+import type { ListRepository } from '../model/repository.ts';
 
 export class FetchSubscribedListService {
   readonly #listRepository: ListRepository;

--- a/pkg/timeline/service/home.test.ts
+++ b/pkg/timeline/service/home.test.ts
@@ -1,17 +1,17 @@
 import { Result } from '@mikuroxina/mini-fn';
 import { describe, expect, it } from 'vitest';
 
-import type { AccountID } from '../../accounts/model/account.js';
-import type { NoteID } from '../../notes/model/note.js';
-import { InMemoryTimelineRepository } from '../adaptor/repository/dummy.js';
-import { InMemoryTimelineCacheRepository } from '../adaptor/repository/dummyCache.js';
+import type { AccountID } from '../../accounts/model/account.ts';
+import type { NoteID } from '../../notes/model/note.ts';
+import { InMemoryTimelineRepository } from '../adaptor/repository/dummy.ts';
+import { InMemoryTimelineCacheRepository } from '../adaptor/repository/dummyCache.ts';
 import {
   dummyDirectNote,
   dummyFollowersNote,
   dummyHomeNote,
   dummyPublicNote,
-} from '../testData/testData.js';
-import { HomeTimelineService } from './home.js';
+} from '../testData/testData.ts';
+import { HomeTimelineService } from './home.ts';
 
 describe('HomeTimelineService', () => {
   const timelineCacheRepository = new InMemoryTimelineCacheRepository([

--- a/pkg/timeline/service/home.ts
+++ b/pkg/timeline/service/home.ts
@@ -1,15 +1,15 @@
 import { Ether, Result } from '@mikuroxina/mini-fn';
 
-import type { AccountID } from '../../accounts/model/account.js';
-import type { Note } from '../../notes/model/note.js';
-import { timelineModuleLogger } from '../adaptor/logger.js';
+import type { AccountID } from '../../accounts/model/account.ts';
+import type { Note } from '../../notes/model/note.ts';
+import { timelineModuleLogger } from '../adaptor/logger.ts';
 import {
   type FetchHomeTimelineFilter,
   type TimelineNotesCacheRepository,
   type TimelineRepository,
   timelineNotesCacheRepoSymbol,
   timelineRepoSymbol,
-} from '../model/repository.js';
+} from '../model/repository.ts';
 
 export class HomeTimelineService {
   readonly #timelineCacheRepository: TimelineNotesCacheRepository;

--- a/pkg/timeline/service/list.test.ts
+++ b/pkg/timeline/service/list.test.ts
@@ -1,15 +1,15 @@
 import { Result } from '@mikuroxina/mini-fn';
 import { describe, expect, it } from 'vitest';
-import { InMemoryTimelineRepository } from '../adaptor/repository/dummy.js';
-import { InMemoryTimelineCacheRepository } from '../adaptor/repository/dummyCache.js';
-import type { ListID } from '../model/list.js';
+import { InMemoryTimelineRepository } from '../adaptor/repository/dummy.ts';
+import { InMemoryTimelineCacheRepository } from '../adaptor/repository/dummyCache.ts';
+import type { ListID } from '../model/list.ts';
 import {
   dummyDirectNote,
   dummyFollowersNote,
   dummyHomeNote,
   dummyPublicNote,
-} from '../testData/testData.js';
-import { ListTimelineService } from './list.js';
+} from '../testData/testData.ts';
+import { ListTimelineService } from './list.ts';
 
 describe('ListTimelineService', () => {
   const cache = new InMemoryTimelineCacheRepository();

--- a/pkg/timeline/service/list.ts
+++ b/pkg/timeline/service/list.ts
@@ -1,14 +1,14 @@
 import { Ether, Result } from '@mikuroxina/mini-fn';
-import type { Note } from '../../notes/model/note.js';
-import { timelineModuleLogger } from '../adaptor/logger.js';
-import type { ListID } from '../model/list.js';
+import type { Note } from '../../notes/model/note.ts';
+import { timelineModuleLogger } from '../adaptor/logger.ts';
+import type { ListID } from '../model/list.ts';
 import {
   type FetchListTimelineFilter,
   type TimelineNotesCacheRepository,
   type TimelineRepository,
   timelineNotesCacheRepoSymbol,
   timelineRepoSymbol,
-} from '../model/repository.js';
+} from '../model/repository.ts';
 
 export class ListTimelineService {
   readonly #timelineCacheRepository: TimelineNotesCacheRepository;

--- a/pkg/timeline/service/noteVisibility.test.ts
+++ b/pkg/timeline/service/noteVisibility.test.ts
@@ -1,15 +1,15 @@
 import { Result } from '@mikuroxina/mini-fn';
 import { describe, expect, it, vi } from 'vitest';
 
-import type { AccountID } from '../../accounts/model/account.js';
-import { partialAccount1 } from '../../accounts/testData/testData.js';
-import { dummyAccountModuleFacade } from '../../intermodule/account.js';
+import type { AccountID } from '../../accounts/model/account.ts';
+import { partialAccount1 } from '../../accounts/testData/testData.ts';
+import { dummyAccountModuleFacade } from '../../intermodule/account.ts';
 import {
   dummyFollowersNote,
   dummyHomeNote,
   dummyPublicNote,
-} from '../testData/testData.js';
-import { NoteVisibilityService } from './noteVisibility.js';
+} from '../testData/testData.ts';
+import { NoteVisibilityService } from './noteVisibility.ts';
 
 describe('NoteVisibilityService', () => {
   const visibilityService = new NoteVisibilityService(dummyAccountModuleFacade);

--- a/pkg/timeline/service/noteVisibility.ts
+++ b/pkg/timeline/service/noteVisibility.ts
@@ -1,11 +1,11 @@
 import { Ether, Result } from '@mikuroxina/mini-fn';
 
-import type { AccountID } from '../../accounts/model/account.js';
+import type { AccountID } from '../../accounts/model/account.ts';
 import {
   type AccountModuleFacade,
   accountModuleFacadeSymbol,
-} from '../../intermodule/account.js';
-import type { Note } from '../../notes/model/note.js';
+} from '../../intermodule/account.ts';
+import type { Note } from '../../notes/model/note.ts';
 
 export interface NoteVisibilityCheckArgs {
   // account id of the user who is trying to see the note

--- a/pkg/timeline/service/public.test.ts
+++ b/pkg/timeline/service/public.test.ts
@@ -1,16 +1,16 @@
 import { Option, Result } from '@mikuroxina/mini-fn';
 import { describe, expect, it } from 'vitest';
 
-import type { AccountID } from '../../accounts/model/account.js';
-import { Note, type NoteID } from '../../notes/model/note.js';
-import { InMemoryTimelineRepository } from '../adaptor/repository/dummy.js';
+import type { AccountID } from '../../accounts/model/account.ts';
+import { Note, type NoteID } from '../../notes/model/note.ts';
+import { InMemoryTimelineRepository } from '../adaptor/repository/dummy.ts';
 import {
   dummyDirectNote,
   dummyFollowersNote,
   dummyHomeNote,
   dummyPublicNote,
-} from '../testData/testData.js';
-import { PublicTimelineService } from './public.js';
+} from '../testData/testData.ts';
+import { PublicTimelineService } from './public.ts';
 
 const dummyPublicNote2 = Result.unwrap(
   Note.new({

--- a/pkg/timeline/service/public.ts
+++ b/pkg/timeline/service/public.ts
@@ -1,11 +1,11 @@
 import { Ether, type Result } from '@mikuroxina/mini-fn';
 
-import type { Note } from '../../notes/model/note.js';
+import type { Note } from '../../notes/model/note.ts';
 import {
   type FetchHomeTimelineFilter,
   type TimelineRepository,
   timelineRepoSymbol,
-} from '../model/repository.js';
+} from '../model/repository.ts';
 
 export class PublicTimelineService {
   readonly #timelineRepository: TimelineRepository;

--- a/pkg/timeline/service/push.test.ts
+++ b/pkg/timeline/service/push.test.ts
@@ -1,22 +1,22 @@
 import { Option, Result } from '@mikuroxina/mini-fn';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import type { AccountID } from '../../accounts/model/account.js';
-import { partialAccount1 } from '../../accounts/testData/testData.js';
-import { dummyAccountModuleFacade } from '../../intermodule/account.js';
-import { addSecondsToDate } from '../../internal/time/mod.js';
-import { Note, type NoteID } from '../../notes/model/note.js';
-import { InMemoryListRepository } from '../adaptor/repository/dummy.js';
-import { InMemoryTimelineCacheRepository } from '../adaptor/repository/dummyCache.js';
-import { List, type ListID } from '../model/list.js';
+import type { AccountID } from '../../accounts/model/account.ts';
+import { partialAccount1 } from '../../accounts/testData/testData.ts';
+import { dummyAccountModuleFacade } from '../../intermodule/account.ts';
+import { addSecondsToDate } from '../../internal/time/mod.ts';
+import { Note, type NoteID } from '../../notes/model/note.ts';
+import { InMemoryListRepository } from '../adaptor/repository/dummy.ts';
+import { InMemoryTimelineCacheRepository } from '../adaptor/repository/dummyCache.ts';
+import { List, type ListID } from '../model/list.ts';
 import {
   dummyFollowersNote,
   dummyHomeNote,
   dummyPublicNote,
-} from '../testData/testData.js';
-import { FetchSubscribedListService } from './fetchSubscribed.js';
-import { NoteVisibilityService } from './noteVisibility.js';
-import { PushTimelineService } from './push.js';
+} from '../testData/testData.ts';
+import { FetchSubscribedListService } from './fetchSubscribed.ts';
+import { NoteVisibilityService } from './noteVisibility.ts';
+import { PushTimelineService } from './push.ts';
 
 describe('PushTimelineService', () => {
   const dummyList = List.reconstruct({

--- a/pkg/timeline/service/push.ts
+++ b/pkg/timeline/service/push.ts
@@ -1,17 +1,17 @@
 import { Ether, Result } from '@mikuroxina/mini-fn';
 
-import type { AccountID } from '../../accounts/model/account.js';
-import type { AccountModuleFacade } from '../../intermodule/account.js';
-import { NoteVisibilityInvalidError } from '../../notes/model/errors.js';
-import type { Note } from '../../notes/model/note.js';
-import { TimelineInternalError } from '../model/errors.js';
-import type { ListID } from '../model/list.js';
+import type { AccountID } from '../../accounts/model/account.ts';
+import type { AccountModuleFacade } from '../../intermodule/account.ts';
+import { NoteVisibilityInvalidError } from '../../notes/model/errors.ts';
+import type { Note } from '../../notes/model/note.ts';
+import { TimelineInternalError } from '../model/errors.ts';
+import type { ListID } from '../model/list.ts';
 import {
   type TimelineNotesCacheRepository,
   timelineNotesCacheRepoSymbol,
-} from '../model/repository.js';
-import type { FetchSubscribedListService } from './fetchSubscribed.js';
-import type { NoteVisibilityService } from './noteVisibility.js';
+} from '../model/repository.ts';
+import type { FetchSubscribedListService } from './fetchSubscribed.ts';
+import type { NoteVisibilityService } from './noteVisibility.ts';
 
 export class PushTimelineService {
   readonly #accountModule: AccountModuleFacade;

--- a/pkg/timeline/service/removeMember.test.ts
+++ b/pkg/timeline/service/removeMember.test.ts
@@ -1,13 +1,13 @@
 import { Result } from '@mikuroxina/mini-fn';
 import { beforeEach, describe, expect, it } from 'vitest';
-import type { AccountID } from '../../accounts/model/account.js';
-import { InMemoryListRepository } from '../adaptor/repository/dummy.js';
+import type { AccountID } from '../../accounts/model/account.ts';
+import { InMemoryListRepository } from '../adaptor/repository/dummy.ts';
 import {
   ListNotFoundError,
   TimelineInsufficientPermissionError,
-} from '../model/errors.js';
-import { List, type ListID } from '../model/list.js';
-import { RemoveListMemberService } from './removeMember.js';
+} from '../model/errors.ts';
+import { List, type ListID } from '../model/list.ts';
+import { RemoveListMemberService } from './removeMember.ts';
 
 describe('RemoveListMemberService', () => {
   const listData = [

--- a/pkg/timeline/service/removeMember.ts
+++ b/pkg/timeline/service/removeMember.ts
@@ -1,11 +1,11 @@
 import { Cat, Ether, Promise, Result } from '@mikuroxina/mini-fn';
-import type { AccountID } from '../../accounts/model/account.js';
+import type { AccountID } from '../../accounts/model/account.ts';
 import {
   ListNotFoundError,
   TimelineInsufficientPermissionError,
-} from '../model/errors.js';
-import type { List, ListID } from '../model/list.js';
-import { type ListRepository, listRepoSymbol } from '../model/repository.js';
+} from '../model/errors.ts';
+import type { List, ListID } from '../model/list.ts';
+import { type ListRepository, listRepoSymbol } from '../model/repository.ts';
 
 export class RemoveListMemberService {
   readonly #listRepository: ListRepository;

--- a/pkg/timeline/testData/testData.ts
+++ b/pkg/timeline/testData/testData.ts
@@ -3,8 +3,8 @@
  * */
 import { Option, Result } from '@mikuroxina/mini-fn';
 
-import type { AccountID } from '../../accounts/model/account.js';
-import { Note, type NoteID } from '../../notes/model/note.js';
+import type { AccountID } from '../../accounts/model/account.ts';
+import { Note, type NoteID } from '../../notes/model/note.ts';
 
 export const dummyPublicNote = Result.unwrap(
   Note.new({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,9 +93,6 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^4.0.0
         version: 4.1.10(vitest@4.1.10)
-      esbuild:
-        specifier: ^0.28.0
-        version: 0.28.2
       lefthook:
         specifier: ^2.0.0
         version: 2.1.10
@@ -223,20 +220,8 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/aix-ppc64@0.28.2':
-    resolution: {integrity: sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [aix]
-
   '@esbuild/android-arm64@0.27.7':
     resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [android]
-
-  '@esbuild/android-arm64@0.28.2':
-    resolution: {integrity: sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -247,20 +232,8 @@ packages:
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-arm@0.28.2':
-    resolution: {integrity: sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==}
-    engines: {node: '>=18'}
-    cpu: [arm]
-    os: [android]
-
   '@esbuild/android-x64@0.27.7':
     resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [android]
-
-  '@esbuild/android-x64@0.28.2':
-    resolution: {integrity: sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -271,20 +244,8 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-arm64@0.28.2':
-    resolution: {integrity: sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [darwin]
-
   '@esbuild/darwin-x64@0.27.7':
     resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@esbuild/darwin-x64@0.28.2':
-    resolution: {integrity: sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -295,20 +256,8 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-arm64@0.28.2':
-    resolution: {integrity: sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [freebsd]
-
   '@esbuild/freebsd-x64@0.27.7':
     resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@esbuild/freebsd-x64@0.28.2':
-    resolution: {integrity: sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -319,20 +268,8 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm64@0.28.2':
-    resolution: {integrity: sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [linux]
-
   '@esbuild/linux-arm@0.27.7':
     resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
-    engines: {node: '>=18'}
-    cpu: [arm]
-    os: [linux]
-
-  '@esbuild/linux-arm@0.28.2':
-    resolution: {integrity: sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -343,20 +280,8 @@ packages:
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.28.2':
-    resolution: {integrity: sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [linux]
-
   '@esbuild/linux-loong64@0.27.7':
     resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
-    engines: {node: '>=18'}
-    cpu: [loong64]
-    os: [linux]
-
-  '@esbuild/linux-loong64@0.28.2':
-    resolution: {integrity: sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -367,20 +292,8 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.28.2':
-    resolution: {integrity: sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==}
-    engines: {node: '>=18'}
-    cpu: [mips64el]
-    os: [linux]
-
   '@esbuild/linux-ppc64@0.27.7':
     resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [linux]
-
-  '@esbuild/linux-ppc64@0.28.2':
-    resolution: {integrity: sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -391,20 +304,8 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.28.2':
-    resolution: {integrity: sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==}
-    engines: {node: '>=18'}
-    cpu: [riscv64]
-    os: [linux]
-
   '@esbuild/linux-s390x@0.27.7':
     resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
-    engines: {node: '>=18'}
-    cpu: [s390x]
-    os: [linux]
-
-  '@esbuild/linux-s390x@0.28.2':
-    resolution: {integrity: sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -415,20 +316,8 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/linux-x64@0.28.2':
-    resolution: {integrity: sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [linux]
-
   '@esbuild/netbsd-arm64@0.27.7':
     resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [netbsd]
-
-  '@esbuild/netbsd-arm64@0.28.2':
-    resolution: {integrity: sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -439,20 +328,8 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.28.2':
-    resolution: {integrity: sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [netbsd]
-
   '@esbuild/openbsd-arm64@0.27.7':
     resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openbsd]
-
-  '@esbuild/openbsd-arm64@0.28.2':
-    resolution: {integrity: sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -463,20 +340,8 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.28.2':
-    resolution: {integrity: sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [openbsd]
-
   '@esbuild/openharmony-arm64@0.27.7':
     resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openharmony]
-
-  '@esbuild/openharmony-arm64@0.28.2':
-    resolution: {integrity: sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
@@ -487,20 +352,8 @@ packages:
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/sunos-x64@0.28.2':
-    resolution: {integrity: sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [sunos]
-
   '@esbuild/win32-arm64@0.27.7':
     resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [win32]
-
-  '@esbuild/win32-arm64@0.28.2':
-    resolution: {integrity: sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
@@ -511,20 +364,8 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.28.2':
-    resolution: {integrity: sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [win32]
-
   '@esbuild/win32-x64@0.27.7':
     resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [win32]
-
-  '@esbuild/win32-x64@0.28.2':
-    resolution: {integrity: sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -1519,11 +1360,6 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  esbuild@0.28.2:
-    resolution: {integrity: sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==}
-    engines: {node: '>=18'}
-    hasBin: true
-
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
@@ -2491,157 +2327,79 @@ snapshots:
   '@esbuild/aix-ppc64@0.27.7':
     optional: true
 
-  '@esbuild/aix-ppc64@0.28.2':
-    optional: true
-
   '@esbuild/android-arm64@0.27.7':
-    optional: true
-
-  '@esbuild/android-arm64@0.28.2':
     optional: true
 
   '@esbuild/android-arm@0.27.7':
     optional: true
 
-  '@esbuild/android-arm@0.28.2':
-    optional: true
-
   '@esbuild/android-x64@0.27.7':
-    optional: true
-
-  '@esbuild/android-x64@0.28.2':
     optional: true
 
   '@esbuild/darwin-arm64@0.27.7':
     optional: true
 
-  '@esbuild/darwin-arm64@0.28.2':
-    optional: true
-
   '@esbuild/darwin-x64@0.27.7':
-    optional: true
-
-  '@esbuild/darwin-x64@0.28.2':
     optional: true
 
   '@esbuild/freebsd-arm64@0.27.7':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.28.2':
-    optional: true
-
   '@esbuild/freebsd-x64@0.27.7':
-    optional: true
-
-  '@esbuild/freebsd-x64@0.28.2':
     optional: true
 
   '@esbuild/linux-arm64@0.27.7':
     optional: true
 
-  '@esbuild/linux-arm64@0.28.2':
-    optional: true
-
   '@esbuild/linux-arm@0.27.7':
-    optional: true
-
-  '@esbuild/linux-arm@0.28.2':
     optional: true
 
   '@esbuild/linux-ia32@0.27.7':
     optional: true
 
-  '@esbuild/linux-ia32@0.28.2':
-    optional: true
-
   '@esbuild/linux-loong64@0.27.7':
-    optional: true
-
-  '@esbuild/linux-loong64@0.28.2':
     optional: true
 
   '@esbuild/linux-mips64el@0.27.7':
     optional: true
 
-  '@esbuild/linux-mips64el@0.28.2':
-    optional: true
-
   '@esbuild/linux-ppc64@0.27.7':
-    optional: true
-
-  '@esbuild/linux-ppc64@0.28.2':
     optional: true
 
   '@esbuild/linux-riscv64@0.27.7':
     optional: true
 
-  '@esbuild/linux-riscv64@0.28.2':
-    optional: true
-
   '@esbuild/linux-s390x@0.27.7':
-    optional: true
-
-  '@esbuild/linux-s390x@0.28.2':
     optional: true
 
   '@esbuild/linux-x64@0.27.7':
     optional: true
 
-  '@esbuild/linux-x64@0.28.2':
-    optional: true
-
   '@esbuild/netbsd-arm64@0.27.7':
-    optional: true
-
-  '@esbuild/netbsd-arm64@0.28.2':
     optional: true
 
   '@esbuild/netbsd-x64@0.27.7':
     optional: true
 
-  '@esbuild/netbsd-x64@0.28.2':
-    optional: true
-
   '@esbuild/openbsd-arm64@0.27.7':
-    optional: true
-
-  '@esbuild/openbsd-arm64@0.28.2':
     optional: true
 
   '@esbuild/openbsd-x64@0.27.7':
     optional: true
 
-  '@esbuild/openbsd-x64@0.28.2':
-    optional: true
-
   '@esbuild/openharmony-arm64@0.27.7':
-    optional: true
-
-  '@esbuild/openharmony-arm64@0.28.2':
     optional: true
 
   '@esbuild/sunos-x64@0.27.7':
     optional: true
 
-  '@esbuild/sunos-x64@0.28.2':
-    optional: true
-
   '@esbuild/win32-arm64@0.27.7':
-    optional: true
-
-  '@esbuild/win32-arm64@0.28.2':
     optional: true
 
   '@esbuild/win32-ia32@0.27.7':
     optional: true
 
-  '@esbuild/win32-ia32@0.28.2':
-    optional: true
-
   '@esbuild/win32-x64@0.27.7':
-    optional: true
-
-  '@esbuild/win32-x64@0.28.2':
     optional: true
 
   '@gar/promise-retry@1.0.3': {}
@@ -3631,35 +3389,6 @@ snapshots:
       '@esbuild/win32-arm64': 0.27.7
       '@esbuild/win32-ia32': 0.27.7
       '@esbuild/win32-x64': 0.27.7
-
-  esbuild@0.28.2:
-    optionalDependencies:
-      '@esbuild/aix-ppc64': 0.28.2
-      '@esbuild/android-arm': 0.28.2
-      '@esbuild/android-arm64': 0.28.2
-      '@esbuild/android-x64': 0.28.2
-      '@esbuild/darwin-arm64': 0.28.2
-      '@esbuild/darwin-x64': 0.28.2
-      '@esbuild/freebsd-arm64': 0.28.2
-      '@esbuild/freebsd-x64': 0.28.2
-      '@esbuild/linux-arm': 0.28.2
-      '@esbuild/linux-arm64': 0.28.2
-      '@esbuild/linux-ia32': 0.28.2
-      '@esbuild/linux-loong64': 0.28.2
-      '@esbuild/linux-mips64el': 0.28.2
-      '@esbuild/linux-ppc64': 0.28.2
-      '@esbuild/linux-riscv64': 0.28.2
-      '@esbuild/linux-s390x': 0.28.2
-      '@esbuild/linux-x64': 0.28.2
-      '@esbuild/netbsd-arm64': 0.28.2
-      '@esbuild/netbsd-x64': 0.28.2
-      '@esbuild/openbsd-arm64': 0.28.2
-      '@esbuild/openbsd-x64': 0.28.2
-      '@esbuild/openharmony-arm64': 0.28.2
-      '@esbuild/sunos-x64': 0.28.2
-      '@esbuild/win32-arm64': 0.28.2
-      '@esbuild/win32-ia32': 0.28.2
-      '@esbuild/win32-x64': 0.28.2
 
   estree-walker@3.0.3:
     dependencies:

--- a/scripts/apidoc.ts
+++ b/scripts/apidoc.ts
@@ -1,7 +1,7 @@
 import { writeFileSync } from 'node:fs';
 import { testClient } from 'hono/testing';
 
-import { app } from '../main.js';
+import { app } from '../main.ts';
 
 const client = testClient(app);
 const res = await client.doc.$get();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,10 +24,13 @@
     "forceConsistentCasingInFileNames": true,
     "allowUnreachableCode": false,
     "verbatimModuleSyntax": true,
+    "allowImportingTsExtensions": true,
+    "rewriteRelativeImportExtensions": true,
+    "erasableSyntaxOnly": true,
     "pretty": true,
     "esModuleInterop": true,
     "resolveJsonModule": true
   },
-  "include": ["**/*.ts", "scripts/build.js"],
+  "include": ["**/*.ts"],
   "exclude": ["node_modules", "build"]
 }


### PR DESCRIPTION
close #1668

## What does this PR do?

- 相対 import の拡張子を `.js` から `.ts` に置き換え、Node.js による TypeScript の直接実行へ移行しました
- `esbuild` の直接依存とビルド工程を削除し、CI と API スキーマ生成を直接実行へ更新しました
- ついでにDockerのnodeイメージをバージョンアップしました

## Additional information

> work with ai
