### PR TITLE
fix: 添付ファイルが無い投稿を作るときはAttachmentRepositoryにアクセスしない

### DIFF
--- a/pkg/notes/service/create.test.ts
+++ b/pkg/notes/service/create.test.ts
@@ -1,5 +1,5 @@
 import { Option, Result } from '@mikuroxina/mini-fn';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import type { AccountID } from '../../accounts/model/account.js';
 import { Medium, type MediumID } from '../../drive/model/medium.js';
@@ -58,6 +58,21 @@ describe('CreateService', () => {
     );
 
     expect(Result.isOk(res)).toBe(true);
+  });
+
+  it('does not create attachments when none are provided', async () => {
+    const attachmentCreateSpy = vi.spyOn(attachmentRepository, 'create');
+
+    const res = await createService.handle(
+      'Hello world',
+      '',
+      '102' as AccountID,
+      [],
+      'PUBLIC',
+    );
+
+    expect(Result.isOk(res)).toBe(true);
+    expect(attachmentCreateSpy).not.toHaveBeenCalled();
   });
 
   it('with attachments', async () => {

--- a/pkg/notes/service/create.ts
+++ b/pkg/notes/service/create.ts
@@ -73,10 +73,12 @@ export class CreateService {
         .runWith(({ note }) =>
           this.#deps.noteRepository.create(note).then(Result.map(() => [])),
         )
-        .runWith(({ note }) =>
-          this.#deps.noteAttachmentRepository
-            .create(note.getID(), note.getAttachmentFileID())
-            .then(Result.map(() => [])),
+        .when(
+          () => attachmentFileID.length !== 0,
+          ({ note }) =>
+            this.#deps.noteAttachmentRepository
+              .create(note.getID(), note.getAttachmentFileID())
+              .then(Result.map(() => [])),
         )
         // ToDo: Even if the note cannot be pushed to the timeline, the note is created successfully, so there is no error here.
         // ToDo: use job queue to push note to timeline


### PR DESCRIPTION
close #1736 

## What does this PR do?
- 添付ファイルが無い投稿を行うときに無駄なRepositoryアクセスをしないように修正

## Additional information
