### PR TITLE
chore(ci): Node 26でcorepackが同梱されなくなった問題に対応

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM node:26-slim AS base
 ENV PNPM_HOME=/pnpm
 ENV PATH="${PNPM_HOME}:${PATH}"
-RUN corepack enable
+RUN npm install -g corepack@latest && corepack enable
 
 WORKDIR /app
 COPY package.json pnpm-lock.yaml ./


### PR DESCRIPTION

## What does this PR do?
- #1668 でNodeのバージョンを上げた結果、corepackが同梱されないバージョンになっていました
- その影響でdockerイメージのビルドが落ちるようになった
- npmを使ってcorepackをインストールするように変更

## Additional information
