### PR TITLE
feat: driveのドメインイベント生成をワイヤリングする

### DIFF
--- a/pkg/drive/model/medium.test.ts
+++ b/pkg/drive/model/medium.test.ts
@@ -2,6 +2,7 @@ import { Option, Result } from '@mikuroxina/mini-fn';
 import { describe, expect, it } from 'vitest';
 
 import type { AccountID } from '../../accounts/model/account.ts';
+import { MockClock, SnowflakeIDGenerator } from '../../internal/id/mod.ts';
 import { MediaSizeTooLargeError, MediaTypeInvalidError } from './errors.ts';
 import { Medium, type MediumID } from './medium.ts';
 
@@ -18,16 +19,23 @@ const baseArgs = {
   maxSize: 1024 * 1024,
 } as const;
 
+const idGenerator = new SnowflakeIDGenerator(0, new MockClock(new Date()));
+const baseMeta = {
+  idGenerator,
+  actor: baseArgs.authorId,
+  occurredAt: new Date(),
+} as const;
+
 describe('Medium.new', () => {
   it('creates a medium when the source is valid', () => {
-    const res = Medium.new({ ...baseArgs, sourceMime: 'image/png' });
+    const res = Medium.new({ ...baseArgs, sourceMime: 'image/png' }, baseMeta);
 
     expect(Result.isOk(res)).toBe(true);
     expect(Result.unwrap(res).getMime()).toBe('image/webp');
   });
 
   it('rejects a disallowed source MIME type', () => {
-    const res = Medium.new({ ...baseArgs, sourceMime: 'image/heic' });
+    const res = Medium.new({ ...baseArgs, sourceMime: 'image/heic' }, baseMeta);
 
     expect(Result.isErr(res)).toBe(true);
     expect(res[1]).toStrictEqual(
@@ -36,11 +44,14 @@ describe('Medium.new', () => {
   });
 
   it('rejects a file larger than the limit', () => {
-    const res = Medium.new({
-      ...baseArgs,
-      sourceMime: 'image/png',
-      size: baseArgs.maxSize + 1,
-    });
+    const res = Medium.new(
+      {
+        ...baseArgs,
+        sourceMime: 'image/png',
+        size: baseArgs.maxSize + 1,
+      },
+      baseMeta,
+    );
 
     expect(Result.isErr(res)).toBe(true);
     expect(res[1]).toStrictEqual(
@@ -49,12 +60,49 @@ describe('Medium.new', () => {
   });
 
   it('accepts a file exactly at the size limit', () => {
-    const res = Medium.new({
-      ...baseArgs,
-      sourceMime: 'image/png',
-      size: baseArgs.maxSize,
-    });
+    const res = Medium.new(
+      {
+        ...baseArgs,
+        sourceMime: 'image/png',
+        size: baseArgs.maxSize,
+      },
+      baseMeta,
+    );
 
     expect(Result.isOk(res)).toBe(true);
+  });
+});
+
+describe('Medium.new events', () => {
+  it('emits a medium.created event on success', () => {
+    const res = Medium.new({ ...baseArgs, sourceMime: 'image/png' }, baseMeta);
+
+    const medium = Result.unwrap(res);
+    const events = medium.pullEvents();
+    expect(events).toHaveLength(1);
+    const [event] = events;
+    expect(event?.eventName).toBe('medium.created');
+    expect(event?.target).toBe(baseArgs.id);
+    expect(event?.actor).toBe(baseArgs.authorId);
+  });
+
+  it.each([
+    ['disallowed source MIME type', { sourceMime: 'image/heic' }],
+    [
+      'file larger than the limit',
+      { sourceMime: 'image/png', size: baseArgs.maxSize + 1 },
+    ],
+  ])('does not emit an event when validation fails: %s', (_, override) => {
+    const res = Medium.new({ ...baseArgs, ...override }, baseMeta);
+
+    expect(Result.isErr(res)).toBe(true);
+  });
+
+  it('pullEvents() removes events, returning nothing on the second call', () => {
+    const res = Medium.new({ ...baseArgs, sourceMime: 'image/png' }, baseMeta);
+    const medium = Result.unwrap(res);
+
+    expect(medium.pullEvents()).toHaveLength(1);
+    expect(medium.pullEvents()).toHaveLength(0);
   });
 });

--- a/pkg/drive/model/medium.ts
+++ b/pkg/drive/model/medium.ts
@@ -2,8 +2,10 @@ import { type Option, Result } from '@mikuroxina/mini-fn';
 import * as v from 'valibot';
 
 import type { AccountID } from '../../accounts/model/account.ts';
+import type { EventMeta } from '../../internal/event/type.ts';
 import type { ID } from '../../internal/id/type.ts';
 import { MediaSizeTooLargeError, MediaTypeInvalidError } from './errors.ts';
+import { type MediumEvent, mediumEventFactory } from './event/mediumEvents.ts';
 
 export type MediumID = ID<Medium>;
 
@@ -54,7 +56,11 @@ export class Medium {
 
   public static new(
     arg: NewMediumArgs,
-  ): Result.Result<MediaSizeTooLargeError | MediaTypeInvalidError, Medium> {
+    meta: EventMeta<AccountID>,
+  ): Result.Result<
+    MediaSizeTooLargeError | MediaTypeInvalidError | Error,
+    Medium
+  > {
     if (!v.safeParse(sourceMimeSchema, arg.sourceMime).success) {
       return Result.err(
         new MediaTypeInvalidError('Invalid file type', { cause: null }),
@@ -67,11 +73,29 @@ export class Medium {
         new MediaSizeTooLargeError('File size is too large', { cause: null }),
       );
     }
-    return Result.ok(new Medium(arg));
+
+    const event = mediumEventFactory.created(meta.idGenerator, {
+      target: arg.id,
+      actor: arg.authorId,
+      occurredAt: meta.occurredAt,
+      authorID: arg.authorId,
+    });
+    if (Result.isErr(event)) {
+      return event;
+    }
+
+    const medium = new Medium(arg);
+    medium.#events.push(Result.unwrap(event));
+    return Result.ok(medium);
   }
 
   public static reconstruct(arg: CreateMediumArgs): Medium {
     return new Medium(arg);
+  }
+
+  #events: MediumEvent[] = [];
+  pullEvents(): MediumEvent[] {
+    return this.#events.splice(0);
   }
 
   readonly #id: MediumID;

--- a/pkg/drive/service/upload.test.ts
+++ b/pkg/drive/service/upload.test.ts
@@ -13,7 +13,8 @@ import {
 import { UploadMediaService } from './upload.ts';
 
 describe('upload', () => {
-  const idGenerator = new SnowflakeIDGenerator(0, new MockClock(new Date()));
+  const clock = new MockClock(new Date());
+  const idGenerator = new SnowflakeIDGenerator(0, clock);
   const repository = new InMemoryMediaRepository([]);
   const storageService = new LocalStorage();
   const service = new UploadMediaService(
@@ -21,6 +22,7 @@ describe('upload', () => {
     repository,
     storageService,
     1024 * 1024 * 10,
+    clock,
   );
 
   it('valid files', async () => {
@@ -46,6 +48,7 @@ describe('upload', () => {
       repository,
       storageService,
       10,
+      clock,
     );
     const a = await readFile('./pkg/drive/testData/flower.jpeg');
     const res = await s.handle({

--- a/pkg/drive/service/upload.ts
+++ b/pkg/drive/service/upload.ts
@@ -4,7 +4,7 @@ import { fileTypeFromBuffer } from 'file-type';
 import sharp from 'sharp';
 
 import type { AccountID } from '../../accounts/model/account.ts';
-import type { SnowflakeIDGenerator } from '../../internal/id/mod.ts';
+import type { Clock, SnowflakeIDGenerator } from '../../internal/id/mod.ts';
 import { DriveInternalError, MediaTypeInvalidError } from '../model/errors.ts';
 import { Medium } from '../model/medium.ts';
 import type { MediaRepository } from '../model/repository.ts';
@@ -21,16 +21,19 @@ export class UploadMediaService {
   readonly #repository: MediaRepository;
   readonly #storage: Storage;
   readonly #MAX_MEDIA_SIZE: number;
+  readonly #clock: Clock;
   constructor(
     idGenerator: SnowflakeIDGenerator,
     repository: MediaRepository,
     storage: Storage,
     MAX_MEDIA_SIZE: number,
+    clock: Clock,
   ) {
     this.#idGenerator = idGenerator;
     this.#repository = repository;
     this.#storage = storage;
     this.#MAX_MEDIA_SIZE = MAX_MEDIA_SIZE;
+    this.#clock = clock;
   }
 
   /**
@@ -69,21 +72,28 @@ export class UploadMediaService {
         )
         .addMWith('medium', ({ id, mime, processed }) =>
           Promise.resolve(
-            Medium.new({
-              id,
-              name: args.name,
-              authorId: args.authorId,
-              nsfw: args.nsfw,
-              mime: 'image/webp',
-              hash: Option.unwrapOr('')(
-                Option.map((p: ProcessedImage) => p.hash)(processed),
-              ),
-              url: Option.none(),
-              thumbnailUrl: Option.none(),
-              sourceMime: mime,
-              size: args.file.length,
-              maxSize: this.#MAX_MEDIA_SIZE,
-            }),
+            Medium.new(
+              {
+                id,
+                name: args.name,
+                authorId: args.authorId,
+                nsfw: args.nsfw,
+                mime: 'image/webp',
+                hash: Option.unwrapOr('')(
+                  Option.map((p: ProcessedImage) => p.hash)(processed),
+                ),
+                url: Option.none(),
+                thumbnailUrl: Option.none(),
+                sourceMime: mime,
+                size: args.file.length,
+                maxSize: this.#MAX_MEDIA_SIZE,
+              },
+              {
+                idGenerator: this.#idGenerator,
+                actor: args.authorId,
+                occurredAt: new Date(Number(this.#clock.now())),
+              },
+            ),
           ),
         )
         // NOTE: The source is valid, so a failed processing is an internal error.

--- a/pkg/internal/event/type.ts
+++ b/pkg/internal/event/type.ts
@@ -18,3 +18,17 @@ export interface DomainEvent<
   readonly payload: Payload;
   readonly occurredAt: Date;
 }
+
+import type { SnowflakeIDGenerator } from '../id/mod.ts';
+
+/**
+ * A model's state-changing method takes this as its trailing argument to
+ * generate the corresponding domain event. `Actor` is `AccountID` for
+ * user-initiated operations, `Option.Option<AccountID>` when the operation
+ * may originate from the system/batch processing (see DomainEvent).
+ */
+export interface EventMeta<Actor> {
+  readonly idGenerator: SnowflakeIDGenerator;
+  readonly actor: Actor;
+  readonly occurredAt: Date;
+}


### PR DESCRIPTION
related #1661

## What does this PR do?
- `Medium`クラスに`#events`フィールドと破壊的取り出しを行う`pullEvents()`を追加しました
- `Medium.new()`でバリデーション成功後に`medium.created`イベントを生成し、`#events`に積むようにしました
- イベント生成が失敗した場合は状態を変更せず`Result.err`を返すようにしました
- `EventMeta<Actor>`型を`pkg/internal/event/type.ts`に追加しました
- `UploadMediaService`に`Clock`を注入し、`Medium.new()`呼び出しに`meta`を渡すようにしました
- `medium.test.ts`にイベント生成・バリデーション失敗時の非生成・`pullEvents()`の破壊的取り出しを検証するテストを追加しました

## Additional information

🤖 Generated with [Claude Code](https://claude.com/claude-code)
