### PR TITLE
refactor: 削除イベントを発行するようにした

### DIFF
--- a/pkg/accounts/model/follow.test.ts
+++ b/pkg/accounts/model/follow.test.ts
@@ -48,12 +48,12 @@ describe('AccountFollow domain events', () => {
     expect(follow.pullEvents()).toStrictEqual([]);
   });
 
-  it('setDeletedAt() generates an account.follow.unfollowed event', () => {
+  it('delete() generates an account.follow.unfollowed event', () => {
     const follow = Result.unwrap(AccountFollow.new(exampleInput));
     follow.pullEvents();
 
     const deletedAt = new Date('2023-09-11T00:00:00.000Z');
-    const result = follow.setDeletedAt(deletedAt);
+    const result = follow.delete(deletedAt);
     expect(Result.isOk(result)).toBe(true);
 
     const events = follow.pullEvents();
@@ -67,11 +67,11 @@ describe('AccountFollow domain events', () => {
     });
   });
 
-  it('setDeletedAt() does not push an event when validation fails', () => {
+  it('delete() does not push an event when validation fails', () => {
     const follow = Result.unwrap(AccountFollow.new(exampleInput));
     follow.pullEvents();
 
-    const result = follow.setDeletedAt(new Date('2023-09-09T00:00:00.000Z'));
+    const result = follow.delete(new Date('2023-09-09T00:00:00.000Z'));
     expect(Result.isErr(result)).toBe(true);
     expect(follow.pullEvents()).toStrictEqual([]);
   });

--- a/pkg/accounts/model/follow.ts
+++ b/pkg/accounts/model/follow.ts
@@ -89,9 +89,7 @@ export class AccountFollow {
     return this.#deletedAt;
   }
 
-  setDeletedAt(
-    deletedAt: Date,
-  ): Result.Result<AccountFollowDateInvalidError, void> {
+  delete(deletedAt: Date): Result.Result<AccountFollowDateInvalidError, void> {
     if (this.#createdAt > deletedAt) {
       return Result.err(
         new AccountFollowDateInvalidError(
@@ -111,5 +109,12 @@ export class AccountFollow {
       ),
     );
     return Result.ok(undefined);
+  }
+
+  /** @deprecated Use delete() instead. */
+  setDeletedAt(
+    deletedAt: Date,
+  ): Result.Result<AccountFollowDateInvalidError, void> {
+    return this.delete(deletedAt);
   }
 }

--- a/pkg/drive/model/medium.test.ts
+++ b/pkg/drive/model/medium.test.ts
@@ -109,4 +109,17 @@ describe('Medium.new events', () => {
     expect(medium.pullEvents()).toHaveLength(1);
     expect(medium.pullEvents()).toHaveLength(0);
   });
+
+  it('deleted() returns a medium.deleted event', () => {
+    const medium = Medium.reconstruct(baseArgs);
+
+    medium.deleted();
+
+    const events = medium.pullEvents();
+    expect(events).toHaveLength(1);
+    expect(events[0]?.eventName).toBe('medium.deleted');
+    expect(events[0]?.target).toBe(baseArgs.id);
+    expect(events[0]?.actor).toBe(baseArgs.authorId);
+    expect(events[0]?.payload).toStrictEqual({});
+  });
 });

--- a/pkg/drive/model/medium.ts
+++ b/pkg/drive/model/medium.ts
@@ -131,4 +131,15 @@ export class Medium {
   getThumbnailUrl(): Option.Option<string> {
     return this.#thumbnailUrl;
   }
+
+  deleted(actor: AccountID = this.#authorId): void {
+    this.#events.push(
+      Result.unwrap(
+        mediumEventFactory.deleted({
+          target: this.#id,
+          actor,
+        }),
+      ),
+    );
+  }
 }

--- a/pkg/notes/model/bookmark.test.ts
+++ b/pkg/notes/model/bookmark.test.ts
@@ -53,5 +53,20 @@ describe('Bookmark', () => {
 
       expect(bookmark.pullEvents()).toStrictEqual([]);
     });
+
+    it('deleted() returns a note.bookmark.deleted event', () => {
+      const bookmark = Bookmark.reconstruct(exampleInput);
+
+      bookmark.deleted();
+
+      const events = bookmark.pullEvents();
+      expect(events).toHaveLength(1);
+      expect(events[0]?.eventName).toBe('note.bookmark.deleted');
+      expect(events[0]?.target).toBe(exampleInput.noteID);
+      expect(events[0]?.actor).toBe(exampleInput.accountID);
+      expect(events[0]?.payload).toStrictEqual({
+        accountID: exampleInput.accountID,
+      });
+    });
   });
 });

--- a/pkg/notes/model/bookmark.ts
+++ b/pkg/notes/model/bookmark.ts
@@ -52,4 +52,14 @@ export class Bookmark {
   getAccountID(): AccountID {
     return this.#accountID;
   }
+
+  deleted(actor: AccountID = this.#accountID): void {
+    this.#events.push(
+      bookmarkEventFactory.deleted({
+        target: this.#noteID,
+        actor,
+        accountID: this.#accountID,
+      }),
+    );
+  }
 }

--- a/pkg/notes/model/directNote.test.ts
+++ b/pkg/notes/model/directNote.test.ts
@@ -100,12 +100,12 @@ describe('DirectNote', () => {
     });
   });
 
-  describe('setDeletedAt', () => {
+  describe('delete', () => {
     it('sets deletedAt when date is after createdAt', () => {
       const note = Result.unwrap(DirectNote.new(exampleInput));
       const deletedAt = new Date('2023-09-11T00:00:00.000Z');
 
-      const result = note.setDeletedAt(deletedAt);
+      const result = note.delete(deletedAt);
       expect(Result.isOk(result)).toBe(true);
       expect(note.getDeletedAt()).toStrictEqual(Option.some(deletedAt));
     });
@@ -114,8 +114,23 @@ describe('DirectNote', () => {
       const note = Result.unwrap(DirectNote.new(exampleInput));
       const deletedAt = new Date('2023-09-09T00:00:00.000Z');
 
-      const result = note.setDeletedAt(deletedAt);
+      const result = note.delete(deletedAt);
       expect(Result.isErr(result)).toBe(true);
+    });
+
+    it('returns a note.deleted event', () => {
+      const note = Result.unwrap(DirectNote.new(exampleInput));
+      const deletedAt = new Date('2023-09-11T00:00:00.000Z');
+
+      const result = note.delete(deletedAt);
+      expect(Result.isOk(result)).toBe(true);
+
+      const events = note.pullEvents();
+      expect(events).toHaveLength(1);
+      expect(events[0]?.eventName).toBe('note.deleted');
+      expect(events[0]?.target).toBe(exampleInput.id);
+      expect(events[0]?.actor).toBe(exampleInput.authorID);
+      expect(events[0]?.payload).toStrictEqual({});
     });
   });
 

--- a/pkg/notes/model/directNote.ts
+++ b/pkg/notes/model/directNote.ts
@@ -10,6 +10,7 @@ import {
   DirectNoteSelfSendError,
   DirectNoteTooManyAttachmentsError,
 } from './errors.ts';
+import { type NoteEvent, noteEventFactory } from './event/noteEvents.ts';
 import { cwCommentSchema, noteContentSchema } from './note.ts';
 
 export type DirectNoteID = ID<DirectNote>;
@@ -42,6 +43,7 @@ export class DirectNote {
   readonly #attachmentFileID: readonly MediumID[];
   readonly #createdAt: Date;
   #deletedAt: Option.Option<Date>;
+  #events: NoteEvent[] = [];
 
   private constructor(arg: CreateDirectNoteArgs) {
     this.#id = arg.id;
@@ -148,12 +150,17 @@ export class DirectNote {
     return this.#createdAt;
   }
 
+  pullEvents(): NoteEvent[] {
+    return this.#events.splice(0);
+  }
+
   getDeletedAt(): Option.Option<Date> {
     return this.#deletedAt;
   }
 
-  setDeletedAt(
+  delete(
     deletedAt: Date,
+    actor: AccountID = this.#authorID,
   ): Result.Result<DirectNoteDateInvalidError, void> {
     if (this.#createdAt > deletedAt) {
       return Result.err(
@@ -163,6 +170,19 @@ export class DirectNote {
       );
     }
     this.#deletedAt = Option.some(deletedAt);
+    this.#events.push(
+      noteEventFactory.deleted({
+        target: this.#id,
+        actor,
+      }),
+    );
     return Result.ok(undefined);
+  }
+
+  /** @deprecated Use delete() instead. */
+  setDeletedAt(
+    deletedAt: Date,
+  ): Result.Result<DirectNoteDateInvalidError, void> {
+    return this.delete(deletedAt);
   }
 }

--- a/pkg/notes/model/event/noteEvents.ts
+++ b/pkg/notes/model/event/noteEvents.ts
@@ -3,16 +3,19 @@ import { Result } from '@mikuroxina/mini-fn';
 import type { AccountID } from '../../../accounts/model/account.ts';
 import { eventIDGenerator } from '../../../internal/event/idGenerator.ts';
 import type { DomainEvent } from '../../../internal/event/type.ts';
+import type { DirectNoteID } from '../directNote.ts';
 import type { NoteID, NoteVisibility } from '../note.ts';
 
+export type NoteTargetID = NoteID | DirectNoteID;
+
 export type NoteCreatedEvent = DomainEvent<
-  NoteID,
+  NoteTargetID,
   'note.created',
   { authorID: AccountID; visibility: NoteVisibility },
   AccountID
 >;
 export type NoteDeletedEvent = DomainEvent<
-  NoteID,
+  NoteTargetID,
   'note.deleted',
   Record<string, never>,
   AccountID
@@ -38,7 +41,7 @@ export type NoteEvent =
 
 export const noteEventFactory = {
   created(args: {
-    target: NoteID;
+    target: NoteTargetID;
     actor: AccountID;
     authorID: AccountID;
     visibility: NoteVisibility;
@@ -55,7 +58,7 @@ export const noteEventFactory = {
   },
 
   deleted(args: {
-    target: NoteID;
+    target: NoteTargetID;
     actor: AccountID;
     occurredAt?: Date;
   }): NoteDeletedEvent {

--- a/pkg/notes/model/note.test.ts
+++ b/pkg/notes/model/note.test.ts
@@ -487,15 +487,12 @@ describe('Note', () => {
       expect(note.pullEvents()).toStrictEqual([]);
     });
 
-    describe('setDeletedAt', () => {
+    describe('delete', () => {
       it('should push exactly one note.deleted event for a normal note', () => {
         const note = Result.unwrap(Note.new(exampleInput, actor));
         note.pullEvents();
 
-        const res = note.setDeletedAt(
-          new Date('2023-09-11T00:00:00.000Z'),
-          actor,
-        );
+        const res = note.delete(new Date('2023-09-11T00:00:00.000Z'), actor);
         expect(Result.isOk(res)).toBe(true);
 
         const events = note.pullEvents();
@@ -522,10 +519,7 @@ describe('Note', () => {
         );
         note.pullEvents();
 
-        const res = note.setDeletedAt(
-          new Date('2023-09-11T00:00:00.000Z'),
-          actor,
-        );
+        const res = note.delete(new Date('2023-09-11T00:00:00.000Z'), actor);
         expect(Result.isOk(res)).toBe(true);
 
         const events = note.pullEvents();
@@ -537,10 +531,7 @@ describe('Note', () => {
         const note = Result.unwrap(Note.new(exampleInput, actor));
         note.pullEvents();
 
-        const res = note.setDeletedAt(
-          new Date('2000-01-01T00:00:00.000Z'),
-          actor,
-        );
+        const res = note.delete(new Date('2000-01-01T00:00:00.000Z'), actor);
         expect(Result.isErr(res)).toBe(true);
         expect(note.pullEvents()).toStrictEqual([]);
       });

--- a/pkg/notes/model/note.ts
+++ b/pkg/notes/model/note.ts
@@ -396,7 +396,7 @@ export class Note {
     return this.#deletedAt;
   }
 
-  setDeletedAt(
+  delete(
     deletedAt: Date,
     actor: AccountID,
   ): Result.Result<NoteDateInvalidError, void> {
@@ -415,5 +415,13 @@ export class Note {
     this.#deletedAt = Option.some(deletedAt);
     this.#events.push(event);
     return Result.ok(undefined);
+  }
+
+  /** @deprecated Use delete() instead. */
+  setDeletedAt(
+    deletedAt: Date,
+    actor: AccountID,
+  ): Result.Result<NoteDateInvalidError, void> {
+    return this.delete(deletedAt, actor);
   }
 }

--- a/pkg/notes/model/reaction.test.ts
+++ b/pkg/notes/model/reaction.test.ts
@@ -151,5 +151,25 @@ describe('Reaction', () => {
 
       expect(reaction.pullEvents()).toStrictEqual([]);
     });
+
+    it('deleted() returns a note.reaction.deleted event', () => {
+      const reaction = Reaction.reconstruct({
+        id: baseArgs.id,
+        accountID: baseArgs.accountID,
+        noteID: normalNote.getID(),
+        body: baseArgs.body,
+      });
+
+      reaction.deleted();
+
+      const events = reaction.pullEvents();
+      expect(events).toHaveLength(1);
+      expect(events[0]?.eventName).toBe('note.reaction.deleted');
+      expect(events[0]?.target).toBe(normalNote.getID());
+      expect(events[0]?.actor).toBe(baseArgs.accountID);
+      expect(events[0]?.payload).toStrictEqual({
+        accountID: baseArgs.accountID,
+      });
+    });
   });
 });

--- a/pkg/notes/model/reaction.ts
+++ b/pkg/notes/model/reaction.ts
@@ -113,4 +113,14 @@ export class Reaction {
   getEmoji(): Emoji {
     return this.#emoji;
   }
+
+  deleted(actor: AccountID = this.#accountID): void {
+    this.#events.push(
+      reactionEventFactory.deleted({
+        target: this.#noteID,
+        actor,
+        accountID: this.#accountID,
+      }),
+    );
+  }
 }

--- a/pkg/timeline/model/list.test.ts
+++ b/pkg/timeline/model/list.test.ts
@@ -272,5 +272,20 @@ describe('List', () => {
         expect(list.pullEvents()).toStrictEqual([]);
       });
     });
+
+    describe('list.deleted', () => {
+      it('should return exactly one list.deleted event', () => {
+        const list = List.reconstruct(args);
+
+        list.deleted();
+
+        const events = list.pullEvents();
+        expect(events).toHaveLength(1);
+        expect(events[0]?.eventName).toBe('list.deleted');
+        expect(events[0]?.target).toBe(args.id);
+        expect(events[0]?.actor).toBe(args.ownerId);
+        expect(events[0]?.payload).toStrictEqual({});
+      });
+    });
   });
 });

--- a/pkg/timeline/model/list.ts
+++ b/pkg/timeline/model/list.ts
@@ -152,6 +152,15 @@ export class List {
     return this.#createdAt;
   }
 
+  deleted(actor: AccountID = this.#ownerId): void {
+    this.#events.push(
+      listEventFactory.deleted({
+        target: this.#id,
+        actor,
+      }),
+    );
+  }
+
   addMember(
     memberId: AccountID,
     actor: AccountID,


### PR DESCRIPTION
close #1836

## What does this PR do?
- setDeletedAtをdeprecatedにし、deleteメソッドに処理を移植
- setDeletedAtのないモデルはdeleteメソッドを新設 

## Additional information
- 感想: イベントが発行されるかのテスト、毎回書くと面倒なのでもう少し良くしたい気もする(アイデアはない)

