### PR TITLE
refactor(accounts): AccountFollowモデルでフォロー解除する

### DIFF
--- a/pkg/accounts/adaptor/repository/dummy/follow.ts
+++ b/pkg/accounts/adaptor/repository/dummy/follow.ts
@@ -1,6 +1,5 @@
 import { Ether, Result } from '@mikuroxina/mini-fn';
 import type { AccountID } from '../../../model/account.ts';
-import { AccountNotFoundError } from '../../../model/errors.ts';
 import type { AccountFollow } from '../../../model/follow.ts';
 import {
   type AccountFollowCount,
@@ -36,17 +35,7 @@ export class InMemoryAccountFollowRepository
     return Result.ok(undefined);
   }
 
-  async unfollow(
-    accountID: AccountID,
-    targetID: AccountID,
-  ): Promise<Result.Result<Error, void>> {
-    const follow = [...this.#data].find(
-      (f) => f.getFromID() === accountID && f.getTargetID() === targetID,
-    );
-    if (!follow) {
-      return Result.err(new AccountNotFoundError('not found', { cause: null }));
-    }
-
+  async unfollow(follow: AccountFollow): Promise<Result.Result<Error, void>> {
     this.#data.delete(follow);
     return Result.ok(undefined);
   }

--- a/pkg/accounts/adaptor/repository/prisma/prisma.ts
+++ b/pkg/accounts/adaptor/repository/prisma/prisma.ts
@@ -306,21 +306,20 @@ export class PrismaAccountFollowRepository implements AccountFollowRepository {
     }
   }
 
-  async unfollow(
-    fromID: AccountID,
-    targetID: AccountID,
-  ): Promise<Result.Result<Error, void>> {
+  async unfollow(follow: AccountFollow): Promise<Result.Result<Error, void>> {
     try {
       // ToDo: Should replace with a hard delete. It can't follow it back again due to a composite primary key.
       await this.#prisma.following.update({
         where: {
           fromId_toId: {
-            fromId: fromID,
-            toId: targetID,
+            fromId: follow.getFromID(),
+            toId: follow.getTargetID(),
           },
         },
         data: {
-          deletedAt: new Date(),
+          deletedAt: Option.isNone(follow.getDeletedAt())
+            ? undefined
+            : Option.unwrap(follow.getDeletedAt()),
         },
       });
       return Result.ok(undefined);

--- a/pkg/accounts/mod.ts
+++ b/pkg/accounts/mod.ts
@@ -201,7 +201,8 @@ export const controller = new AccountController({
   unFollowService: Ether.runEther(
     Cat.cat(unfollow)
       .feed(Ether.compose(accountFollowRepository))
-      .feed(Ether.compose(accountRepository)).value,
+      .feed(Ether.compose(accountRepository))
+      .feed(Ether.compose(clock)).value,
   ),
   resendTokenService: Ether.runEther(
     Cat.cat(resendToken)

--- a/pkg/accounts/model/repository.ts
+++ b/pkg/accounts/model/repository.ts
@@ -54,10 +54,7 @@ export interface AccountFollowCount {
 }
 export interface AccountFollowRepository {
   follow(follow: AccountFollow): Promise<Result.Result<Error, void>>;
-  unfollow(
-    fromID: AccountID,
-    targetID: AccountID,
-  ): Promise<Result.Result<Error, void>>;
+  unfollow(follow: AccountFollow): Promise<Result.Result<Error, void>>;
   fetchAllFollowers(
     accountID: AccountID,
   ): Promise<Result.Result<Error, AccountFollow[]>>;

--- a/pkg/accounts/service/unfollow.test.ts
+++ b/pkg/accounts/service/unfollow.test.ts
@@ -1,6 +1,7 @@
 import { Option, Result } from '@mikuroxina/mini-fn';
 import { describe, expect, it } from 'vitest';
 
+import { MockClock } from '../../internal/id/mod.ts';
 import { InMemoryAccountRepository } from '../adaptor/repository/dummy/account.ts';
 import { InMemoryAccountFollowRepository } from '../adaptor/repository/dummy/follow.ts';
 import { Account, type AccountID } from '../model/account.ts';
@@ -42,16 +43,20 @@ await accountRepository.create(
     deletedAt: undefined,
   }),
 );
-const repository = new InMemoryAccountFollowRepository([
-  Result.unwrap(
-    AccountFollow.new({
-      fromID: '1' as AccountID,
-      targetID: '2' as AccountID,
-      createdAt: new Date(),
-    }),
-  ),
-]);
-const service = new UnfollowService(repository, accountRepository);
+const follow = Result.unwrap(
+  AccountFollow.new({
+    fromID: '1' as AccountID,
+    targetID: '2' as AccountID,
+    createdAt: new Date('2023-09-10T00:00:00Z'),
+  }),
+);
+follow.pullEvents();
+const repository = new InMemoryAccountFollowRepository([follow]);
+const service = new UnfollowService(
+  repository,
+  accountRepository,
+  new MockClock(new Date('2023-09-11T00:00:00Z')),
+);
 
 describe('UnfollowService', () => {
   it('should unfollow', async () => {
@@ -61,5 +66,9 @@ describe('UnfollowService', () => {
     );
 
     expect(Option.isSome(res)).toBe(false);
+    expect(follow.getDeletedAt()).toStrictEqual(
+      Option.some(new Date('2023-09-11T00:00:00Z')),
+    );
+    expect(follow.pullEvents()).toHaveLength(1);
   });
 });

--- a/pkg/accounts/service/unfollow.ts
+++ b/pkg/accounts/service/unfollow.ts
@@ -1,5 +1,6 @@
 import { Cat, Ether, Option, Promise, Result } from '@mikuroxina/mini-fn';
 
+import { type Clock, clockSymbol } from '../../internal/id/mod.ts';
 import type { AccountName } from '../model/account.ts';
 import { AccountNotFoundError } from '../model/errors.ts';
 import {
@@ -12,12 +13,15 @@ import {
 export class UnfollowService {
   readonly #followRepository: AccountFollowRepository;
   readonly #accountRepository: AccountRepository;
+  readonly #clock: Clock;
   constructor(
     followRepository: AccountFollowRepository,
     accountRepository: AccountRepository,
+    clock: Clock,
   ) {
     this.#followRepository = followRepository;
     this.#accountRepository = accountRepository;
+    this.#clock = clock;
   }
 
   async handle(
@@ -47,12 +51,30 @@ export class UnfollowService {
           ),
         ),
       )
-      .finishM(({ fromAccount, targetAccount }) =>
-        this.#followRepository.unfollow(
-          fromAccount.getID(),
-          targetAccount.getID(),
-        ),
-      );
+      .addMWith('allFollows', ({ fromAccount }) =>
+        this.#followRepository.fetchAllFollowing(fromAccount.getID()),
+      )
+      .addMWith('follow', async ({ allFollows, targetAccount }) => {
+        const follow = allFollows.find(
+          (item) => item.getTargetID() === targetAccount.getID(),
+        );
+        return follow
+          ? Result.ok(follow)
+          : Result.err(
+              new AccountNotFoundError('follow not found', {
+                cause: null,
+              }),
+            );
+      })
+      .runWith(({ follow }) =>
+        Promise.resolve(
+          follow.delete(new Date(Number(this.#clock.now()))),
+        ).then(Result.map(() => [])),
+      )
+      .runWith(({ follow }) =>
+        monad.map(() => [])(this.#followRepository.unfollow(follow)),
+      )
+      .finish(() => []);
 
     return Result.optionErr(res);
   }
@@ -61,10 +83,11 @@ export class UnfollowService {
 export const unfollowSymbol = Ether.newEtherSymbol<UnfollowService>();
 export const unfollow = Ether.newEther(
   unfollowSymbol,
-  ({ accountFollowRepository, accountRepository }) =>
-    new UnfollowService(accountFollowRepository, accountRepository),
+  ({ accountFollowRepository, accountRepository, clock }) =>
+    new UnfollowService(accountFollowRepository, accountRepository, clock),
   {
     accountFollowRepository: followRepoSymbol,
     accountRepository: accountRepoSymbol,
+    clock: clockSymbol,
   },
 );


### PR DESCRIPTION
close #1838 

## What does this PR do?
- Repositoryにあったフォロー解除の処理をドメインモデルに移動させました
  - メソッドの挙動は #1840 と同じ

## Additional information
- 
